### PR TITLE
Phase C: outbound webhooks (event subscribers)

### DIFF
--- a/docs/superpowers/plans/2026-04-26-webhooks-phase-c.md
+++ b/docs/superpowers/plans/2026-04-26-webhooks-phase-c.md
@@ -1,0 +1,1163 @@
+# Webhooks Phase C Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Add outbound webhooks: operator declares N event subscribers in `workflow.yaml`; engine fans out audit events to all matching subscribers.
+
+**Architecture:** New `workflows/code_review/webhooks/` package mirrors `runtimes/` and `reviewers/`. `Webhook` Protocol with `deliver(event)` + `matches(event)` methods. `compose_audit_subscribers(...)` fans out to N subscribers with per-subscriber exception isolation. Workspace builder composes the existing comments publisher with N webhooks into one publisher passed to `_make_audit_fn`.
+
+**Tech Stack:** Python 3.11 stdlib (`urllib.request`, `fnmatch`), JSON Schema, pyyaml, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-webhooks-phase-c-design.md`
+
+**Worktree:** `/home/radxa/WS/hermes-relay/.claude/worktrees/webhooks-phase-c` on branch `claude/webhooks-phase-c` from main `47ae160`. Baseline 477 tests passing. Use `/usr/bin/python3`.
+
+---
+
+## File Structure
+
+**New files:**
+- `workflows/code_review/webhooks/__init__.py` — Protocol, registry, `build_webhooks`, `compose_audit_subscribers`, glob filter
+- `workflows/code_review/webhooks/http_json.py` — `HttpJsonWebhook`
+- `workflows/code_review/webhooks/slack_incoming.py` — `SlackIncomingWebhook`
+- `workflows/code_review/webhooks/disabled.py` — `DisabledWebhook`
+- `tests/test_webhooks_phase_c.py`
+- `tests/test_webhooks_schema.py`
+
+**Modified files:**
+- `workflows/code_review/schema.yaml` — top-level `webhooks:` array
+- `workflows/code_review/workspace.py` — build webhooks, compose subscribers
+- `skills/operator/SKILL.md` — document `webhooks:` config
+
+---
+
+## Task 1: Webhook Protocol + registry + compose
+
+**Files:**
+- Create: `workflows/code_review/webhooks/__init__.py`
+- Test: `tests/test_webhooks_phase_c.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_webhooks_phase_c.py`:
+
+```python
+"""Phase C tests: webhook event subscribers."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_webhook_module_exposes_protocol_registry_and_compose():
+    from workflows.code_review.webhooks import (
+        Webhook, WebhookContext, register, build_webhooks,
+        compose_audit_subscribers, _WEBHOOK_KINDS,
+    )
+    assert callable(register)
+    assert callable(build_webhooks)
+    assert callable(compose_audit_subscribers)
+    assert isinstance(_WEBHOOK_KINDS, dict)
+
+
+def test_build_webhooks_empty_list_returns_empty():
+    from workflows.code_review.webhooks import build_webhooks
+    assert build_webhooks([], run_fn=None) == []
+
+
+def test_build_webhooks_unknown_kind_raises():
+    from workflows.code_review.webhooks import build_webhooks
+    with pytest.raises(ValueError, match="unknown"):
+        build_webhooks([{"name": "x", "kind": "made-up"}], run_fn=None)
+
+
+def test_compose_audit_subscribers_fans_out():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+
+    sub1 = MagicMock()
+    sub2 = MagicMock()
+    sub3 = MagicMock()
+    pub = compose_audit_subscribers([sub1, sub2, sub3])
+    pub(action="X", summary="Y", extra={"k": "v"})
+    for s in (sub1, sub2, sub3):
+        s.assert_called_once()
+        evt = s.call_args[0][0]
+        assert evt["action"] == "X"
+        assert evt["summary"] == "Y"
+        assert evt["k"] == "v"
+
+
+def test_compose_audit_subscribers_isolates_exceptions():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+
+    sub1 = MagicMock(side_effect=RuntimeError("boom"))
+    sub2 = MagicMock()
+    sub3 = MagicMock()
+    pub = compose_audit_subscribers([sub1, sub2, sub3])
+    # Should not raise
+    pub(action="X", summary="Y", extra={})
+    sub2.assert_called_once()
+    sub3.assert_called_once()
+
+
+def test_compose_audit_subscribers_empty_list_is_noop():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+    pub = compose_audit_subscribers([])
+    pub(action="X", summary="Y", extra={})  # no-op, no error
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/webhooks-phase-c
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: No module named 'workflows.code_review.webhooks'`.
+
+- [ ] **Step 3: Create the package skeleton**
+
+Create `workflows/code_review/webhooks/__init__.py`:
+
+```python
+"""Pluggable outbound webhook subscribers for audit events.
+
+Mirrors the runtime/reviewer layers: Protocol + @register decorator +
+factory. ``compose_audit_subscribers`` fans out an audit event to N
+subscribers with per-subscriber exception isolation, matching the
+publisher contract used by ``workspace._make_audit_fn``.
+"""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class WebhookContext:
+    """Workspace-scoped primitives a webhook needs at delivery time."""
+
+    run_fn: Callable[..., Any] | None
+    now_iso: Callable[[], str]
+
+
+@runtime_checkable
+class Webhook(Protocol):
+    """Protocol every webhook kind implements."""
+
+    name: str
+
+    def deliver(self, audit_event: dict[str, Any]) -> None: ...
+
+    def matches(self, audit_event: dict[str, Any]) -> bool: ...
+
+
+_WEBHOOK_KINDS: dict[str, type] = {}
+
+
+def register(kind: str):
+    """Decorator: registers a class as the implementation for a webhook kind."""
+
+    def _register(cls):
+        _WEBHOOK_KINDS[kind] = cls
+        return cls
+
+    return _register
+
+
+def event_matches(audit_event: dict[str, Any], event_globs: list[str] | None) -> bool:
+    """Match an audit event's `action` against a list of fnmatch globs.
+
+    None / empty list => match all (implicit ['*']).
+    """
+    action = str(audit_event.get("action") or "")
+    if not event_globs:
+        return True
+    return any(fnmatch.fnmatchcase(action, g) for g in event_globs)
+
+
+def build_webhooks(
+    webhooks_cfg: list[dict] | None,
+    *,
+    run_fn: Callable[..., Any] | None = None,
+) -> list[Webhook]:
+    """Instantiate one Webhook per subscription. Empty/None config -> []."""
+    if not webhooks_cfg:
+        return []
+    # Lazy import for side-effect registration.
+    from workflows.code_review.webhooks import http_json  # noqa: F401
+    from workflows.code_review.webhooks import slack_incoming  # noqa: F401
+    from workflows.code_review.webhooks import disabled as _disabled  # noqa: F401
+
+    import time as _time
+    ctx = WebhookContext(run_fn=run_fn, now_iso=lambda: _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()))
+
+    out: list[Webhook] = []
+    for sub_cfg in webhooks_cfg:
+        if sub_cfg.get("enabled") is False:
+            kind = "disabled"
+        else:
+            kind = sub_cfg.get("kind") or ""
+        if kind not in _WEBHOOK_KINDS:
+            raise ValueError(
+                f"unknown webhook kind={kind!r}; "
+                f"registered kinds: {sorted(_WEBHOOK_KINDS)}"
+            )
+        cls = _WEBHOOK_KINDS[kind]
+        out.append(cls(sub_cfg, ws_context=ctx))
+    return out
+
+
+def compose_audit_subscribers(
+    subscribers: list[Callable[[dict], None]],
+) -> Callable[..., None]:
+    """Fan-out callable matching the publisher contract used by
+    ``_make_audit_fn``: ``publisher(action, summary, extra=...)``.
+
+    Each subscriber receives a fully-built audit_event dict
+    ``{"at": ..., "action": ..., "summary": ..., **extra}``.
+    Per-subscriber exceptions are caught and swallowed.
+    """
+    import time as _time
+
+    def _now_iso():
+        return _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime())
+
+    def publisher(*, action, summary, extra=None):
+        event = {"at": _now_iso(), "action": action, "summary": summary, **(extra or {})}
+        for sub in subscribers:
+            try:
+                sub(event)
+            except Exception:
+                # Best-effort: never break workflow execution.
+                pass
+
+    return publisher
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: 6 passed.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 483 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(webhooks): add Webhook Protocol + registry + compose
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: http-json webhook
+
+**Files:**
+- Create: `workflows/code_review/webhooks/http_json.py`
+- Test: `tests/test_webhooks_phase_c.py` (extend)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/test_webhooks_phase_c.py`:
+
+```python
+def test_http_json_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import http_json  # noqa: F401
+    assert "http-json" in _WEBHOOK_KINDS
+
+
+def test_http_json_webhook_posts_payload_to_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh1", "kind": "http-json", "url": "https://example.com/hook"}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+    assert len(webhooks) == 1
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+
+    assert mock_urlopen.called
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "https://example.com/hook"
+    assert req.get_method() == "POST"
+    body = req.data.decode("utf-8")
+    import json
+    parsed = json.loads(body)
+    assert parsed["action"] == "X"
+    assert parsed["summary"] == "Y"
+    assert req.headers.get("Content-type") == "application/json"
+
+
+def test_http_json_webhook_includes_custom_headers():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "headers": {"X-Custom": "v1", "Authorization": "Bearer xyz"},
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+
+    req = mock_urlopen.call_args[0][0]
+    # urllib normalizes header keys via title-case
+    assert req.headers.get("X-custom") == "v1"
+    assert req.headers.get("Authorization") == "Bearer xyz"
+
+
+def test_http_json_webhook_retries_on_failure():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "retry-count": 2,
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen", side_effect=OSError("net down")) as mock_urlopen:
+        # Should not raise; retry-count: 2 means 1 initial + 2 retries = 3 calls.
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        assert mock_urlopen.call_count == 3
+
+
+def test_http_json_webhook_no_retry_on_success():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "retry-count": 5,
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        assert mock_urlopen.call_count == 1
+
+
+def test_http_json_webhook_matches_default_all_events():
+    from workflows.code_review.webhooks import build_webhooks
+    cfg = [{"name": "wh1", "kind": "http-json", "url": "https://x"}]
+    wh = build_webhooks(cfg, run_fn=None)[0]
+    assert wh.matches({"action": "anything"}) is True
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: workflows.code_review.webhooks.http_json`.
+
+- [ ] **Step 3: Create the http-json webhook**
+
+Create `workflows/code_review/webhooks/http_json.py`:
+
+```python
+"""HTTP-JSON outbound webhook (POST raw audit-event JSON to a URL)."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    event_matches,
+    register,
+)
+
+
+_DEFAULT_TIMEOUT = 5
+_DEFAULT_RETRY_COUNT = 1
+
+
+@register("http-json")
+class HttpJsonWebhook:
+    """POSTs each audit event verbatim as JSON to a configured URL.
+
+    Config shape (YAML):
+        - name: my-hook
+          kind: http-json
+          url: https://example.com/hook
+          headers: {X-Custom: v}
+          events: ["merge_*"]
+          timeout-seconds: 5
+          retry-count: 1
+    """
+
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed")
+        self._url = cfg.get("url") or ""
+        self._headers = dict(cfg.get("headers") or {})
+        self._events = list(cfg.get("events") or [])
+        self._timeout = int(cfg.get("timeout-seconds") or _DEFAULT_TIMEOUT)
+        self._retry_count = int(cfg.get("retry-count") if cfg.get("retry-count") is not None else _DEFAULT_RETRY_COUNT)
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return event_matches(audit_event, self._events)
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        if not self._url:
+            return
+        body = json.dumps(audit_event).encode("utf-8")
+        attempts = self._retry_count + 1
+        last_err: Exception | None = None
+        for _ in range(attempts):
+            try:
+                req = urllib.request.Request(
+                    self._url,
+                    data=body,
+                    method="POST",
+                    headers={"Content-type": "application/json", **self._headers},
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout):
+                    return
+            except (urllib.error.URLError, OSError) as e:
+                last_err = e
+                continue
+        # All retries exhausted; swallow (compose_audit_subscribers also catches,
+        # but be explicit: webhook delivery is best-effort).
+        return
+```
+
+- [ ] **Step 4: Run target tests**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: 12 passed.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 489 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(webhooks): add http-json webhook
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: slack-incoming webhook
+
+**Files:**
+- Create: `workflows/code_review/webhooks/slack_incoming.py`
+- Test: `tests/test_webhooks_phase_c.py` (extend)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+def test_slack_incoming_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import slack_incoming  # noqa: F401
+    assert "slack-incoming" in _WEBHOOK_KINDS
+
+
+def test_slack_incoming_payload_shape():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "slack", "kind": "slack-incoming",
+        "url": "https://hooks.slack.com/services/X/Y/Z",
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({
+            "action": "merge_and_promote",
+            "summary": "Merged PR #42",
+            "issueNumber": 42,
+            "headSha": "abc123",
+            "at": "2026-04-26T12:00:00Z",
+        })
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url.startswith("https://hooks.slack.com/")
+    import json
+    payload = json.loads(req.data.decode("utf-8"))
+    assert "text" in payload
+    assert "blocks" in payload
+    assert "merge_and_promote" in payload["text"]
+    assert "Merged PR #42" in payload["text"]
+    # Block layout: section + context
+    assert any(b.get("type") == "section" for b in payload["blocks"])
+    assert any(b.get("type") == "context" for b in payload["blocks"])
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the slack-incoming webhook**
+
+Create `workflows/code_review/webhooks/slack_incoming.py`:
+
+```python
+"""Slack Incoming Webhook delivery.
+
+Reformats audit events into Slack block payloads. Operator supplies
+the Incoming Webhook URL; the engine never authenticates separately.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    event_matches,
+    register,
+)
+
+
+_DEFAULT_TIMEOUT = 5
+_DEFAULT_RETRY_COUNT = 1
+
+
+@register("slack-incoming")
+class SlackIncomingWebhook:
+    """Posts audit events to a Slack Incoming Webhook URL with block layout.
+
+    Config shape (YAML):
+        - name: notify-slack
+          kind: slack-incoming
+          url: https://hooks.slack.com/services/T.../B.../...
+          events: ["merge_and_promote"]
+    """
+
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed")
+        self._url = cfg.get("url") or ""
+        self._events = list(cfg.get("events") or [])
+        self._timeout = int(cfg.get("timeout-seconds") or _DEFAULT_TIMEOUT)
+        self._retry_count = int(cfg.get("retry-count") if cfg.get("retry-count") is not None else _DEFAULT_RETRY_COUNT)
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return event_matches(audit_event, self._events)
+
+    def _build_payload(self, audit_event: dict[str, Any]) -> dict[str, Any]:
+        action = str(audit_event.get("action") or "")
+        summary = str(audit_event.get("summary") or "")
+        issue_number = audit_event.get("issueNumber")
+        head_sha = audit_event.get("headSha")
+        at = audit_event.get("at")
+
+        context_bits = []
+        if issue_number is not None:
+            context_bits.append(f"issue #{issue_number}")
+        if head_sha:
+            context_bits.append(f"`{head_sha}`")
+        if at:
+            context_bits.append(str(at))
+        context_text = " · ".join(context_bits) or "code-review event"
+
+        return {
+            "text": f"[code-review] {action} — {summary}",
+            "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": f"*{action}*\n{summary}"}},
+                {"type": "context", "elements": [{"type": "mrkdwn", "text": context_text}]},
+            ],
+        }
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        if not self._url:
+            return
+        body = json.dumps(self._build_payload(audit_event)).encode("utf-8")
+        attempts = self._retry_count + 1
+        for _ in range(attempts):
+            try:
+                req = urllib.request.Request(
+                    self._url,
+                    data=body,
+                    method="POST",
+                    headers={"Content-type": "application/json"},
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout):
+                    return
+            except (urllib.error.URLError, OSError):
+                continue
+        return
+```
+
+- [ ] **Step 4: Run target + full**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 14 in target, 491 total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(webhooks): add slack-incoming webhook
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: disabled webhook + filter tests
+
+**Files:**
+- Create: `workflows/code_review/webhooks/disabled.py`
+- Test: `tests/test_webhooks_phase_c.py` (extend)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+def test_disabled_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import disabled  # noqa: F401
+    assert "disabled" in _WEBHOOK_KINDS
+
+
+def test_disabled_webhook_does_not_call_urlopen():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "disabled"}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        mock_urlopen.assert_not_called()
+
+
+def test_disabled_via_enabled_false():
+    """enabled: false overrides any kind."""
+    from workflows.code_review.webhooks import build_webhooks
+    from workflows.code_review.webhooks.disabled import DisabledWebhook
+
+    cfg = [{"name": "wh", "kind": "http-json", "url": "https://x", "enabled": False}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+    assert isinstance(webhooks[0], DisabledWebhook)
+
+
+def test_event_filter_glob_matches_exact():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "run_claude_review"}, ["run_claude_review"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["run_claude_review"]) is False
+
+
+def test_event_filter_glob_matches_prefix():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "run_claude_review"}, ["run_*"]) is True
+    assert event_matches({"action": "run_internal_review"}, ["run_*"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["run_*"]) is False
+
+
+def test_event_filter_glob_suffix():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "internal_review"}, ["*_review"]) is True
+    assert event_matches({"action": "external_review"}, ["*_review"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["*_review"]) is False
+
+
+def test_event_filter_omitted_defaults_to_all():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "any"}, None) is True
+    assert event_matches({"action": "any"}, []) is True
+
+
+def test_event_filter_multiple_globs_or():
+    from workflows.code_review.webhooks import event_matches
+    globs = ["merge_*", "operator_*"]
+    assert event_matches({"action": "merge_and_promote"}, globs) is True
+    assert event_matches({"action": "operator_attention_required"}, globs) is True
+    assert event_matches({"action": "run_claude_review"}, globs) is False
+
+
+def test_filtered_subscriber_does_not_deliver_unmatched_events():
+    """When wrapping a webhook into a subscriber, non-matching events are skipped."""
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "only-merges", "kind": "http-json",
+        "url": "https://x", "events": ["merge_*"],
+    }]
+    wh = build_webhooks(cfg, run_fn=None)[0]
+    assert wh.matches({"action": "merge_and_promote"}) is True
+    assert wh.matches({"action": "run_claude_review"}) is False
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the disabled webhook**
+
+Create `workflows/code_review/webhooks/disabled.py`:
+
+```python
+"""Disabled webhook — no-op delivery, never matches."""
+from __future__ import annotations
+
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    register,
+)
+
+
+@register("disabled")
+class DisabledWebhook:
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed-disabled")
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return False
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        return None
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_phase_c.py -v
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: ~23 in target, 500 total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(webhooks): add disabled webhook + event filter coverage
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Schema extensions
+
+**Files:**
+- Modify: `workflows/code_review/schema.yaml`
+- Test: `tests/test_webhooks_schema.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_webhooks_schema.py`:
+
+```python
+"""Phase C schema validation."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "workflows/code_review/schema.yaml"
+
+
+def _schema():
+    return yaml.safe_load(SCHEMA_PATH.read_text())
+
+
+def _base_config():
+    return {
+        "workflow": "code-review",
+        "schema-version": 1,
+        "instance": {"name": "test", "engine-owner": "hermes"},
+        "repository": {
+            "local-path": "/tmp/x",
+            "github-slug": "x/y",
+            "active-lane-label": "active",
+        },
+        "runtimes": {
+            "codex-acpx": {
+                "kind": "acpx-codex",
+                "session-idle-freshness-seconds": 900,
+                "session-idle-grace-seconds": 1800,
+                "session-nudge-cooldown-seconds": 600,
+            },
+        },
+        "agents": {
+            "coder": {"default": {"name": "c", "model": "m", "runtime": "codex-acpx"}},
+            "internal-reviewer": {"name": "ir", "model": "m", "runtime": "codex-acpx"},
+            "external-reviewer": {"enabled": True, "name": "er"},
+        },
+        "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+        "triggers": {"lane-selector": {"type": "label", "label": "active"}},
+        "storage": {"ledger": "x", "health": "x", "audit-log": "x"},
+    }
+
+
+def test_schema_accepts_no_webhooks_block():
+    Draft7Validator(_schema()).validate(_base_config())
+
+
+def test_schema_accepts_empty_webhooks_array():
+    cfg = _base_config()
+    cfg["webhooks"] = []
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_http_json_webhook():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "http-json", "url": "https://x"}]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_slack_incoming_webhook():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "slack", "kind": "slack-incoming", "url": "https://hooks.slack.com/X"}]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_full_subscription():
+    cfg = _base_config()
+    cfg["webhooks"] = [{
+        "name": "wh", "kind": "http-json", "url": "https://x",
+        "enabled": True,
+        "events": ["merge_*", "run_*"],
+        "headers": {"X-Custom": "v"},
+        "timeout-seconds": 10,
+        "retry-count": 3,
+    }]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_unknown_kind():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "made-up"}]
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_extra_property_on_subscription():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "http-json", "urls": "https://x"}]  # typo
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)
+
+
+def test_existing_yoyopod_workflow_yaml_still_validates():
+    yoyopod = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/config/workflow.yaml"))
+    if not yoyopod.exists():
+        pytest.skip("yoyopod workspace not present on this host")
+    cfg = yaml.safe_load(yoyopod.read_text())
+    Draft7Validator(_schema()).validate(cfg)
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_schema.py -v
+```
+Expected: FAIL on `webhooks` kind enum tests.
+
+- [ ] **Step 3: Edit schema.yaml**
+
+In `workflows/code_review/schema.yaml`, add a new top-level property after `observability:`:
+
+```yaml
+  webhooks:
+    type: array
+    items:
+      type: object
+      required: [name, kind]
+      additionalProperties: false
+      properties:
+        name: {type: string}
+        kind:
+          type: string
+          enum: [http-json, slack-incoming, disabled]
+        enabled: {type: boolean}
+        url: {type: string}
+        events:
+          type: array
+          items: {type: string}
+        headers:
+          type: object
+          additionalProperties: {type: string}
+        timeout-seconds: {type: integer, minimum: 1}
+        retry-count: {type: integer, minimum: 0}
+```
+
+- [ ] **Step 4: Run target + full**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_webhooks_schema.py -v
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 8 in target, 508 total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(schema): add webhooks block with kind enum + per-subscription fields
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Workspace integration
+
+**Files:**
+- Modify: `workflows/code_review/workspace.py`
+
+- [ ] **Step 1: Wire webhooks into the publisher chain**
+
+Locate the existing publisher creation around `workspace.py:560`:
+```python
+_publisher = _make_comment_publisher(
+    workflow_root=workspace_root,
+    repo_slug=_repo_slug,
+    workflow_yaml=yaml_cfg or {},
+    get_active_issue_number=lambda: ...,
+    get_workflow_state=lambda: ...,
+    get_is_operator_attention=lambda: ...,
+)
+audit = _make_audit_fn(audit_log_path=audit_log_path, publisher=_publisher)
+```
+
+Replace with a fan-out chain. After the `_publisher = _make_comment_publisher(...)` call:
+
+```python
+from workflows.code_review.webhooks import build_webhooks, compose_audit_subscribers
+
+_webhooks = build_webhooks((yaml_cfg or {}).get("webhooks") or [], run_fn=_run)
+
+def _adapt_legacy_publisher(legacy_pub):
+    """The legacy comments publisher takes (action=, summary=, extra=).
+    Compose-style subscribers receive a single audit_event dict. Adapt."""
+    if legacy_pub is None:
+        return None
+    def _sub(audit_event):
+        legacy_pub(
+            action=audit_event.get("action") or "",
+            summary=audit_event.get("summary") or "",
+            extra={k: v for k, v in audit_event.items() if k not in ("action", "summary", "at")},
+        )
+    return _sub
+
+def _adapt_webhook(wh):
+    """Wrap a Webhook into a (audit_event)->None subscriber that respects matches()."""
+    def _sub(audit_event):
+        if not wh.matches(audit_event):
+            return
+        wh.deliver(audit_event)
+    return _sub
+
+_subscribers = []
+_legacy = _adapt_legacy_publisher(_publisher)
+if _legacy is not None:
+    _subscribers.append(_legacy)
+for _wh in _webhooks:
+    _subscribers.append(_adapt_webhook(_wh))
+
+_fanout_publisher = compose_audit_subscribers(_subscribers) if _subscribers else None
+audit = _make_audit_fn(audit_log_path=audit_log_path, publisher=_fanout_publisher)
+```
+
+Note: `_run` is the workspace-scoped subprocess primitive — verify it's defined before this block. Search for `def _run` or `_run =` in workspace.py and confirm. If `_run` is not yet defined at this point in the file, pass `None` for `run_fn`.
+
+- [ ] **Step 2: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 508 passed. If any existing test fails because the publisher signature changed, investigate — `_make_audit_fn` itself didn't change; only what's passed in changed. Existing mocks of `_make_comment_publisher` should still work.
+
+- [ ] **Step 3: Verify yoyopod still validates and behaves**
+
+```bash
+/usr/bin/python3 -c "
+import yaml
+from pathlib import Path
+from jsonschema import Draft7Validator
+schema = yaml.safe_load(Path('workflows/code_review/schema.yaml').read_text())
+cfg = yaml.safe_load(Path('/home/radxa/.hermes/workflows/yoyopod/config/workflow.yaml').read_text())
+Draft7Validator(schema).validate(cfg)
+print('yoyopod config valid')
+"
+```
+Expected: `yoyopod config valid`. Yoyopod has no `webhooks:` block ⇒ `build_webhooks([])` → empty list → only the legacy comments publisher runs (behavior preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(workspace): fan out audit events to comments publisher + webhooks
+
+Workspace builds N webhook subscribers from yaml_cfg.webhooks and
+composes them with the existing comments publisher into one fan-out
+publisher passed to _make_audit_fn. Subscribers run inline; per-
+subscriber exceptions are isolated.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Operator docs
+
+**Files:**
+- Modify: `skills/operator/SKILL.md`
+
+- [ ] **Step 1: Append section**
+
+Append to `skills/operator/SKILL.md`:
+
+````markdown
+## Webhooks (Phase C — outbound event subscribers)
+
+Declare N webhook subscriptions under top-level `webhooks:`. Each subscription receives audit events that match its `events:` filter.
+
+```yaml
+webhooks:
+  - name: notify-slack
+    kind: slack-incoming
+    url: https://hooks.slack.com/services/T.../B.../...
+    events: ["merge_and_promote", "operator_attention_required"]
+
+  - name: ci-mirror
+    kind: http-json
+    url: https://ci.example.com/hooks/code-review
+    headers:
+      Authorization: Bearer xyz
+    events: ["run_*", "merge_*"]
+    timeout-seconds: 5
+    retry-count: 2
+
+  - name: temporarily-off
+    kind: http-json
+    url: https://example.com/hook
+    enabled: false   # short-circuit without removing the entry
+```
+
+**Kinds:**
+- `http-json` — POST raw audit-event JSON to `url` with optional `headers:`.
+- `slack-incoming` — POST Slack-formatted blocks to a Slack Incoming Webhook URL.
+- `disabled` — explicit no-op (equivalent to `enabled: false`).
+
+**Event filter (`events:`):** list of fnmatch globs against the audit event's `action` field. Examples:
+- `["*"]` or omitted ⇒ all events
+- `["run_*"]` ⇒ everything starting with `run_`
+- `["merge_and_promote"]` ⇒ exact match
+- `["*_review"]` ⇒ suffix match
+- Multiple globs are OR'd
+
+**Delivery semantics:** fire-and-forget, inline retry (default `retry-count: 1` ⇒ initial + 1 retry). Per-subscriber exceptions are swallowed — webhooks cannot break workflow execution. No persistent queue: if the engine crashes mid-delivery the event lives in `audit-log` JSONL but is not redelivered.
+
+**Audit-event payload (what `http-json` POSTs):**
+```json
+{
+  "at": "2026-04-26T12:34:56Z",
+  "action": "merge_and_promote",
+  "summary": "Merged PR #42",
+  "issueNumber": 42,
+  "headSha": "abc123"
+}
+```
+
+(Extra fields beyond `at`/`action`/`summary` come from the action's audit context — they vary by action.)
+````
+
+- [ ] **Step 2: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 508 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "docs(operator): document webhooks config surface
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run full suite**
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/webhooks-phase-c
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 508 passed.
+
+- [ ] **Sanity-check live yoyopod config still validates**
+
+```bash
+/usr/bin/python3 -c "
+import yaml
+from pathlib import Path
+from jsonschema import Draft7Validator
+schema = yaml.safe_load(Path('workflows/code_review/schema.yaml').read_text())
+cfg = yaml.safe_load(Path('/home/radxa/.hermes/workflows/yoyopod/config/workflow.yaml').read_text())
+Draft7Validator(schema).validate(cfg)
+print('yoyopod config valid')
+"
+```
+Expected: `yoyopod config valid`.
+
+- [ ] **Use superpowers:finishing-a-development-branch** to wrap up.

--- a/docs/superpowers/specs/2026-04-26-webhooks-phase-c-design.md
+++ b/docs/superpowers/specs/2026-04-26-webhooks-phase-c-design.md
@@ -1,0 +1,226 @@
+# Webhooks (Outbound Event Subscribers) — Phase C Design
+
+**Status:** Approved
+**Date:** 2026-04-26
+**Branch:** `claude/webhooks-phase-c` (worktree at `.claude/worktrees/webhooks-phase-c`)
+**Baseline:** main `47ae160`, 477 tests passing
+
+## Problem
+
+The code-review workflow already emits structured audit events (`_make_audit_fn` in `workspace.py:311`) on every action transition. Today only one consumer plugs in: the GitHub-comments publisher (`_make_comment_publisher`). Operators who want to mirror events to Slack, a custom dashboard, a CI hook, or any external system have no path other than reading the audit JSONL file.
+
+Phase C adds **outbound webhooks**: operator declares N event subscribers in `workflow.yaml`, each with a kind (`http-json`, `slack-incoming`, `disabled`), a URL, and an event filter. The engine fans out each audit event to all matching subscribers, fire-and-forget with one best-effort retry. Subscribers run inline in the audit hook — same exception-swallowing semantics as the existing comments publisher (observability must never break workflow execution).
+
+## Scope
+
+### In scope (this PR)
+1. **`Webhook` Protocol + registry** — new package `workflows/code_review/webhooks/` mirroring `runtimes/` and `reviewers/`. Protocol has one method: `deliver(audit_event: dict) → None`. `@register("<kind>")` decorator + `_WEBHOOK_KINDS` registry + `build_webhooks(webhooks_cfg, *, run_fn) → list[Webhook]` factory.
+2. **`http-json` webhook** — POST raw audit-event JSON to a URL. Configurable headers, timeout, retry count (default 1). Uses `urllib.request` (stdlib only — no new dependencies).
+3. **`slack-incoming` webhook** — POSTs Slack-formatted blocks (`{"text": "...", "blocks": [...]}`) to an Incoming Webhook URL. Operator supplies the URL; payload built from the audit event's `action` + `summary`.
+4. **`disabled` webhook** — explicit kind for `enabled: false`. No-op `deliver`.
+5. **Composing publisher** — generalize the `publisher=` slot in `_make_audit_fn` from a single callable to a list of subscribers. New `compose_audit_subscribers(subscribers: list[Callable]) → Callable` that fans out and swallows per-subscriber exceptions independently. The existing comments publisher is one entry; webhooks become additional entries.
+6. **Schema** — new top-level `webhooks:` block (array of subscriptions). Each subscription has `name`, `kind`, optional `url`, optional `enabled`, optional `events:` filter (list of action-name globs), optional `headers:`, `timeout-seconds:`, `retry-count:`.
+7. **Event filtering** — `events:` filter is a list of action-name globs (`*` for all, `merge_*` for prefix matches, `run_claude_review` for exact). When omitted ⇒ all events.
+8. **Tests** — protocol + registry, http-json delivery (mocked urllib), slack-incoming payload shape, disabled provider, event-filter glob matching, fan-out exception isolation, schema validation.
+9. **Operator docs** — `skills/operator/SKILL.md` documents the new `webhooks:` config surface.
+
+### Out of scope (deferred)
+- **Inbound webhooks** (e.g., GitHub webhook → trigger a workflow tick). Different shape entirely; would need an HTTP listener.
+- **Persistent retry queue.** Fire-and-forget with N retries inline. If the engine crashes mid-delivery the event is logged in the audit JSONL but not redelivered.
+- **HMAC signing on outbound** (`X-Hub-Signature` style). Operators who need this can put a reverse proxy in front.
+- **Templated payloads.** `slack-incoming` builds a fixed block layout; if operators want custom formatting, Phase D problem.
+- **Phase D rename pass** — still pending.
+
+## Architecture
+
+### Webhook layering
+```
+        ┌────────────────────────────────────────┐
+        │     workspace.py: _make_audit_fn       │
+        │     (publisher=fan_out)                │
+        └─────────────────┬──────────────────────┘
+                          │ audit_event dict
+                ┌─────────▼──────────┐
+                │   fan_out(event)   │  ← compose_audit_subscribers
+                │   - per-subscriber │
+                │   - swallow errors │
+                └────┬───────────┬──┘
+                     │           │
+       ┌─────────────▼┐         ┌▼──────────────┐
+       │ comments_pub │         │ webhooks list │
+       │  (existing)  │         │  (Phase C)    │
+       └──────────────┘         └───────┬───────┘
+                                        │
+                            ┌───────────┼───────────┐
+                            ▼           ▼           ▼
+                     ┌────────┐  ┌─────────┐  ┌──────────┐
+                     │ http-  │  │ slack-  │  │ disabled │
+                     │ json   │  │ incoming│  └──────────┘
+                     └────────┘  └─────────┘
+```
+
+### Webhook Protocol contract
+```python
+# workflows/code_review/webhooks/__init__.py
+
+@dataclass(frozen=True)
+class WebhookContext:
+    """Workspace-scoped primitives a webhook needs at delivery time."""
+    run_fn: Callable[..., Any] | None    # for shelling out (e.g. curl) if needed
+    now_iso: Callable[[], str]
+
+
+@runtime_checkable
+class Webhook(Protocol):
+    name: str
+
+    def deliver(self, audit_event: dict[str, Any]) -> None: ...
+
+    def matches(self, audit_event: dict[str, Any]) -> bool: ...
+```
+
+### Schema changes
+```yaml
+# New top-level block (optional)
+webhooks:
+  type: array
+  items:
+    type: object
+    required: [name, kind]
+    additionalProperties: false
+    properties:
+      name: {type: string}
+      kind:
+        type: string
+        enum: [http-json, slack-incoming, disabled]
+      enabled: {type: boolean}     # default true
+      url: {type: string}
+      events:
+        type: array
+        items: {type: string}      # glob: "*", "run_*", "merge_and_promote"
+      headers:
+        type: object
+        additionalProperties: {type: string}
+      timeout-seconds: {type: integer, minimum: 1}
+      retry-count: {type: integer, minimum: 0}
+```
+
+### Audit-event payload shape (already defined by `_make_audit_fn`)
+```json
+{
+  "at": "2026-04-26T12:34:56Z",
+  "action": "run_claude_review",
+  "summary": "Internal review queued for issue #42",
+  "issueNumber": 42,
+  "headSha": "abc123"
+}
+```
+
+`http-json` webhook POSTs this dict verbatim. `slack-incoming` reformats:
+```json
+{
+  "text": "[code-review] run_claude_review — Internal review queued for issue #42",
+  "blocks": [
+    {"type": "section", "text": {"type": "mrkdwn", "text": "*run_claude_review*\nInternal review queued for issue #42"}},
+    {"type": "context", "elements": [{"type": "mrkdwn", "text": "issue #42 · `abc123` · 2026-04-26T12:34:56Z"}]}
+  ]
+}
+```
+
+### Event-filter glob semantics
+Match an audit event's `action` field against each glob in `events:`:
+- `*` → match all
+- `run_*` → prefix match (`run_claude_review`, `run_internal_review`, etc.)
+- `merge_and_promote` → exact match
+- `*_review` → suffix match
+- Multiple globs OR'd
+
+When `events:` is omitted from config ⇒ implicit `["*"]`.
+
+### Composing subscribers
+```python
+# workflows/code_review/webhooks/__init__.py
+
+def compose_audit_subscribers(
+    subscribers: list[Callable[[dict], None]],
+) -> Callable[[Any], None]:
+    """Fan-out callable matching the publisher contract used by
+    _make_audit_fn: publisher(action, summary, extra=...).
+
+    Each subscriber receives a fully-built audit_event dict. Per-subscriber
+    exceptions are caught and swallowed so one bad subscriber cannot break
+    others or affect workflow execution.
+    """
+```
+
+The existing `comments_publisher` (which currently takes `action=, summary=, extra=`) is wrapped to consume the `audit_event` dict instead. Workspace builder composes `[comments_publisher_wrapper, *webhook_subscribers]` and passes the result to `_make_audit_fn(publisher=...)`.
+
+### Workspace integration
+```python
+# workspace.py around line 560
+_comments_pub = _make_comment_publisher(...)  # existing
+_webhooks = build_webhooks(yaml_cfg.get("webhooks") or [], run_fn=_run)
+_subscribers = []
+if _comments_pub:
+    _subscribers.append(_wrap_legacy_publisher(_comments_pub))
+for wh in _webhooks:
+    _subscribers.append(_wrap_webhook(wh))   # filters by wh.matches() inside
+_publisher = compose_audit_subscribers(_subscribers)
+audit = _make_audit_fn(audit_log_path=audit_log_path, publisher=_publisher)
+```
+
+## Migration path for live `yoyopod` workspace
+
+Live `~/.hermes/workflows/yoyopod/config/workflow.yaml` does NOT have a `webhooks:` block. After this PR:
+- Schema treats `webhooks:` as optional ⇒ existing config still validates.
+- `build_webhooks([])` returns an empty list ⇒ no behavior change.
+- `compose_audit_subscribers([_comments_pub])` is a single-element fan-out ⇒ behavior preserved.
+
+To opt in, operator adds:
+```yaml
+webhooks:
+  - name: notify-slack
+    kind: slack-incoming
+    url: https://hooks.slack.com/services/T.../B.../...
+    events: ["merge_and_promote", "operator_attention_required"]
+```
+
+## Tests
+
+New file `tests/test_webhooks_phase_c.py`:
+- `test_webhook_protocol_kinds_registered` — `http-json`, `slack-incoming`, `disabled` all in `_WEBHOOK_KINDS`.
+- `test_build_webhooks_empty_list_returns_empty` — `[]` ⇒ `[]`, no errors.
+- `test_build_webhooks_unknown_kind_raises` — `ValueError` with kind list.
+- `test_http_json_webhook_posts_payload_to_url` — mocked `urllib.request.urlopen`, asserts URL + JSON body + Content-Type header.
+- `test_http_json_webhook_includes_custom_headers` — `headers:` config appears in the request.
+- `test_http_json_webhook_retries_on_failure` — `retry-count: 2` ⇒ urlopen called 3 times total when all fail.
+- `test_http_json_webhook_no_retry_on_success` — succeeds on first try ⇒ no retries.
+- `test_slack_incoming_payload_shape` — POSTed JSON has `text`, `blocks` keys; blocks include action + summary.
+- `test_disabled_webhook_does_not_call_urlopen` — `kind: disabled` ⇒ urlopen never called.
+- `test_disabled_webhook_via_enabled_false` — `enabled: false` overrides any kind.
+- `test_event_filter_glob_matches_exact` — `events: ["run_claude_review"]` matches that action only.
+- `test_event_filter_glob_matches_prefix` — `events: ["run_*"]` matches all `run_*` actions.
+- `test_event_filter_omitted_defaults_to_all` — no `events:` key ⇒ all events match.
+- `test_event_filter_no_match_skips_delivery` — non-matching action ⇒ urlopen not called.
+- `test_compose_audit_subscribers_fans_out` — 3 subscribers each receive the same event.
+- `test_compose_audit_subscribers_isolates_exceptions` — subscriber 1 raises ⇒ subscribers 2 & 3 still called.
+- `test_compose_audit_subscribers_signature_matches_publisher` — accepts `(action=, summary=, extra=)`.
+
+New file `tests/test_webhooks_schema.py`:
+- `test_schema_accepts_empty_webhooks_array`
+- `test_schema_accepts_http_json_webhook`
+- `test_schema_accepts_slack_incoming_webhook`
+- `test_schema_rejects_unknown_kind`
+- `test_schema_rejects_extra_properties_on_subscription`
+- `test_existing_yoyopod_workflow_yaml_still_validates`
+
+Existing 477 stay green. Target: ~477 + 23 new = ~500 passing. (Coincidental match with Phase B target — Phase C branches from main, not from Phase B.)
+
+## Open questions
+
+None. Locked in:
+- Outbound only; inbound deferred.
+- Fire-and-forget with inline retry; no persistent queue.
+- Three built-in kinds: `http-json`, `slack-incoming`, `disabled`.
+- Stdlib-only delivery (`urllib.request`).
+- Schema is `additionalProperties: false` per subscription (catch operator typos like `urls:` vs `url:`).

--- a/skills/operator/SKILL.md
+++ b/skills/operator/SKILL.md
@@ -225,6 +225,8 @@ webhooks:
 
 **Delivery semantics:** fire-and-forget, inline retry (default `retry-count: 1` ⇒ initial + 1 retry). Per-subscriber exceptions are swallowed — webhooks cannot break workflow execution. No persistent queue: if the engine crashes mid-delivery the event lives in `audit-log` JSONL but is not redelivered.
 
+**Security:** webhook URLs MUST use `http://` or `https://`. Other schemes (file, gopher, ftp) are rejected at workspace setup. Audit events contain issue numbers, head SHAs, and branch names; choose webhook destinations carefully. `timeout-seconds` is capped at 30; `retry-count` at 5 — webhook delivery runs inline in the audit hook.
+
 **Audit-event payload (what `http-json` POSTs):**
 ```json
 {

--- a/skills/operator/SKILL.md
+++ b/skills/operator/SKILL.md
@@ -184,3 +184,56 @@ agents:
 **Deprecated:** the top-level `codex-bot:` block (`logins`/`clean-reactions`/`pending-reactions`) is still honored as a fallback for one release. Move those keys inside `agents.external-reviewer:` to silence the deprecation path.
 
 **Prompt overrides:** the repair-handoff prompt now lives at `workflows/code_review/prompts/external-reviewer-repair-handoff.md`. Drop a file at `<workspace>/config/prompts/external-reviewer-repair-handoff.md` to override it (Phase A resolution chain).
+
+## Webhooks (Phase C — outbound event subscribers)
+
+Declare N webhook subscriptions under top-level `webhooks:`. Each subscription receives audit events that match its `events:` filter.
+
+```yaml
+webhooks:
+  - name: notify-slack
+    kind: slack-incoming
+    url: https://hooks.slack.com/services/T.../B.../...
+    events: ["merge_and_promote", "operator_attention_required"]
+
+  - name: ci-mirror
+    kind: http-json
+    url: https://ci.example.com/hooks/code-review
+    headers:
+      Authorization: Bearer xyz
+    events: ["run_*", "merge_*"]
+    timeout-seconds: 5
+    retry-count: 2
+
+  - name: temporarily-off
+    kind: http-json
+    url: https://example.com/hook
+    enabled: false   # short-circuit without removing the entry
+```
+
+**Kinds:**
+- `http-json` — POST raw audit-event JSON to `url` with optional `headers:`.
+- `slack-incoming` — POST Slack-formatted blocks to a Slack Incoming Webhook URL.
+- `disabled` — explicit no-op (equivalent to `enabled: false`).
+
+**Event filter (`events:`):** list of fnmatch globs against the audit event's `action` field. Examples:
+- `["*"]` or omitted ⇒ all events
+- `["run_*"]` ⇒ everything starting with `run_`
+- `["merge_and_promote"]` ⇒ exact match
+- `["*_review"]` ⇒ suffix match
+- Multiple globs are OR'd
+
+**Delivery semantics:** fire-and-forget, inline retry (default `retry-count: 1` ⇒ initial + 1 retry). Per-subscriber exceptions are swallowed — webhooks cannot break workflow execution. No persistent queue: if the engine crashes mid-delivery the event lives in `audit-log` JSONL but is not redelivered.
+
+**Audit-event payload (what `http-json` POSTs):**
+```json
+{
+  "at": "2026-04-26T12:34:56Z",
+  "action": "merge_and_promote",
+  "summary": "Merged PR #42",
+  "issueNumber": 42,
+  "headSha": "abc123"
+}
+```
+
+(Extra fields beyond `at`/`action`/`summary` come from the action's audit context — they vary by action.)

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -61,3 +61,97 @@ def test_compose_audit_subscribers_empty_list_is_noop():
     from workflows.code_review.webhooks import compose_audit_subscribers
     pub = compose_audit_subscribers([])
     pub(action="X", summary="Y", extra={})  # no-op, no error
+
+
+def test_http_json_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import http_json  # noqa: F401
+    assert "http-json" in _WEBHOOK_KINDS
+
+
+def test_http_json_webhook_posts_payload_to_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh1", "kind": "http-json", "url": "https://example.com/hook"}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+    assert len(webhooks) == 1
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+
+    assert mock_urlopen.called
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "https://example.com/hook"
+    assert req.get_method() == "POST"
+    body = req.data.decode("utf-8")
+    import json
+    parsed = json.loads(body)
+    assert parsed["action"] == "X"
+    assert parsed["summary"] == "Y"
+    assert req.headers.get("Content-type") == "application/json"
+
+
+def test_http_json_webhook_includes_custom_headers():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "headers": {"X-Custom": "v1", "Authorization": "Bearer xyz"},
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+
+    req = mock_urlopen.call_args[0][0]
+    # urllib normalizes header keys via title-case
+    assert req.headers.get("X-custom") == "v1"
+    assert req.headers.get("Authorization") == "Bearer xyz"
+
+
+def test_http_json_webhook_retries_on_failure():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "retry-count": 2,
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen", side_effect=OSError("net down")) as mock_urlopen:
+        # Should not raise; retry-count: 2 means 1 initial + 2 retries = 3 calls.
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        assert mock_urlopen.call_count == 3
+
+
+def test_http_json_webhook_no_retry_on_success():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "wh1", "kind": "http-json",
+        "url": "https://example.com/hook",
+        "retry-count": 5,
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        assert mock_urlopen.call_count == 1
+
+
+def test_http_json_webhook_matches_default_all_events():
+    from workflows.code_review.webhooks import build_webhooks
+    cfg = [{"name": "wh1", "kind": "http-json", "url": "https://x"}]
+    wh = build_webhooks(cfg, run_fn=None)[0]
+    assert wh.matches({"action": "anything"}) is True

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -1,0 +1,63 @@
+"""Phase C tests: webhook event subscribers."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_webhook_module_exposes_protocol_registry_and_compose():
+    from workflows.code_review.webhooks import (
+        Webhook, WebhookContext, register, build_webhooks,
+        compose_audit_subscribers, _WEBHOOK_KINDS,
+    )
+    assert callable(register)
+    assert callable(build_webhooks)
+    assert callable(compose_audit_subscribers)
+    assert isinstance(_WEBHOOK_KINDS, dict)
+
+
+def test_build_webhooks_empty_list_returns_empty():
+    from workflows.code_review.webhooks import build_webhooks
+    assert build_webhooks([], run_fn=None) == []
+
+
+def test_build_webhooks_unknown_kind_raises():
+    from workflows.code_review.webhooks import build_webhooks
+    with pytest.raises(ValueError, match="unknown"):
+        build_webhooks([{"name": "x", "kind": "made-up"}], run_fn=None)
+
+
+def test_compose_audit_subscribers_fans_out():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+
+    sub1 = MagicMock()
+    sub2 = MagicMock()
+    sub3 = MagicMock()
+    pub = compose_audit_subscribers([sub1, sub2, sub3])
+    pub(action="X", summary="Y", extra={"k": "v"})
+    for s in (sub1, sub2, sub3):
+        s.assert_called_once()
+        evt = s.call_args[0][0]
+        assert evt["action"] == "X"
+        assert evt["summary"] == "Y"
+        assert evt["k"] == "v"
+
+
+def test_compose_audit_subscribers_isolates_exceptions():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+
+    sub1 = MagicMock(side_effect=RuntimeError("boom"))
+    sub2 = MagicMock()
+    sub3 = MagicMock()
+    pub = compose_audit_subscribers([sub1, sub2, sub3])
+    # Should not raise
+    pub(action="X", summary="Y", extra={})
+    sub2.assert_called_once()
+    sub3.assert_called_once()
+
+
+def test_compose_audit_subscribers_empty_list_is_noop():
+    from workflows.code_review.webhooks import compose_audit_subscribers
+    pub = compose_audit_subscribers([])
+    pub(action="X", summary="Y", extra={})  # no-op, no error

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -269,3 +269,36 @@ def test_filtered_subscriber_does_not_deliver_unmatched_events():
     wh = build_webhooks(cfg, run_fn=None)[0]
     assert wh.matches({"action": "merge_and_promote"}) is True
     assert wh.matches({"action": "run_claude_review"}) is False
+
+
+def test_build_webhooks_rejects_file_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "http-json", "url": "file:///etc/passwd"}]
+    with pytest.raises(ValueError, match="unsupported URL scheme"):
+        build_webhooks(cfg, run_fn=None)
+
+
+def test_build_webhooks_rejects_gopher_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "slack-incoming", "url": "gopher://internal/"}]
+    with pytest.raises(ValueError, match="unsupported URL scheme"):
+        build_webhooks(cfg, run_fn=None)
+
+
+def test_build_webhooks_accepts_http_and_https():
+    from workflows.code_review.webhooks import build_webhooks
+
+    for url in ("https://example.com/hook", "http://example.com/hook"):
+        cfg = [{"name": "wh", "kind": "http-json", "url": url}]
+        assert len(build_webhooks(cfg, run_fn=None)) == 1
+
+
+def test_build_webhooks_disabled_kind_skips_scheme_check():
+    """Disabled webhooks don't deliver — scheme check shouldn't apply."""
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "disabled", "url": "file:///irrelevant"}]
+    # Should not raise
+    assert len(build_webhooks(cfg, run_fn=None)) == 1

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -25,7 +25,7 @@ def test_build_webhooks_empty_list_returns_empty():
 def test_build_webhooks_unknown_kind_raises():
     from workflows.code_review.webhooks import build_webhooks
     with pytest.raises(ValueError, match="unknown"):
-        build_webhooks([{"name": "x", "kind": "made-up"}], run_fn=None)
+        build_webhooks([{"name": "x", "kind": "made-up", "url": "https://example.com"}], run_fn=None)
 
 
 def test_compose_audit_subscribers_fans_out():
@@ -301,4 +301,28 @@ def test_build_webhooks_disabled_kind_skips_scheme_check():
 
     cfg = [{"name": "wh", "kind": "disabled", "url": "file:///irrelevant"}]
     # Should not raise
+    assert len(build_webhooks(cfg, run_fn=None)) == 1
+
+
+def test_build_webhooks_rejects_http_json_without_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "http-json"}]
+    with pytest.raises(ValueError, match="requires a 'url'"):
+        build_webhooks(cfg, run_fn=None)
+
+
+def test_build_webhooks_rejects_slack_incoming_without_url():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "slack-incoming"}]
+    with pytest.raises(ValueError, match="requires a 'url'"):
+        build_webhooks(cfg, run_fn=None)
+
+
+def test_build_webhooks_disabled_kind_allows_missing_url():
+    """Disabled is the explicit no-op kind; url isn't required."""
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "disabled"}]
     assert len(build_webhooks(cfg, run_fn=None)) == 1

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -195,3 +195,77 @@ def test_slack_incoming_payload_shape():
     # Block layout: section + context
     assert any(b.get("type") == "section" for b in payload["blocks"])
     assert any(b.get("type") == "context" for b in payload["blocks"])
+
+
+def test_disabled_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import disabled  # noqa: F401
+    assert "disabled" in _WEBHOOK_KINDS
+
+
+def test_disabled_webhook_does_not_call_urlopen():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{"name": "wh", "kind": "disabled"}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        webhooks[0].deliver({"action": "X", "summary": "Y"})
+        mock_urlopen.assert_not_called()
+
+
+def test_disabled_via_enabled_false():
+    """enabled: false overrides any kind."""
+    from workflows.code_review.webhooks import build_webhooks
+    from workflows.code_review.webhooks.disabled import DisabledWebhook
+
+    cfg = [{"name": "wh", "kind": "http-json", "url": "https://x", "enabled": False}]
+    webhooks = build_webhooks(cfg, run_fn=None)
+    assert isinstance(webhooks[0], DisabledWebhook)
+
+
+def test_event_filter_glob_matches_exact():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "run_claude_review"}, ["run_claude_review"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["run_claude_review"]) is False
+
+
+def test_event_filter_glob_matches_prefix():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "run_claude_review"}, ["run_*"]) is True
+    assert event_matches({"action": "run_internal_review"}, ["run_*"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["run_*"]) is False
+
+
+def test_event_filter_glob_suffix():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "internal_review"}, ["*_review"]) is True
+    assert event_matches({"action": "external_review"}, ["*_review"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["*_review"]) is False
+
+
+def test_event_filter_omitted_defaults_to_all():
+    from workflows.code_review.webhooks import event_matches
+    assert event_matches({"action": "any"}, None) is True
+    assert event_matches({"action": "any"}, []) is True
+
+
+def test_event_filter_multiple_globs_or():
+    from workflows.code_review.webhooks import event_matches
+    globs = ["merge_*", "operator_*"]
+    assert event_matches({"action": "merge_and_promote"}, globs) is True
+    assert event_matches({"action": "operator_attention_required"}, globs) is True
+    assert event_matches({"action": "run_claude_review"}, globs) is False
+
+
+def test_filtered_subscriber_does_not_deliver_unmatched_events():
+    """When wrapping a webhook into a subscriber, non-matching events are skipped."""
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "only-merges", "kind": "http-json",
+        "url": "https://x", "events": ["merge_*"],
+    }]
+    wh = build_webhooks(cfg, run_fn=None)[0]
+    assert wh.matches({"action": "merge_and_promote"}) is True
+    assert wh.matches({"action": "run_claude_review"}) is False

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -155,3 +155,43 @@ def test_http_json_webhook_matches_default_all_events():
     cfg = [{"name": "wh1", "kind": "http-json", "url": "https://x"}]
     wh = build_webhooks(cfg, run_fn=None)[0]
     assert wh.matches({"action": "anything"}) is True
+
+
+def test_slack_incoming_webhook_registered():
+    from workflows.code_review.webhooks import _WEBHOOK_KINDS
+    from workflows.code_review.webhooks import slack_incoming  # noqa: F401
+    assert "slack-incoming" in _WEBHOOK_KINDS
+
+
+def test_slack_incoming_payload_shape():
+    from workflows.code_review.webhooks import build_webhooks
+
+    cfg = [{
+        "name": "slack", "kind": "slack-incoming",
+        "url": "https://hooks.slack.com/services/X/Y/Z",
+    }]
+    webhooks = build_webhooks(cfg, run_fn=None)
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__ = lambda self: self
+        mock_urlopen.return_value.__exit__ = lambda self, *a: None
+        mock_urlopen.return_value.status = 200
+        webhooks[0].deliver({
+            "action": "merge_and_promote",
+            "summary": "Merged PR #42",
+            "issueNumber": 42,
+            "headSha": "abc123",
+            "at": "2026-04-26T12:00:00Z",
+        })
+
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url.startswith("https://hooks.slack.com/")
+    import json
+    payload = json.loads(req.data.decode("utf-8"))
+    assert "text" in payload
+    assert "blocks" in payload
+    assert "merge_and_promote" in payload["text"]
+    assert "Merged PR #42" in payload["text"]
+    # Block layout: section + context
+    assert any(b.get("type") == "section" for b in payload["blocks"])
+    assert any(b.get("type") == "context" for b in payload["blocks"])

--- a/tests/test_webhooks_schema.py
+++ b/tests/test_webhooks_schema.py
@@ -1,0 +1,102 @@
+"""Phase C schema validation."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "workflows/code_review/schema.yaml"
+
+
+def _schema():
+    return yaml.safe_load(SCHEMA_PATH.read_text())
+
+
+def _base_config():
+    return {
+        "workflow": "code-review",
+        "schema-version": 1,
+        "instance": {"name": "test", "engine-owner": "hermes"},
+        "repository": {
+            "local-path": "/tmp/x",
+            "github-slug": "x/y",
+            "active-lane-label": "active",
+        },
+        "runtimes": {
+            "codex-acpx": {
+                "kind": "acpx-codex",
+                "session-idle-freshness-seconds": 900,
+                "session-idle-grace-seconds": 1800,
+                "session-nudge-cooldown-seconds": 600,
+            },
+        },
+        "agents": {
+            "coder": {"default": {"name": "c", "model": "m", "runtime": "codex-acpx"}},
+            "internal-reviewer": {"name": "ir", "model": "m", "runtime": "codex-acpx"},
+            "external-reviewer": {"enabled": True, "name": "er"},
+        },
+        "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+        "triggers": {"lane-selector": {"type": "label", "label": "active"}},
+        "storage": {"ledger": "x", "health": "x", "audit-log": "x"},
+    }
+
+
+def test_schema_accepts_no_webhooks_block():
+    Draft7Validator(_schema()).validate(_base_config())
+
+
+def test_schema_accepts_empty_webhooks_array():
+    cfg = _base_config()
+    cfg["webhooks"] = []
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_http_json_webhook():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "http-json", "url": "https://x"}]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_slack_incoming_webhook():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "slack", "kind": "slack-incoming", "url": "https://hooks.slack.com/X"}]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_accepts_full_subscription():
+    cfg = _base_config()
+    cfg["webhooks"] = [{
+        "name": "wh", "kind": "http-json", "url": "https://x",
+        "enabled": True,
+        "events": ["merge_*", "run_*"],
+        "headers": {"X-Custom": "v"},
+        "timeout-seconds": 10,
+        "retry-count": 3,
+    }]
+    Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_unknown_kind():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "made-up"}]
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_extra_property_on_subscription():
+    cfg = _base_config()
+    cfg["webhooks"] = [{"name": "wh", "kind": "http-json", "urls": "https://x"}]  # typo
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)
+
+
+def test_existing_yoyopod_workflow_yaml_still_validates():
+    yoyopod = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/config/workflow.yaml"))
+    if not yoyopod.exists():
+        pytest.skip("yoyopod workspace not present on this host")
+    cfg = yaml.safe_load(yoyopod.read_text())
+    Draft7Validator(_schema()).validate(cfg)

--- a/tests/test_webhooks_schema.py
+++ b/tests/test_webhooks_schema.py
@@ -100,3 +100,23 @@ def test_existing_yoyopod_workflow_yaml_still_validates():
         pytest.skip("yoyopod workspace not present on this host")
     cfg = yaml.safe_load(yoyopod.read_text())
     Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_excessive_timeout():
+    cfg = _base_config()
+    cfg["webhooks"] = [{
+        "name": "wh", "kind": "http-json", "url": "https://x",
+        "timeout-seconds": 60,
+    }]
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)
+
+
+def test_schema_rejects_excessive_retry_count():
+    cfg = _base_config()
+    cfg["webhooks"] = [{
+        "name": "wh", "kind": "http-json", "url": "https://x",
+        "retry-count": 100,
+    }]
+    with pytest.raises(ValidationError):
+        Draft7Validator(_schema()).validate(cfg)

--- a/workflows/code_review/schema.yaml
+++ b/workflows/code_review/schema.yaml
@@ -234,8 +234,8 @@ properties:
         headers:
           type: object
           additionalProperties: {type: string}
-        timeout-seconds: {type: integer, minimum: 1}
-        retry-count: {type: integer, minimum: 0}
+        timeout-seconds: {type: integer, minimum: 1, maximum: 30}
+        retry-count: {type: integer, minimum: 0, maximum: 5}
 
 definitions:
   acpx-codex-runtime:

--- a/workflows/code_review/schema.yaml
+++ b/workflows/code_review/schema.yaml
@@ -215,6 +215,28 @@ properties:
             type: array
             items: {type: string}
 
+  webhooks:
+    type: array
+    items:
+      type: object
+      required: [name, kind]
+      additionalProperties: false
+      properties:
+        name: {type: string}
+        kind:
+          type: string
+          enum: [http-json, slack-incoming, disabled]
+        enabled: {type: boolean}
+        url: {type: string}
+        events:
+          type: array
+          items: {type: string}
+        headers:
+          type: object
+          additionalProperties: {type: string}
+        timeout-seconds: {type: integer, minimum: 1}
+        retry-count: {type: integer, minimum: 0}
+
 definitions:
   acpx-codex-runtime:
     type: object

--- a/workflows/code_review/webhooks/__init__.py
+++ b/workflows/code_review/webhooks/__init__.py
@@ -82,6 +82,11 @@ def build_webhooks(
             kind = "disabled"
         else:
             kind = sub_cfg.get("kind") or ""
+        # Operator-error guard: non-disabled webhooks must declare a url.
+        if kind != "disabled" and not sub_cfg.get("url"):
+            raise ValueError(
+                f"webhook {sub_cfg.get('name')!r}: kind={kind!r} requires a 'url' field"
+            )
         if kind not in _WEBHOOK_KINDS:
             raise ValueError(
                 f"unknown webhook kind={kind!r}; "

--- a/workflows/code_review/webhooks/__init__.py
+++ b/workflows/code_review/webhooks/__init__.py
@@ -38,6 +38,11 @@ def register(kind: str):
     """Decorator: registers a class as the implementation for a webhook kind."""
 
     def _register(cls):
+        if kind in _WEBHOOK_KINDS:
+            raise ValueError(
+                f"duplicate webhook kind={kind!r}; "
+                f"already registered as {_WEBHOOK_KINDS[kind].__name__}"
+            )
         _WEBHOOK_KINDS[kind] = cls
         return cls
 
@@ -82,6 +87,19 @@ def build_webhooks(
                 f"unknown webhook kind={kind!r}; "
                 f"registered kinds: {sorted(_WEBHOOK_KINDS)}"
             )
+        # SSRF guard: only allow http(s) URLs. urllib.request.urlopen will
+        # otherwise happily open file://, gopher://, ftp:// etc. and leak
+        # audit-event content (issue numbers, head SHAs, branch names) to
+        # arbitrary local resources.
+        url = sub_cfg.get("url")
+        if url and kind != "disabled":
+            from urllib.parse import urlparse
+            scheme = urlparse(url).scheme.lower()
+            if scheme not in ("http", "https"):
+                raise ValueError(
+                    f"webhook {sub_cfg.get('name')!r}: unsupported URL scheme "
+                    f"{scheme!r} (only http/https allowed; got {url!r})"
+                )
         cls = _WEBHOOK_KINDS[kind]
         out.append(cls(sub_cfg, ws_context=ctx))
     return out

--- a/workflows/code_review/webhooks/__init__.py
+++ b/workflows/code_review/webhooks/__init__.py
@@ -63,21 +63,10 @@ def build_webhooks(
     """Instantiate one Webhook per subscription. Empty/None config -> []."""
     if not webhooks_cfg:
         return []
-    # Lazy import for side-effect registration. Wrapped in try/except so this
-    # module stands alone before Tasks 2-4 land. Once http_json/slack_incoming/
-    # disabled exist, remove the wrappers.
-    try:
-        from workflows.code_review.webhooks import http_json  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        from workflows.code_review.webhooks import slack_incoming  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        from workflows.code_review.webhooks import disabled as _disabled  # noqa: F401
-    except ImportError:
-        pass
+    # Lazy import for side-effect registration.
+    from workflows.code_review.webhooks import http_json  # noqa: F401
+    from workflows.code_review.webhooks import slack_incoming  # noqa: F401
+    from workflows.code_review.webhooks import disabled as _disabled  # noqa: F401
 
     import time as _time
     ctx = WebhookContext(run_fn=run_fn, now_iso=lambda: _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()))

--- a/workflows/code_review/webhooks/__init__.py
+++ b/workflows/code_review/webhooks/__init__.py
@@ -1,0 +1,125 @@
+"""Pluggable outbound webhook subscribers for audit events.
+
+Mirrors the runtime/reviewer layers: Protocol + @register decorator +
+factory. ``compose_audit_subscribers`` fans out an audit event to N
+subscribers with per-subscriber exception isolation, matching the
+publisher contract used by ``workspace._make_audit_fn``.
+"""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class WebhookContext:
+    """Workspace-scoped primitives a webhook needs at delivery time."""
+
+    run_fn: Callable[..., Any] | None
+    now_iso: Callable[[], str]
+
+
+@runtime_checkable
+class Webhook(Protocol):
+    """Protocol every webhook kind implements."""
+
+    name: str
+
+    def deliver(self, audit_event: dict[str, Any]) -> None: ...
+
+    def matches(self, audit_event: dict[str, Any]) -> bool: ...
+
+
+_WEBHOOK_KINDS: dict[str, type] = {}
+
+
+def register(kind: str):
+    """Decorator: registers a class as the implementation for a webhook kind."""
+
+    def _register(cls):
+        _WEBHOOK_KINDS[kind] = cls
+        return cls
+
+    return _register
+
+
+def event_matches(audit_event: dict[str, Any], event_globs: list[str] | None) -> bool:
+    """Match an audit event's `action` against a list of fnmatch globs.
+
+    None / empty list => match all (implicit ['*']).
+    """
+    action = str(audit_event.get("action") or "")
+    if not event_globs:
+        return True
+    return any(fnmatch.fnmatchcase(action, g) for g in event_globs)
+
+
+def build_webhooks(
+    webhooks_cfg: list[dict] | None,
+    *,
+    run_fn: Callable[..., Any] | None = None,
+) -> list[Webhook]:
+    """Instantiate one Webhook per subscription. Empty/None config -> []."""
+    if not webhooks_cfg:
+        return []
+    # Lazy import for side-effect registration. Wrapped in try/except so this
+    # module stands alone before Tasks 2-4 land. Once http_json/slack_incoming/
+    # disabled exist, remove the wrappers.
+    try:
+        from workflows.code_review.webhooks import http_json  # noqa: F401
+    except ImportError:
+        pass
+    try:
+        from workflows.code_review.webhooks import slack_incoming  # noqa: F401
+    except ImportError:
+        pass
+    try:
+        from workflows.code_review.webhooks import disabled as _disabled  # noqa: F401
+    except ImportError:
+        pass
+
+    import time as _time
+    ctx = WebhookContext(run_fn=run_fn, now_iso=lambda: _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()))
+
+    out: list[Webhook] = []
+    for sub_cfg in webhooks_cfg:
+        if sub_cfg.get("enabled") is False:
+            kind = "disabled"
+        else:
+            kind = sub_cfg.get("kind") or ""
+        if kind not in _WEBHOOK_KINDS:
+            raise ValueError(
+                f"unknown webhook kind={kind!r}; "
+                f"registered kinds: {sorted(_WEBHOOK_KINDS)}"
+            )
+        cls = _WEBHOOK_KINDS[kind]
+        out.append(cls(sub_cfg, ws_context=ctx))
+    return out
+
+
+def compose_audit_subscribers(
+    subscribers: list[Callable[[dict], None]],
+) -> Callable[..., None]:
+    """Fan-out callable matching the publisher contract used by
+    ``_make_audit_fn``: ``publisher(action, summary, extra=...)``.
+
+    Each subscriber receives a fully-built audit_event dict
+    ``{"at": ..., "action": ..., "summary": ..., **extra}``.
+    Per-subscriber exceptions are caught and swallowed.
+    """
+    import time as _time
+
+    def _now_iso():
+        return _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime())
+
+    def publisher(*, action, summary, extra=None):
+        event = {"at": _now_iso(), "action": action, "summary": summary, **(extra or {})}
+        for sub in subscribers:
+            try:
+                sub(event)
+            except Exception:
+                # Best-effort: never break workflow execution.
+                pass
+
+    return publisher

--- a/workflows/code_review/webhooks/disabled.py
+++ b/workflows/code_review/webhooks/disabled.py
@@ -1,0 +1,24 @@
+"""Disabled webhook — no-op delivery, never matches."""
+from __future__ import annotations
+
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    register,
+)
+
+
+@register("disabled")
+class DisabledWebhook:
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed-disabled")
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return False
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        return None

--- a/workflows/code_review/webhooks/http_json.py
+++ b/workflows/code_review/webhooks/http_json.py
@@ -1,0 +1,69 @@
+"""HTTP-JSON outbound webhook (POST raw audit-event JSON to a URL)."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    event_matches,
+    register,
+)
+
+
+_DEFAULT_TIMEOUT = 5
+_DEFAULT_RETRY_COUNT = 1
+
+
+@register("http-json")
+class HttpJsonWebhook:
+    """POSTs each audit event verbatim as JSON to a configured URL.
+
+    Config shape (YAML):
+        - name: my-hook
+          kind: http-json
+          url: https://example.com/hook
+          headers: {X-Custom: v}
+          events: ["merge_*"]
+          timeout-seconds: 5
+          retry-count: 1
+    """
+
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed")
+        self._url = cfg.get("url") or ""
+        self._headers = dict(cfg.get("headers") or {})
+        self._events = list(cfg.get("events") or [])
+        self._timeout = int(cfg.get("timeout-seconds") or _DEFAULT_TIMEOUT)
+        self._retry_count = int(cfg.get("retry-count") if cfg.get("retry-count") is not None else _DEFAULT_RETRY_COUNT)
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return event_matches(audit_event, self._events)
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        if not self._url:
+            return
+        body = json.dumps(audit_event).encode("utf-8")
+        attempts = self._retry_count + 1
+        last_err: Exception | None = None
+        for _ in range(attempts):
+            try:
+                req = urllib.request.Request(
+                    self._url,
+                    data=body,
+                    method="POST",
+                    headers={"Content-type": "application/json", **self._headers},
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout):
+                    return
+            except (urllib.error.URLError, OSError) as e:
+                last_err = e
+                continue
+        # All retries exhausted; swallow (compose_audit_subscribers also catches,
+        # but be explicit: webhook delivery is best-effort).
+        return

--- a/workflows/code_review/webhooks/slack_incoming.py
+++ b/workflows/code_review/webhooks/slack_incoming.py
@@ -1,0 +1,89 @@
+"""Slack Incoming Webhook delivery.
+
+Reformats audit events into Slack block payloads. Operator supplies
+the Incoming Webhook URL; the engine never authenticates separately.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflows.code_review.webhooks import (
+    Webhook,
+    WebhookContext,
+    event_matches,
+    register,
+)
+
+
+_DEFAULT_TIMEOUT = 5
+_DEFAULT_RETRY_COUNT = 1
+
+
+@register("slack-incoming")
+class SlackIncomingWebhook:
+    """Posts audit events to a Slack Incoming Webhook URL with block layout.
+
+    Config shape (YAML):
+        - name: notify-slack
+          kind: slack-incoming
+          url: https://hooks.slack.com/services/T.../B.../...
+          events: ["merge_and_promote"]
+    """
+
+    def __init__(self, cfg: dict, *, ws_context: WebhookContext):
+        self._cfg = cfg
+        self._ctx = ws_context
+        self.name = str(cfg.get("name") or "unnamed")
+        self._url = cfg.get("url") or ""
+        self._events = list(cfg.get("events") or [])
+        self._timeout = int(cfg.get("timeout-seconds") or _DEFAULT_TIMEOUT)
+        self._retry_count = int(cfg.get("retry-count") if cfg.get("retry-count") is not None else _DEFAULT_RETRY_COUNT)
+
+    def matches(self, audit_event: dict[str, Any]) -> bool:
+        return event_matches(audit_event, self._events)
+
+    def _build_payload(self, audit_event: dict[str, Any]) -> dict[str, Any]:
+        action = str(audit_event.get("action") or "")
+        summary = str(audit_event.get("summary") or "")
+        issue_number = audit_event.get("issueNumber")
+        head_sha = audit_event.get("headSha")
+        at = audit_event.get("at")
+
+        context_bits = []
+        if issue_number is not None:
+            context_bits.append(f"issue #{issue_number}")
+        if head_sha:
+            context_bits.append(f"`{head_sha}`")
+        if at:
+            context_bits.append(str(at))
+        context_text = " · ".join(context_bits) or "code-review event"
+
+        return {
+            "text": f"[code-review] {action} — {summary}",
+            "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": f"*{action}*\n{summary}"}},
+                {"type": "context", "elements": [{"type": "mrkdwn", "text": context_text}]},
+            ],
+        }
+
+    def deliver(self, audit_event: dict[str, Any]) -> None:
+        if not self._url:
+            return
+        body = json.dumps(self._build_payload(audit_event)).encode("utf-8")
+        attempts = self._retry_count + 1
+        for _ in range(attempts):
+            try:
+                req = urllib.request.Request(
+                    self._url,
+                    data=body,
+                    method="POST",
+                    headers={"Content-type": "application/json"},
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout):
+                    return
+            except (urllib.error.URLError, OSError):
+                continue
+        return

--- a/workflows/code_review/workspace.py
+++ b/workflows/code_review/workspace.py
@@ -567,7 +567,40 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
             _ns_load_ledger().get("workflowState") == "operator_attention_required"
         ),
     )
-    audit = _make_audit_fn(audit_log_path=audit_log_path, publisher=_publisher)
+    from workflows.code_review.webhooks import build_webhooks, compose_audit_subscribers
+
+    _webhooks = build_webhooks((yaml_cfg or {}).get("webhooks") or [], run_fn=_run)
+
+    def _adapt_legacy_publisher(legacy_pub):
+        """The legacy comments publisher takes (action=, summary=, extra=).
+        Compose-style subscribers receive a single audit_event dict. Adapt."""
+        if legacy_pub is None:
+            return None
+        def _sub(audit_event):
+            legacy_pub(
+                action=audit_event.get("action") or "",
+                summary=audit_event.get("summary") or "",
+                extra={k: v for k, v in audit_event.items() if k not in ("action", "summary", "at")},
+            )
+        return _sub
+
+    def _adapt_webhook(wh):
+        """Wrap a Webhook into a (audit_event)->None subscriber that respects matches()."""
+        def _sub(audit_event):
+            if not wh.matches(audit_event):
+                return
+            wh.deliver(audit_event)
+        return _sub
+
+    _subscribers = []
+    _legacy = _adapt_legacy_publisher(_publisher)
+    if _legacy is not None:
+        _subscribers.append(_legacy)
+    for _wh in _webhooks:
+        _subscribers.append(_adapt_webhook(_wh))
+
+    _fanout_publisher = compose_audit_subscribers(_subscribers) if _subscribers else None
+    audit = _make_audit_fn(audit_log_path=audit_log_path, publisher=_fanout_publisher)
 
     # Pre-declared so closures below can resolve them once ``ns`` is built.
     # Bindings happen after ``ns`` is created, below.


### PR DESCRIPTION
## Summary

Phase C of the model-agnostic refactor. Audit events fan out to N operator-declared webhook subscribers — no behavior change unless a `webhooks:` block is present.

- New `workflows/code_review/webhooks/` package with `Webhook` Protocol, `WebhookContext`, `@register` registry, `build_webhooks()` factory, `compose_audit_subscribers()` fan-out, `event_matches()` glob helper
- Three providers:
  - `http-json` — POST raw audit-event JSON to a URL with optional headers
  - `slack-incoming` — POST Slack-formatted blocks to an Incoming Webhook URL
  - `disabled` — explicit no-op kind (also triggered by `enabled: false`)
- Schema gains optional top-level `webhooks:` array. Each subscription has `additionalProperties: false`, `kind:` enum, `events:` glob filter, optional headers/timeout/retry
- Workspace builder fans out audit events to the existing comments publisher + N webhooks; per-subscriber exceptions are isolated (one bad subscriber can't break workflow execution)
- Stdlib-only delivery (`urllib.request`); fire-and-forget with bounded inline retry

## Security

- **SSRF guard:** `build_webhooks` rejects non-`http(s)` URL schemes at workspace setup. Without this, `urllib.request.urlopen` would happily open `file://`, `gopher://`, `ftp://` URLs and leak audit-event payloads (issue numbers, head SHAs, branch names) to arbitrary local resources.
- **Bounded retry budget:** schema caps `timeout-seconds` at 30 and `retry-count` at 5. Worst case per audit hook: 6 webhooks × 6 attempts × 30s ≈ 18min; previously unbounded.
- **Duplicate-kind guard:** `@register` raises on duplicate kind keys instead of silently overwriting.

## Out of scope (deferred)

- Inbound webhooks (e.g. GitHub webhook → trigger workflow tick)
- Persistent retry queue (current path is fire-and-forget; engine crash mid-delivery loses the in-flight retry but the event is still in `audit-log` JSONL)
- HMAC signing on outbound (`X-Hub-Signature` style)
- Templated payloads (`slack-incoming` builds a fixed block layout)
- Phase D rename pass

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-26-webhooks-phase-c-design.md`
- Plan: `docs/superpowers/plans/2026-04-26-webhooks-phase-c.md`

## Test plan

- [x] 514 tests passing (477 baseline + 37 new)
- [x] Live yoyopod `workflow.yaml` still validates against the extended schema (no `webhooks:` block ⇒ no behavior change)
- [x] Per-subscriber exception isolation verified
- [x] Event glob semantics covered (exact, prefix, suffix, multi-glob OR, omitted-defaults-to-all)
- [x] Two-stage review per task; final reviewer flagged SSRF + unbounded retry budget; both fixed in 2bcbc4f
- [ ] Operator review of the new webhooks config surface in `skills/operator/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)