### PR TITLE
Phase D-1: persisted-state migration (reviews.claudeCode -> reviews.internalReview)

### DIFF
--- a/docs/superpowers/plans/2026-04-26-rename-pass-phase-d-1.md
+++ b/docs/superpowers/plans/2026-04-26-rename-pass-phase-d-1.md
@@ -1,0 +1,653 @@
+# Rename Pass Phase D-1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Migrate persisted ledger keys `reviews.claudeCode` → `reviews.internalReview` and `reviews.codexCloud` → `reviews.externalReview`. One-shot migration + read-both/write-new code paths. Action-type literal `run_claude_review` → `run_internal_review` with alias.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-rename-pass-phase-d-1-design.md`
+
+**Worktree:** `/home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-1` on branch `claude/rename-pass-phase-d-1` from main `47ae160`. Baseline 477 tests passing. Use `/usr/bin/python3`.
+
+---
+
+## File Structure
+
+**New files:**
+- `workflows/code_review/migrations.py` — `REVIEW_KEY_RENAMES`, `migrate_review_keys`, `get_review`, `migrate_persisted_ledger`
+- `tests/test_rename_pass_phase_d_1.py`
+
+**Modified files:**
+- `workflows/code_review/actions.py` — write sites for `claudeCode`, action-type literal
+- `workflows/code_review/orchestrator.py` — read sites for `claudeCode`
+- `workflows/code_review/reviews.py` — read + write sites for `claudeCode` and `codexCloud`
+- `workflows/code_review/workflow.py` — read sites for `claudeCode`
+- `workflows/code_review/status.py` — read sites for `claudeCode`
+- `workflows/code_review/workspace.py` — invoke `migrate_persisted_ledger` on bootstrap
+- `skills/operator/SKILL.md` — note about migration
+
+---
+
+## Task 1: Migrations module
+
+**Files:**
+- Create: `workflows/code_review/migrations.py`
+- Test: `tests/test_rename_pass_phase_d_1.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_rename_pass_phase_d_1.py`:
+
+```python
+"""Phase D-1 tests: persisted-state migration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_migrate_review_keys_renames_legacy_keys():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"claudeCode": {"v": 1}, "codexCloud": {"v": 2}}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is True
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert out["reviews"]["externalReview"] == {"v": 2}
+    assert "claudeCode" not in out["reviews"]
+    assert "codexCloud" not in out["reviews"]
+
+
+def test_migrate_review_keys_idempotent():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"internalReview": {"v": 1}, "externalReview": {"v": 2}}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is False
+    assert out["reviews"]["internalReview"] == {"v": 1}
+
+
+def test_migrate_review_keys_new_key_wins_when_both_present():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {
+        "claudeCode": {"v": "old"}, "internalReview": {"v": "new"},
+        "codexCloud": {"v": "old2"}, "externalReview": {"v": "new2"},
+    }}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is True  # old keys were dropped
+    assert out["reviews"]["internalReview"] == {"v": "new"}
+    assert out["reviews"]["externalReview"] == {"v": "new2"}
+    assert "claudeCode" not in out["reviews"]
+    assert "codexCloud" not in out["reviews"]
+
+
+def test_migrate_review_keys_passes_through_unknown_keys():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"claudeCode": {"v": 1}, "rockClaw": {"v": 9}}}
+    out, _ = migrate_review_keys(ledger)
+    assert out["reviews"]["rockClaw"] == {"v": 9}
+
+
+def test_migrate_review_keys_handles_missing_reviews_block():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"activeLane": {"number": 42}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is False
+    assert out == ledger
+
+
+def test_get_review_returns_new_when_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"internalReview": {"v": 1}}
+    assert get_review(reviews, "internalReview") == {"v": 1}
+
+
+def test_get_review_falls_back_to_legacy_when_only_legacy_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"claudeCode": {"v": 1}}
+    assert get_review(reviews, "internalReview") == {"v": 1}
+
+    reviews = {"codexCloud": {"v": 2}}
+    assert get_review(reviews, "externalReview") == {"v": 2}
+
+
+def test_get_review_prefers_new_when_both_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"claudeCode": {"v": "old"}, "internalReview": {"v": "new"}}
+    assert get_review(reviews, "internalReview") == {"v": "new"}
+
+
+def test_get_review_returns_empty_dict_for_unknown_key():
+    from workflows.code_review.migrations import get_review
+
+    assert get_review({"x": 1}, "made-up") == {}
+
+
+def test_get_review_returns_empty_dict_when_value_is_none():
+    from workflows.code_review.migrations import get_review
+
+    assert get_review({"internalReview": None}, "internalReview") == {}
+
+
+def test_migrate_persisted_ledger_rewrites_file_atomically(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    p.write_text(json.dumps({"reviews": {"claudeCode": {"v": 1}}}, indent=2))
+    migrate_persisted_ledger(p)
+    out = json.loads(p.read_text())
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert "claudeCode" not in out["reviews"]
+
+
+def test_migrate_persisted_ledger_noop_on_already_migrated(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    initial = {"reviews": {"internalReview": {"v": 1}}}
+    p.write_text(json.dumps(initial, indent=2))
+    mtime_before = p.stat().st_mtime_ns
+    # Sleep just enough that any rewrite would change mtime
+    import time
+    time.sleep(0.01)
+    migrate_persisted_ledger(p)
+    mtime_after = p.stat().st_mtime_ns
+    assert mtime_before == mtime_after  # file untouched
+
+
+def test_migrate_persisted_ledger_handles_missing_file(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "does-not-exist.json"
+    # Should not raise
+    migrate_persisted_ledger(p)
+    assert not p.exists()
+
+
+def test_migrate_persisted_ledger_preserves_indent(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    p.write_text(json.dumps({"reviews": {"claudeCode": {"v": 1}}}, indent=2))
+    migrate_persisted_ledger(p)
+    text = p.read_text()
+    assert "  " in text  # 2-space indent preserved
+
+
+def test_existing_yoyopod_ledger_migrates_cleanly(tmp_path):
+    """Smoke test: copy live yoyopod ledger to tmp, migrate, assert it works."""
+    from workflows.code_review.migrations import migrate_persisted_ledger, get_review
+    import os
+    src = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json"))
+    if not src.exists():
+        pytest.skip("yoyopod ledger not present on this host")
+
+    dst = tmp_path / "ledger.json"
+    dst.write_text(src.read_text())
+    migrate_persisted_ledger(dst)
+
+    out = json.loads(dst.read_text())
+    reviews = out.get("reviews") or {}
+    # Old keys gone (if they were present)
+    assert "claudeCode" not in reviews
+    assert "codexCloud" not in reviews
+    # New keys readable via get_review (passes whether or not the source had old keys)
+    _ = get_review(reviews, "internalReview")
+    _ = get_review(reviews, "externalReview")
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-1
+/usr/bin/python3 -m pytest tests/test_rename_pass_phase_d_1.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: No module named 'workflows.code_review.migrations'`.
+
+- [ ] **Step 3: Create migrations module**
+
+Create `workflows/code_review/migrations.py`:
+
+```python
+"""Persisted-state migrations for the code-review workflow.
+
+Phase D-1 rationale:
+  reviews.claudeCode -> reviews.internalReview
+  reviews.codexCloud -> reviews.externalReview
+
+The old names tied the ledger to specific providers (Claude / Codex
+Cloud). Phases A-C made runtimes/reviewers/webhooks pluggable; this
+migration removes the last operator-visible coupling to provider names.
+
+`migrate_persisted_ledger(path)` runs idempotently on workspace setup.
+`get_review(reviews_dict, new_key)` reads new key with legacy fallback
+so an unmigrated ledger still works for one release.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REVIEW_KEY_RENAMES: dict[str, str] = {
+    "claudeCode": "internalReview",
+    "codexCloud": "externalReview",
+}
+
+_LEGACY_KEY_FOR: dict[str, str] = {v: k for k, v in REVIEW_KEY_RENAMES.items()}
+
+
+def migrate_review_keys(ledger: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Rewrite legacy `reviews.<old>` keys to their new names.
+
+    If both old and new keys are present, the new value wins and the
+    old key is dropped. Returns ``(ledger, was_changed)``. The ``ledger``
+    object is mutated in place AND returned for convenience.
+    """
+    reviews = ledger.get("reviews")
+    if not isinstance(reviews, dict):
+        return ledger, False
+
+    changed = False
+    for old_key, new_key in REVIEW_KEY_RENAMES.items():
+        if old_key in reviews:
+            if new_key not in reviews:
+                reviews[new_key] = reviews[old_key]
+            del reviews[old_key]
+            changed = True
+    return ledger, changed
+
+
+def get_review(reviews: dict[str, Any] | None, new_key: str) -> dict[str, Any]:
+    """Read a review by its new key; fall back to the legacy key."""
+    reviews = reviews or {}
+    value = reviews.get(new_key)
+    if value:
+        return value
+    legacy_key = _LEGACY_KEY_FOR.get(new_key)
+    if legacy_key:
+        legacy_value = reviews.get(legacy_key)
+        if legacy_value:
+            return legacy_value
+    return {}
+
+
+def migrate_persisted_ledger(path: Path | str) -> bool:
+    """Migrate the on-disk ledger at ``path``, atomically.
+
+    Returns True if the file was rewritten, False otherwise. Missing
+    files are silently no-op'd. Indent-2 JSON format is preserved.
+    """
+    p = Path(path)
+    if not p.exists():
+        return False
+    try:
+        ledger = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    _, changed = migrate_review_keys(ledger)
+    if not changed:
+        return False
+
+    # Atomic temp-file + rename in the same directory.
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=p.name, suffix=".tmp", dir=str(p.parent)
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(ledger, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, p)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+    return True
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_rename_pass_phase_d_1.py -v
+```
+Expected: 14 passed (or 13 + 1 skipped if yoyopod ledger absent).
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 491 passed (or 490 + 1 skipped).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(migrations): add persisted-state migration helpers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Rename claudeCode reads via get_review
+
+**Files:**
+- Modify: `workflows/code_review/orchestrator.py` (~6 read sites at lines 148, 185, 193, 364, 365)
+- Modify: `workflows/code_review/reviews.py` (~5 read sites at lines 207, 1348, 1358, 1366, 1494)
+- Modify: `workflows/code_review/workflow.py` (~2 read sites at lines 62, 177)
+- Modify: `workflows/code_review/status.py` (~1 read site at line 440)
+
+- [ ] **Step 1: Mechanical replacement of all read sites**
+
+For each occurrence of `reviews.get("claudeCode")` or `(reviews or {}).get("claudeCode")` or `existing_reviews.get("claudeCode")`, replace with `get_review(reviews_dict, "internalReview")`.
+
+Add `from workflows.code_review.migrations import get_review` to the top of each modified file (or to local scope where natural).
+
+Specific transformations:
+- `orchestrator.py:148`: `existing_claude_review = existing_reviews.get("claudeCode")` → `existing_claude_review = get_review(existing_reviews, "internalReview")` (note: the variable name `existing_claude_review` is preserved; renaming the local var is Phase D-2's problem to keep this PR small).
+- `orchestrator.py:185`: `inter_review_agent_review=reviews["claudeCode"]` → `inter_review_agent_review=get_review(reviews, "internalReview")` — but `reviews["claudeCode"]` is a write-target-style read inside an indexable dict. Inspect the surrounding code: if it's actually being passed as a value (not assigned), the `get_review` call is fine. If it's expected to mutate the dict, this needs different handling. Read the surrounding 5 lines and decide.
+- `orchestrator.py:193`, `:364`, `:365`: same pattern; use `get_review(reviews, "internalReview")` for read-only access.
+- `orchestrator.py:340`: `previous_claude_review = ((ledger.get("reviews") or {}).get("claudeCode") or {}).copy()` → `previous_claude_review = get_review(ledger.get("reviews"), "internalReview").copy()`
+- `reviews.py:207`: `claude_review = reviews.get("claudeCode") or {}` → `claude_review = get_review(reviews, "internalReview")`
+- `reviews.py:1348`, `:1358`, `:1366`: `claude_review=reviews.get("claudeCode")` → `claude_review=get_review(reviews, "internalReview")` — note these pass to function kwargs; the parameter rename `claude_review` → `internal_review` is Phase D-2.
+- `reviews.py:1494`: `existing_claude_review = existing_reviews.get("claudeCode")` → `existing_claude_review = get_review(existing_reviews, "internalReview")`
+- `workflow.py:62`: `claude_review = (reviews or {}).get("claudeCode")` → `claude_review = get_review(reviews, "internalReview")` (note `or {}` is no longer needed because `get_review` handles None)
+- `workflow.py:177`: `claude_review=(reviews or {}).get("claudeCode")` → `claude_review=get_review(reviews, "internalReview")`
+- `status.py:440`: this one is special — it's part of a fallback chain `ledger.get("claudeModel") or ledger.get("interReviewAgentModel") or ((reviews.get("claudeCode") or {}).get("model"))`. Replace the `reviews.get("claudeCode")` part: `or get_review(reviews, "internalReview").get("model")`.
+
+- [ ] **Step 2: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 491 passed. Tests that mock `reviews["claudeCode"]` directly still work because `get_review` falls back to the legacy key.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: read reviews.internalReview via get_review (with legacy fallback)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Rename codexCloud reads via get_review
+
+**Files:**
+- Modify: same files as Task 2, plus any `codexCloud` read sites
+
+- [ ] **Step 1: Find all codexCloud reads**
+
+```bash
+grep -rn 'reviews.*get("codexCloud")\|reviews\[.codexCloud.\]' workflows/code_review/*.py | grep -v test_
+```
+
+Apply the same `get_review(reviews, "externalReview")` pattern to each.
+
+- [ ] **Step 2: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 491 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: read reviews.externalReview via get_review (with legacy fallback)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Rename write sites
+
+**Files:**
+- Modify: `workflows/code_review/actions.py` (lines 369, 401, 435 for `claudeCode`; similar for `codexCloud`)
+- Modify: `workflows/code_review/reviews.py` (lines 1504, 1531 for `claudeCode`)
+
+- [ ] **Step 1: Replace assignment targets**
+
+`actions.py:369`: `ledger['reviews']['claudeCode'] = build_inter_review_agent_running_review(...)` → `ledger['reviews']['internalReview'] = build_inter_review_agent_running_review(...)`. Also delete any stale `claudeCode` key in the same dict to avoid both keys being live during the read-both window: `ledger['reviews'].pop('claudeCode', None)`.
+
+Same pattern for lines 401, 435 in actions.py.
+
+In reviews.py:1504 and :1531: `"claudeCode": normalize_review(...)` (inside dict literals constructing `reviews`) → `"internalReview": normalize_review(...)`.
+
+For codexCloud writes (search `grep -n '"codexCloud"' workflows/code_review/*.py`): same pattern — replace key in dict literal with `"externalReview"`.
+
+- [ ] **Step 2: Verify reads of the same data still work**
+
+After the write-site rename, code paths that read the same dict in the same tick must read via `get_review` (Tasks 2 + 3 already did this) so the new key is found. Sanity check:
+
+```bash
+grep -rn '"claudeCode"\|"codexCloud"' workflows/code_review/*.py | grep -v test_ | grep -v migrations.py
+```
+Expected: only the in-comment / docstring references remain (no live code).
+
+- [ ] **Step 3: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 491 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: write reviews.internalReview / reviews.externalReview (drop legacy keys)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Action-type rename + workspace integration
+
+**Files:**
+- Modify: `workflows/code_review/actions.py:473`
+- Modify: `workflows/code_review/workflow.py` (any `pick_workflow_action` site that emits the literal)
+- Modify: `workflows/code_review/workspace.py` — invoke `migrate_persisted_ledger` at bootstrap
+- Test: `tests/test_rename_pass_phase_d_1.py` (extend)
+
+- [ ] **Step 1: Add failing tests for the action-type alias**
+
+Append to `tests/test_rename_pass_phase_d_1.py`:
+
+```python
+def test_action_dispatcher_accepts_run_internal_review():
+    """The dispatcher matches the new literal."""
+    # This test is structural — actions.py has a single dispatch site at line 473.
+    # We test by reading the source and asserting both literals are matched.
+    from pathlib import Path
+    src = Path(__file__).resolve().parent.parent / "workflows/code_review/actions.py"
+    text = src.read_text()
+    # Expected dispatcher form: action_type in ('run_internal_review', 'run_claude_review')
+    assert "run_internal_review" in text
+    assert "run_claude_review" in text  # back-compat alias retained
+
+
+def test_action_dispatcher_accepts_run_claude_review_alias():
+    """Same as above, framed from the alias side."""
+    from pathlib import Path
+    src = Path(__file__).resolve().parent.parent / "workflows/code_review/actions.py"
+    text = src.read_text()
+    # Both literals should appear in the same expression
+    assert "'run_internal_review'" in text or '"run_internal_review"' in text
+    assert "'run_claude_review'" in text or '"run_claude_review"' in text
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_rename_pass_phase_d_1.py::test_action_dispatcher_accepts_run_internal_review -v
+```
+Expected: FAIL — `run_internal_review` not in source.
+
+- [ ] **Step 3: Update actions.py:473**
+
+Change:
+```python
+if action_type == 'run_claude_review':
+    return run_inter_review_agent_review_action(...)
+```
+to:
+```python
+if action_type in ('run_internal_review', 'run_claude_review'):
+    return run_inter_review_agent_review_action(...)
+```
+
+- [ ] **Step 4: Update producers**
+
+Search for sites that emit `'run_claude_review'` (likely in `workflow.py` or `pick_workflow_action`):
+
+```bash
+grep -n "run_claude_review" workflows/code_review/*.py
+```
+
+Producers should now emit `'run_internal_review'`. Consumers continue to accept the alias.
+
+- [ ] **Step 5: Wire migrate_persisted_ledger into workspace bootstrap**
+
+In `workflows/code_review/workspace.py`, after `ledger_path` is determined (around line 583) but before any code reads the ledger, add:
+
+```python
+from workflows.code_review.migrations import migrate_persisted_ledger
+migrate_persisted_ledger(ledger_path)
+```
+
+(Place this immediately after the `ledger_path = ...` assignment.)
+
+- [ ] **Step 6: Run tests**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 493 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(actions): rename run_claude_review -> run_internal_review (alias retained)
+
+Wire migrate_persisted_ledger into workspace bootstrap so existing
+ledgers migrate in-place on first startup. Idempotent on subsequent
+runs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Operator docs
+
+**Files:**
+- Modify: `skills/operator/SKILL.md`
+
+- [ ] **Step 1: Append a section**
+
+Append to `skills/operator/SKILL.md`:
+
+````markdown
+## Persisted-state migration (Phase D-1)
+
+The workflow ledger renames two `reviews.*` keys for provider neutrality:
+- `reviews.claudeCode` → `reviews.internalReview`
+- `reviews.codexCloud` → `reviews.externalReview`
+
+**Migration is automatic.** On workspace bootstrap, the engine rewrites the persisted ledger in place (atomic temp-file + rename). Idempotent: subsequent boots are no-ops.
+
+**Back-compat reads.** For one release, code paths use a `get_review(reviews, new_key)` helper that falls back to the legacy key if the migration hasn't run yet (e.g., a stale process wrote an old key after migration).
+
+**Action-type literal.** The transient action `run_claude_review` is renamed to `run_internal_review`. The dispatcher accepts both for one release.
+
+**What this means for you:** nothing — the rename is transparent. If you write external tooling that reads the ledger directly (e.g., a dashboard parsing `yoyopod-workflow-status.json`), update it to use `reviews.internalReview` / `reviews.externalReview`.
+````
+
+- [ ] **Step 2: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 493 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "docs(operator): document phase D-1 ledger field migration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run full suite**
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-1
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 493 passed (or 492 + 1 skipped).
+
+- [ ] **Sanity-check: live yoyopod ledger migrates cleanly**
+
+```bash
+/usr/bin/python3 -c "
+import json, shutil, tempfile
+from pathlib import Path
+from workflows.code_review.migrations import migrate_persisted_ledger, get_review
+
+src = Path.home() / '.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json'
+with tempfile.TemporaryDirectory() as td:
+    dst = Path(td) / 'l.json'
+    shutil.copy2(src, dst)
+    changed = migrate_persisted_ledger(dst)
+    out = json.loads(dst.read_text())
+    reviews = out.get('reviews') or {}
+    assert 'claudeCode' not in reviews
+    assert 'codexCloud' not in reviews
+    print('migration:', 'rewrote' if changed else 'no-op')
+    print('internalReview present:', 'internalReview' in reviews)
+    print('externalReview present:', 'externalReview' in reviews)
+    print('rockClaw preserved:', 'rockClaw' in reviews)
+"
+```
+
+- [ ] **Sanity-check: schema unchanged for live yoyopod**
+
+```bash
+/usr/bin/python3 -c "
+import yaml
+from pathlib import Path
+from jsonschema import Draft7Validator
+schema = yaml.safe_load(Path('workflows/code_review/schema.yaml').read_text())
+cfg = yaml.safe_load(Path('/home/radxa/.hermes/workflows/yoyopod/config/workflow.yaml').read_text())
+Draft7Validator(schema).validate(cfg)
+print('yoyopod config valid')
+"
+```
+
+- [ ] **Use superpowers:finishing-a-development-branch.**

--- a/docs/superpowers/specs/2026-04-26-rename-pass-phase-d-1-design.md
+++ b/docs/superpowers/specs/2026-04-26-rename-pass-phase-d-1-design.md
@@ -1,0 +1,199 @@
+# Rename Pass Phase D-1 — Persisted-State Migration
+
+**Status:** Approved
+**Date:** 2026-04-26
+**Branch:** `claude/rename-pass-phase-d-1` (worktree at `.claude/worktrees/rename-pass-phase-d-1`)
+**Baseline:** main `47ae160`, 477 tests passing
+
+## Problem
+
+The persisted workflow ledger uses model-tied field names that leak into operator-visible state files:
+
+```json
+{
+  "reviews": {
+    "claudeCode": { "verdict": "PASS_CLEAN", ... },
+    "codexCloud": { "status": "pending", ... }
+  }
+}
+```
+
+These names tie the ledger to specific providers (Claude / Codex Cloud). After Phases A–C made runtimes, reviewers, and webhooks pluggable, the ledger fields are the last operator-visible surface still hard-named to those providers. An operator who configures Greptile as their external reviewer sees `codexCloud: { status: "pending" }` written to disk on every tick — confusing and misleading.
+
+Phase D-1 renames the two `reviews.*` keys to provider-neutral names (`internalReview`, `externalReview`) and migrates existing ledgers in-place on workspace setup. Source code adopts read-both / write-new semantics so unmigrated ledgers still work for one release. The action-type literal `run_claude_review` (transient, not persisted) renames to `run_internal_review` with the same back-compat reader.
+
+## Scope
+
+### In scope (this PR)
+1. **JSON ledger field renames**:
+   - `reviews.claudeCode` → `reviews.internalReview`
+   - `reviews.codexCloud` → `reviews.externalReview`
+2. **One-shot migration** in `workspace.py` on every workspace setup. Reads the persisted ledger; if old keys exist and new keys don't, rewrites the file with new keys. Idempotent. Logs a one-line message on first migration.
+3. **Read-both, write-new in source code**. Helper `_get_review(reviews_dict, key)` accepts the new key and falls back to the old key for one release. All write sites use the new key only.
+4. **Action-type literal** `run_claude_review` → `run_internal_review`. The action-type comes from `pick_workflow_action()` (transient, in-memory only, never persisted) — no migration needed. Just rename the literal in the dispatcher and provide a back-compat alias for one release in case any tests or fixtures use the old name.
+5. **Tests**: migration round-trip, read-both fallback, write-new behavior, action-type alias.
+6. **Operator docs**: `skills/operator/SKILL.md` notes the field rename + automatic migration.
+
+### Out of scope (Phase D-2 + later)
+- Other top-level ledger field renames: `claudeRepairHandoff`, `codexCloudRepairHandoff`, `codexCloudAutoResolved`, `claudeModel`, `interReviewAgentModel`, `lastClaudeVerdict`. (Migrated in D-2 with the same pattern.)
+- Function-name renames in `reviews.py`: `fetch_codex_cloud_review` → `fetch_external_review`, etc. (D-2; depends on Phase B merging.)
+- Internal parameter rename `run_acpx_prompt_fn` → `run_prompt_fn`. (D-2.)
+- Dropping Phase B's `render_codex_cloud_repair_handoff_prompt` alias and the deprecated top-level `codex-bot:` block fallback. (D-2; depends on Phase B merging.)
+- Dropping Phase A's `coder-dispatch.md` / `internal-review-strict.md` filename aliases. (Already done in Phase A — no-op for D.)
+
+## Architecture
+
+### Migration helper
+```python
+# workflows/code_review/migrations.py (new module)
+
+REVIEW_KEY_RENAMES: dict[str, str] = {
+    "claudeCode": "internalReview",
+    "codexCloud": "externalReview",
+}
+
+def migrate_review_keys(ledger: dict) -> tuple[dict, bool]:
+    """Rewrite legacy `reviews.<old>` keys to their new names.
+
+    Returns (migrated_ledger, was_changed). Idempotent — calling twice on
+    an already-migrated ledger returns (ledger, False).
+
+    Migration policy: if the new key already exists, the new key wins
+    (caller already migrated this slot at runtime). Old key is dropped.
+    """
+```
+
+The helper runs once during workspace setup, after the ledger is loaded but before any code reads it. If migration changes anything, the file is written back with `json.dumps(..., indent=2)` matching the existing on-disk format.
+
+### Read-both helper
+```python
+# workflows/code_review/migrations.py
+
+def get_review(reviews: dict, key: str) -> dict:
+    """Read a review by its new key, falling back to the legacy key.
+
+    Defense-in-depth: even after the one-shot migration, if a stale
+    process or external tool wrote an old key to the ledger, code paths
+    that use this helper will still find the data.
+    """
+    new_value = reviews.get(key)
+    if new_value is not None:
+        return new_value
+    legacy_key = _LEGACY_KEY_FOR.get(key)
+    if legacy_key:
+        return reviews.get(legacy_key) or {}
+    return {}
+
+_LEGACY_KEY_FOR = {v: k for k, v in REVIEW_KEY_RENAMES.items()}
+```
+
+### Source-code rename strategy
+
+**Read sites** (~25 references to `claudeCode` + ~20 to `codexCloud`): replace `reviews.get("claudeCode")` and `(reviews or {}).get("claudeCode")` with `get_review(reviews or {}, "internalReview")`. Same for `codexCloud` → `externalReview`. Pattern is mechanical, but volume requires care.
+
+**Write sites** (a handful in `actions.py` and `reviews.py`): replace the assignment target. E.g. `ledger['reviews']['claudeCode'] = ...` becomes `ledger['reviews']['internalReview'] = ...`.
+
+**Mixed code paths** that read AND write to the same dict in one tick: ensure the new key is written, the old key is removed (so a process that crashes mid-tick doesn't leave both keys alive).
+
+### Action-type literal rename
+
+Source: `actions.py:473`:
+```python
+if action_type == 'run_claude_review':
+    return run_inter_review_agent_review_action(...)
+```
+
+Becomes:
+```python
+if action_type in ('run_internal_review', 'run_claude_review'):  # back-compat alias
+    return run_inter_review_agent_review_action(...)
+```
+
+Producers (`pick_workflow_action()` in `workflow.py`) emit only `run_internal_review` after this PR. The alias drops in Phase D-2.
+
+### Migration write-back semantics
+
+The migration runs in `workspace.py` at workspace bootstrap. The ledger path is already known (`ledger_path` variable around line 583). Pseudocode:
+
+```python
+# In workspace.py, after ledger_path is determined but before any reads
+from workflows.code_review.migrations import migrate_persisted_ledger
+
+migrate_persisted_ledger(ledger_path)  # idempotent; logs once if it changed something
+```
+
+`migrate_persisted_ledger` opens the file, runs `migrate_review_keys`, and writes back atomically (temp file + rename) only if anything changed. If the file doesn't exist, it's a no-op.
+
+## Migration path for live `yoyopod` workspace
+
+Live ledger at `~/.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json` currently has:
+```json
+{
+  "reviews": {
+    "claudeCode": { ... },
+    "codexCloud": { ... },
+    "rockClaw": { ... }
+  }
+}
+```
+
+After this PR's first workspace setup:
+- File rewritten to:
+  ```json
+  {
+    "reviews": {
+      "internalReview": { ... },
+      "externalReview": { ... },
+      "rockClaw": { ... }    // unchanged — not in REVIEW_KEY_RENAMES
+    }
+  }
+  ```
+- Subsequent workspace setups: no-op (idempotent).
+- If any other process (cron, script) writes `claudeCode` after migration, the read-both helper still finds it. Next workspace setup re-runs migration and re-rewrites the file.
+
+## Tests
+
+New file `tests/test_rename_pass_phase_d_1.py`:
+
+**Migration helper:**
+- `test_migrate_review_keys_renames_legacy_keys` — `claudeCode` + `codexCloud` → new names; `was_changed=True`.
+- `test_migrate_review_keys_idempotent` — second call returns `was_changed=False`.
+- `test_migrate_review_keys_new_key_wins` — both old + new present ⇒ new wins, old dropped.
+- `test_migrate_review_keys_passes_through_unknown_keys` — `rockClaw` and other keys preserved.
+- `test_migrate_review_keys_handles_missing_reviews_block` — ledger without `reviews:` key returns unchanged.
+
+**Read-both helper:**
+- `test_get_review_returns_new_when_present`
+- `test_get_review_falls_back_to_legacy_when_only_legacy_present`
+- `test_get_review_prefers_new_when_both_present`
+- `test_get_review_returns_empty_dict_for_unknown_key`
+
+**Persisted-ledger migration:**
+- `test_migrate_persisted_ledger_rewrites_file_atomically` (uses tmp file)
+- `test_migrate_persisted_ledger_noop_on_already_migrated` (no file rewrite if already done)
+- `test_migrate_persisted_ledger_handles_missing_file` (silently)
+- `test_migrate_persisted_ledger_preserves_indent_2_format`
+
+**Action-type alias:**
+- `test_action_dispatcher_accepts_run_internal_review`
+- `test_action_dispatcher_accepts_run_claude_review_alias`
+
+**Live-yoyopod regression:**
+- `test_existing_yoyopod_ledger_migrates_cleanly` — copy the live ledger to tmp, run migration, assert all keys round-trip and the read-both helper still works on `rockClaw` and other untouched keys.
+
+Existing 477 tests stay green. Target: 477 + 14 new = 491 passing.
+
+## Risks
+
+1. **In-flight crash during migration** — if the engine crashes between reading the old ledger and writing the new one, atomic temp-file + rename ensures the file is either fully old or fully new, never half-renamed. Standard `os.replace()` semantics on POSIX.
+
+2. **Concurrent writers** — if cron jobs or other processes are writing the ledger while migration runs, the temp+rename pattern means migration can clobber a concurrent write. **Mitigation:** the live YoYoPod workspace is currently idle (`no-active-lane`). Run migration during a quiet window. **Documentation:** the operator notes that `daedalus migrate-state` (future CLI) is the safer manual path; automatic-on-bootstrap is the current default since the workspace is idle anyway.
+
+3. **Code paths that bypass `get_review` and read `claudeCode` directly** — these break only after migration runs. Risk: ~25 read sites; if any are missed, lane state appears empty after migration. **Mitigation:** the test suite exercises every read site through fixture data that uses ONLY the new keys. If any code path still hardcodes the old key, the corresponding test fails.
+
+## Open questions
+
+None — locked in:
+- Read-both / write-new for one release.
+- Migration runs automatically on workspace bootstrap (live workspace is idle so race risk is minimal).
+- Other field renames stay in Phase D-2.

--- a/runtime.py
+++ b/runtime.py
@@ -3286,6 +3286,7 @@ def compare_with_legacy_status(*, workflow_root: Path, legacy_status: dict[str, 
         ("publish_ready_pr", "publish_pr"),
         ("merge_and_promote", "merge_pr"),
         ("run_claude_review", "request_internal_review"),
+        ("run_internal_review", "request_internal_review"),  # Phase D-1 alias
         ("dispatch_codex_turn", "dispatch_implementation_turn"),
         ("noop", "noop"),
         ("noop", None),

--- a/skills/operator/SKILL.md
+++ b/skills/operator/SKILL.md
@@ -239,3 +239,17 @@ webhooks:
 ```
 
 (Extra fields beyond `at`/`action`/`summary` come from the action's audit context — they vary by action.)
+
+## Persisted-state migration (Phase D-1)
+
+The workflow ledger renames two `reviews.*` keys for provider neutrality:
+- `reviews.claudeCode` → `reviews.internalReview`
+- `reviews.codexCloud` → `reviews.externalReview`
+
+**Migration is automatic.** On workspace bootstrap, the engine rewrites the persisted ledger in place (atomic temp-file + rename). Idempotent: subsequent boots are no-ops.
+
+**Back-compat reads.** For one release, code paths use a `get_review(reviews, new_key)` helper that falls back to the legacy key if the migration hasn't run yet (e.g., a stale process wrote an old key after migration).
+
+**Action-type literal.** The transient action `run_claude_review` is renamed to `run_internal_review`. The dispatcher accepts both for one release.
+
+**What this means for you:** nothing — the rename is transparent. If you write external tooling that reads the ledger directly (e.g., a dashboard parsing `yoyopod-workflow-status.json`), update it to use `reviews.internalReview` / `reviews.externalReview`.

--- a/tests/test_rename_pass_phase_d_1.py
+++ b/tests/test_rename_pass_phase_d_1.py
@@ -161,3 +161,25 @@ def test_existing_yoyopod_ledger_migrates_cleanly(tmp_path):
     # New keys readable via get_review (passes whether or not the source had old keys)
     _ = get_review(reviews, "internalReview")
     _ = get_review(reviews, "externalReview")
+
+
+def test_action_dispatcher_accepts_run_internal_review():
+    """The dispatcher matches the new literal."""
+    # This test is structural — actions.py has a single dispatch site at line 473.
+    # We test by reading the source and asserting both literals are matched.
+    from pathlib import Path
+    src = Path(__file__).resolve().parent.parent / "workflows/code_review/actions.py"
+    text = src.read_text()
+    # Expected dispatcher form: action_type in ('run_internal_review', 'run_claude_review')
+    assert "run_internal_review" in text
+    assert "run_claude_review" in text  # back-compat alias retained
+
+
+def test_action_dispatcher_accepts_run_claude_review_alias():
+    """Same as above, framed from the alias side."""
+    from pathlib import Path
+    src = Path(__file__).resolve().parent.parent / "workflows/code_review/actions.py"
+    text = src.read_text()
+    # Both literals should appear in the same expression
+    assert "'run_internal_review'" in text or '"run_internal_review"' in text
+    assert "'run_claude_review'" in text or '"run_claude_review"' in text

--- a/tests/test_rename_pass_phase_d_1.py
+++ b/tests/test_rename_pass_phase_d_1.py
@@ -183,3 +183,27 @@ def test_action_dispatcher_accepts_run_claude_review_alias():
     # Both literals should appear in the same expression
     assert "'run_internal_review'" in text or '"run_internal_review"' in text
     assert "'run_claude_review'" in text or '"run_claude_review"' in text
+
+
+def test_parity_gate_accepts_run_internal_review():
+    """Phase D-1 alias regression: parity compatibility map must accept the new
+    relay action type, otherwise active mode blocks the lane with shadow-parity-mismatch.
+
+    derive_next_action populates legacy_status["nextAction"]["type"] with
+    "run_internal_review" after the rename. compare_with_legacy_status compares
+    (legacy_action.type, relay_action_type). The relay shadow path still emits
+    "request_internal_review" via derive_shadow_actions_for_lane, so the
+    compatibility map must include ("run_internal_review", "request_internal_review")
+    in addition to the legacy ("run_claude_review", "request_internal_review")."""
+    from pathlib import Path
+    repo_root = Path(__file__).resolve().parent.parent
+    runtime_src = (repo_root / "runtime.py").read_text()
+    tools_src = (repo_root / "tools.py").read_text()
+    # Both source files carry a parity compatibility map; both must alias.
+    for src in (runtime_src, tools_src):
+        assert "run_claude_review" in src
+        assert "run_internal_review" in src
+        assert (
+            '("run_internal_review", "request_internal_review")' in src
+            or '("run_internal_review","request_internal_review")' in src
+        )

--- a/tests/test_rename_pass_phase_d_1.py
+++ b/tests/test_rename_pass_phase_d_1.py
@@ -1,0 +1,163 @@
+"""Phase D-1 tests: persisted-state migration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_migrate_review_keys_renames_legacy_keys():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"claudeCode": {"v": 1}, "codexCloud": {"v": 2}}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is True
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert out["reviews"]["externalReview"] == {"v": 2}
+    assert "claudeCode" not in out["reviews"]
+    assert "codexCloud" not in out["reviews"]
+
+
+def test_migrate_review_keys_idempotent():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"internalReview": {"v": 1}, "externalReview": {"v": 2}}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is False
+    assert out["reviews"]["internalReview"] == {"v": 1}
+
+
+def test_migrate_review_keys_new_key_wins_when_both_present():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {
+        "claudeCode": {"v": "old"}, "internalReview": {"v": "new"},
+        "codexCloud": {"v": "old2"}, "externalReview": {"v": "new2"},
+    }}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is True  # old keys were dropped
+    assert out["reviews"]["internalReview"] == {"v": "new"}
+    assert out["reviews"]["externalReview"] == {"v": "new2"}
+    assert "claudeCode" not in out["reviews"]
+    assert "codexCloud" not in out["reviews"]
+
+
+def test_migrate_review_keys_passes_through_unknown_keys():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"reviews": {"claudeCode": {"v": 1}, "rockClaw": {"v": 9}}}
+    out, _ = migrate_review_keys(ledger)
+    assert out["reviews"]["rockClaw"] == {"v": 9}
+
+
+def test_migrate_review_keys_handles_missing_reviews_block():
+    from workflows.code_review.migrations import migrate_review_keys
+
+    ledger = {"activeLane": {"number": 42}}
+    out, changed = migrate_review_keys(ledger)
+    assert changed is False
+    assert out == ledger
+
+
+def test_get_review_returns_new_when_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"internalReview": {"v": 1}}
+    assert get_review(reviews, "internalReview") == {"v": 1}
+
+
+def test_get_review_falls_back_to_legacy_when_only_legacy_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"claudeCode": {"v": 1}}
+    assert get_review(reviews, "internalReview") == {"v": 1}
+
+    reviews = {"codexCloud": {"v": 2}}
+    assert get_review(reviews, "externalReview") == {"v": 2}
+
+
+def test_get_review_prefers_new_when_both_present():
+    from workflows.code_review.migrations import get_review
+
+    reviews = {"claudeCode": {"v": "old"}, "internalReview": {"v": "new"}}
+    assert get_review(reviews, "internalReview") == {"v": "new"}
+
+
+def test_get_review_returns_empty_dict_for_unknown_key():
+    from workflows.code_review.migrations import get_review
+
+    assert get_review({"x": 1}, "made-up") == {}
+
+
+def test_get_review_returns_empty_dict_when_value_is_none():
+    from workflows.code_review.migrations import get_review
+
+    assert get_review({"internalReview": None}, "internalReview") == {}
+
+
+def test_migrate_persisted_ledger_rewrites_file_atomically(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    p.write_text(json.dumps({"reviews": {"claudeCode": {"v": 1}}}, indent=2))
+    migrate_persisted_ledger(p)
+    out = json.loads(p.read_text())
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert "claudeCode" not in out["reviews"]
+
+
+def test_migrate_persisted_ledger_noop_on_already_migrated(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    initial = {"reviews": {"internalReview": {"v": 1}}}
+    p.write_text(json.dumps(initial, indent=2))
+    mtime_before = p.stat().st_mtime_ns
+    # Sleep just enough that any rewrite would change mtime
+    import time
+    time.sleep(0.01)
+    migrate_persisted_ledger(p)
+    mtime_after = p.stat().st_mtime_ns
+    assert mtime_before == mtime_after  # file untouched
+
+
+def test_migrate_persisted_ledger_handles_missing_file(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "does-not-exist.json"
+    # Should not raise
+    migrate_persisted_ledger(p)
+    assert not p.exists()
+
+
+def test_migrate_persisted_ledger_preserves_indent(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "ledger.json"
+    p.write_text(json.dumps({"reviews": {"claudeCode": {"v": 1}}}, indent=2))
+    migrate_persisted_ledger(p)
+    text = p.read_text()
+    assert "  " in text  # 2-space indent preserved
+
+
+def test_existing_yoyopod_ledger_migrates_cleanly(tmp_path):
+    """Smoke test: copy live yoyopod ledger to tmp, migrate, assert it works."""
+    from workflows.code_review.migrations import migrate_persisted_ledger, get_review
+    import os
+    src = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json"))
+    if not src.exists():
+        pytest.skip("yoyopod ledger not present on this host")
+
+    dst = tmp_path / "ledger.json"
+    dst.write_text(src.read_text())
+    migrate_persisted_ledger(dst)
+
+    out = json.loads(dst.read_text())
+    reviews = out.get("reviews") or {}
+    # Old keys gone (if they were present)
+    assert "claudeCode" not in reviews
+    assert "codexCloud" not in reviews
+    # New keys readable via get_review (passes whether or not the source had old keys)
+    _ = get_review(reviews, "internalReview")
+    _ = get_review(reviews, "externalReview")

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -508,8 +508,8 @@ def test_run_dispatch_inter_review_agent_review_records_completed_review_on_succ
     assert len(state["save_ledger_calls"]) == 2
     first_saved = state["save_ledger_calls"][0]
     second_saved = state["save_ledger_calls"][1]
-    assert first_saved["reviews"]["claudeCode"]["status"] == "running"
-    assert second_saved["reviews"]["claudeCode"]["status"] == "completed"
+    assert first_saved["reviews"]["internalReview"]["status"] == "running"
+    assert second_saved["reviews"]["internalReview"]["status"] == "completed"
     # Audit transitions called once per save
     assert len(state["audit_transitions"]) == 2
 
@@ -532,8 +532,8 @@ def test_run_dispatch_inter_review_agent_review_records_failed_review_and_rerais
 
     # After failure path we should still have 2 ledger saves (running + failed)
     assert len(state["save_ledger_calls"]) == 2
-    assert state["save_ledger_calls"][1]["reviews"]["claudeCode"]["status"] == "failed"
-    assert state["save_ledger_calls"][1]["reviews"]["claudeCode"]["failureClass"] == "max_turns_exhausted"
+    assert state["save_ledger_calls"][1]["reviews"]["internalReview"]["status"] == "failed"
+    assert state["save_ledger_calls"][1]["reviews"]["internalReview"]["failureClass"] == "max_turns_exhausted"
 
 
 def _tick_raw_deps():

--- a/tests/test_workflows_code_review_adapter_status.py
+++ b/tests/test_workflows_code_review_adapter_status.py
@@ -931,7 +931,7 @@ def test_apply_ledger_reviews_and_header_writes_expected_keys():
         codex_model="gpt-5.3-codex",
         inter_review_agent_model="claude-sonnet-4-6",
         actor_labels={"coder": "x"},
-        reviews={"rockClaw": {"a": 1}, "claudeCode": {"b": 2}, "codexCloud": {"c": 3}},
+        reviews={"rockClaw": {"a": 1}, "internalReview": {"b": 2}, "externalReview": {"c": 3}},
     )
     assert ledger["schemaVersion"] == 6
     assert ledger["reviewLoopState"] == "awaiting_reviews"
@@ -940,7 +940,7 @@ def test_apply_ledger_reviews_and_header_writes_expected_keys():
     assert ledger["codexModel"] == "gpt-5.3-codex"
     assert ledger["workflowActors"] == {"coder": "x"}
     assert ledger["approval"] == {}
-    assert ledger["reviews"] == {"rockClaw": {"a": 1}, "claudeCode": {"b": 2}, "codexCloud": {"c": 3}}
+    assert ledger["reviews"] == {"rockClaw": {"a": 1}, "internalReview": {"b": 2}, "externalReview": {"c": 3}}
 
 
 def test_apply_ledger_implementation_merge_preserves_prior_ledger_keys():

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -1211,10 +1211,10 @@ def test_build_reviews_block_routes_postpublish_defaults_when_pr_is_ready_for_re
         advisory_reviewer_agent_name="Advisory_Reviewer_Agent",
         now_iso="2026-04-23T00:00:00Z",
     )
-    assert reviews["claudeCode"]["required"] is False
-    assert reviews["codexCloud"]["required"] is True
-    assert reviews["codexCloud"]["reviewScope"] == "postpublish-pr"
-    assert reviews["codexCloud"]["agentName"] == "External_Reviewer_Agent"
+    assert reviews["internalReview"]["required"] is False
+    assert reviews["externalReview"]["required"] is True
+    assert reviews["externalReview"]["reviewScope"] == "postpublish-pr"
+    assert reviews["externalReview"]["agentName"] == "External_Reviewer_Agent"
     assert reviews["rockClaw"]["required"] is False
 
 
@@ -1242,10 +1242,10 @@ def test_build_reviews_block_seeds_local_prepublish_for_draft_pr_state():
         now_iso="2026-04-23T00:00:00Z",
         claude_seed_fn=fake_seed,
     )
-    assert reviews["claudeCode"]["required"] is True
-    assert reviews["claudeCode"]["reviewScope"] == "local-prepublish"
-    assert reviews["codexCloud"]["required"] is False
-    assert reviews["codexCloud"]["agentName"] == "External_Reviewer_Agent"
+    assert reviews["internalReview"]["required"] is True
+    assert reviews["internalReview"]["reviewScope"] == "local-prepublish"
+    assert reviews["externalReview"]["required"] is False
+    assert reviews["externalReview"]["agentName"] == "External_Reviewer_Agent"
 
 
 def test_audit_inter_review_agent_transition_is_noop_when_nothing_changed():

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -614,7 +614,7 @@ def test_synthesize_repair_brief_collects_required_codex_threads_and_local_findi
 
     result = reviews_module.synthesize_repair_brief(
         {
-            "codexCloud": {
+            "externalReview": {
                 "required": True,
                 "threads": [
                     {"id": "t1", "status": "open", "isOutdated": False, "severity": "major", "summary": "Fix API edge", "path": "api.py", "line": 88, "url": "https://example.com/t1"},
@@ -635,9 +635,36 @@ def test_synthesize_repair_brief_collects_required_codex_threads_and_local_findi
 
     assert result["forHeadSha"] == "head-123"
     assert result["openedAt"] == "2026-04-23T00:20:00Z"
-    assert result["rerunRequiredReviewers"] == ["codexCloud", "claudeCode"]
-    assert [item["id"] for item in result["mustFix"]] == ["codexCloud:t1", "claudeCode:blocking:1", "claudeCode:major:1"]
+    assert result["rerunRequiredReviewers"] == ["externalReview", "claudeCode"]
+    assert [item["id"] for item in result["mustFix"]] == ["externalReview:t1", "claudeCode:blocking:1", "claudeCode:major:1"]
     assert [item["summary"] for item in result["shouldFix"]] == ["Rename helper"]
+
+
+def test_synthesize_repair_brief_accepts_legacy_codex_cloud_key():
+    reviews_module = load_module("daedalus_workflows_code_review_reviews_test", "workflows/code_review/reviews.py")
+
+    result = reviews_module.synthesize_repair_brief(
+        {
+            "codexCloud": {
+                "required": True,
+                "threads": [
+                    {"id": "t1", "status": "open", "isOutdated": False, "severity": "major", "summary": "Fix API edge", "path": "api.py", "line": 88, "url": "https://example.com/t1"},
+                    {"id": "t2", "status": "resolved", "isOutdated": False, "severity": "critical", "summary": "Already closed"},
+                ],
+            },
+        },
+        head_sha="head-legacy",
+        now_iso="2026-04-23T00:20:00Z",
+    )
+
+    assert result is not None
+    assert result["forHeadSha"] == "head-legacy"
+    assert result["rerunRequiredReviewers"] == ["codexCloud"]
+    # Legacy key still routes through the externalReview branch — IDs use the
+    # canonical source label so downstream consumers see one shape.
+    assert [item["id"] for item in result["mustFix"]] == ["externalReview:t1"]
+    assert result["mustFix"][0]["source"] == "externalReview"
+    assert result["shouldFix"] == []
 
 
 def test_codex_review_mutation_helpers_cover_pr_ready_thread_resolution_and_superseded_cleanup():

--- a/tools.py
+++ b/tools.py
@@ -83,6 +83,7 @@ def _compatibility_pairs() -> set[tuple[str | None, str | None]]:
         ("publish_ready_pr", "publish_pr"),
         ("merge_and_promote", "merge_pr"),
         ("run_claude_review", "request_internal_review"),
+        ("run_internal_review", "request_internal_review"),  # Phase D-1 alias
         ("dispatch_codex_turn", "dispatch_implementation_turn"),
         ("dispatch_codex_turn", "dispatch_repair_handoff"),
         ("push_pr_update", "push_pr_update"),

--- a/workflows/code_review/actions.py
+++ b/workflows/code_review/actions.py
@@ -474,7 +474,7 @@ def run_tick_raw(
     action = before.get('nextAction') or {'type': 'noop', 'reason': 'no-forward-action-needed'}
     executed: dict[str, Any] | None = None
     action_type = action.get('type')
-    if action_type == 'run_claude_review':
+    if action_type in ('run_internal_review', 'run_claude_review'):
         executed = dispatch_inter_review_agent_review_fn()
     elif action_type == 'dispatch_codex_turn':
         executed = dispatch_implementation_turn_fn()

--- a/workflows/code_review/actions.py
+++ b/workflows/code_review/actions.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
+from workflows.code_review.migrations import get_review
 from workflows.code_review.paths import lane_memo_path, lane_state_path
 from workflows.code_review.sessions import (
     expected_lane_branch,
@@ -365,8 +366,8 @@ def run_dispatch_inter_review_agent_review(
     run_id = new_inter_review_agent_run_id_fn()
     ledger = load_ledger_fn()
     ledger.setdefault('reviews', {})
-    previous = (ledger['reviews'].get('claudeCode') or {}).copy()
-    ledger['reviews']['claudeCode'] = build_inter_review_agent_running_review(
+    previous = get_review(ledger['reviews'], 'internalReview').copy()
+    ledger['reviews']['internalReview'] = build_inter_review_agent_running_review(
         previous,
         run_id=run_id,
         head_sha=head_sha,
@@ -376,11 +377,12 @@ def run_dispatch_inter_review_agent_review(
         agent_name=internal_reviewer_agent_name,
         agent_role=agent_role,
     )
+    ledger['reviews'].pop('claudeCode', None)
     ledger['claudeModel'] = inter_review_agent_model
     ledger['interReviewAgentModel'] = inter_review_agent_model
     ledger['workflowActors'] = actor_labels_payload_fn(impl.get('codexModel'))
     save_ledger_fn(ledger)
-    audit_inter_review_agent_transition_fn(previous, ledger['reviews']['claudeCode'])
+    audit_inter_review_agent_transition_fn(previous, ledger['reviews']['internalReview'])
     memo_path = Path(impl['laneMemoPath']) if impl.get('laneMemoPath') else lane_memo_path(worktree)
     state_path = Path(impl['laneStatePath']) if impl.get('laneStatePath') else lane_state_path(worktree)
     try:
@@ -397,8 +399,8 @@ def run_dispatch_inter_review_agent_review(
         failed_at = now_iso_fn()
         ledger = load_ledger_fn()
         ledger.setdefault('reviews', {})
-        previous = (ledger['reviews'].get('claudeCode') or {}).copy()
-        ledger['reviews']['claudeCode'] = build_inter_review_agent_failed_review(
+        previous = get_review(ledger['reviews'], 'internalReview').copy()
+        ledger['reviews']['internalReview'] = build_inter_review_agent_failed_review(
             previous,
             run_id=run_id,
             head_sha=head_sha,
@@ -411,11 +413,12 @@ def run_dispatch_inter_review_agent_review(
             agent_name=internal_reviewer_agent_name,
             agent_role=agent_role,
         )
+        ledger['reviews'].pop('claudeCode', None)
         ledger['claudeModel'] = inter_review_agent_model
         ledger['interReviewAgentModel'] = inter_review_agent_model
         ledger['workflowActors'] = actor_labels_payload_fn(impl.get('codexModel'))
         save_ledger_fn(ledger)
-        audit_inter_review_agent_transition_fn(previous, ledger['reviews']['claudeCode'])
+        audit_inter_review_agent_transition_fn(previous, ledger['reviews']['internalReview'])
         raise
     completed_at = now_iso_fn()
     final_review = build_inter_review_agent_completed_review(
@@ -431,8 +434,9 @@ def run_dispatch_inter_review_agent_review(
     )
     ledger = load_ledger_fn()
     ledger.setdefault('reviews', {})
-    previous = (ledger['reviews'].get('claudeCode') or {}).copy()
-    ledger['reviews']['claudeCode'] = final_review
+    previous = get_review(ledger['reviews'], 'internalReview').copy()
+    ledger['reviews']['internalReview'] = final_review
+    ledger['reviews'].pop('claudeCode', None)
     ledger['claudeModel'] = inter_review_agent_model
     ledger['interReviewAgentModel'] = inter_review_agent_model
     ledger['workflowActors'] = actor_labels_payload_fn(impl.get('codexModel'))

--- a/workflows/code_review/migrations.py
+++ b/workflows/code_review/migrations.py
@@ -1,0 +1,100 @@
+"""Persisted-state migrations for the code-review workflow.
+
+Phase D-1 rationale:
+  reviews.claudeCode -> reviews.internalReview
+  reviews.codexCloud -> reviews.externalReview
+
+The old names tied the ledger to specific providers (Claude / Codex
+Cloud). Phases A-C made runtimes/reviewers/webhooks pluggable; this
+migration removes the last operator-visible coupling to provider names.
+
+`migrate_persisted_ledger(path)` runs idempotently on workspace setup.
+`get_review(reviews_dict, new_key)` reads new key with legacy fallback
+so an unmigrated ledger still works for one release.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REVIEW_KEY_RENAMES: dict[str, str] = {
+    "claudeCode": "internalReview",
+    "codexCloud": "externalReview",
+}
+
+_LEGACY_KEY_FOR: dict[str, str] = {v: k for k, v in REVIEW_KEY_RENAMES.items()}
+
+
+def migrate_review_keys(ledger: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Rewrite legacy `reviews.<old>` keys to their new names.
+
+    If both old and new keys are present, the new value wins and the
+    old key is dropped. Returns ``(ledger, was_changed)``. The ``ledger``
+    object is mutated in place AND returned for convenience.
+    """
+    reviews = ledger.get("reviews")
+    if not isinstance(reviews, dict):
+        return ledger, False
+
+    changed = False
+    for old_key, new_key in REVIEW_KEY_RENAMES.items():
+        if old_key in reviews:
+            if new_key not in reviews:
+                reviews[new_key] = reviews[old_key]
+            del reviews[old_key]
+            changed = True
+    return ledger, changed
+
+
+def get_review(reviews: dict[str, Any] | None, new_key: str) -> dict[str, Any]:
+    """Read a review by its new key; fall back to the legacy key."""
+    reviews = reviews or {}
+    value = reviews.get(new_key)
+    if value:
+        return value
+    legacy_key = _LEGACY_KEY_FOR.get(new_key)
+    if legacy_key:
+        legacy_value = reviews.get(legacy_key)
+        if legacy_value:
+            return legacy_value
+    return {}
+
+
+def migrate_persisted_ledger(path: Path | str) -> bool:
+    """Migrate the on-disk ledger at ``path``, atomically.
+
+    Returns True if the file was rewritten, False otherwise. Missing
+    files are silently no-op'd. Indent-2 JSON format is preserved.
+    """
+    p = Path(path)
+    if not p.exists():
+        return False
+    try:
+        ledger = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    _, changed = migrate_review_keys(ledger)
+    if not changed:
+        return False
+
+    # Atomic temp-file + rename in the same directory.
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=p.name, suffix=".tmp", dir=str(p.parent)
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(ledger, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, p)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+    return True

--- a/workflows/code_review/orchestrator.py
+++ b/workflows/code_review/orchestrator.py
@@ -4,6 +4,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from workflows.code_review.migrations import get_review
+
 
 """YoYoPod Core workflow orchestration (read-model + reconcile).
 
@@ -145,7 +147,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
     ledger_idle = ledger.get("workflowIdle")
 
     local_candidate_exists = ws._has_local_candidate(local_head_sha, worktree_commits_ahead)
-    existing_claude_review = existing_reviews.get("claudeCode")
+    existing_claude_review = get_review(existing_reviews, "internalReview")
     single_pass_claude_gate_satisfied = ws._single_pass_local_claude_gate_satisfied(existing_claude_review, local_head_sha, lane_state)
     effective_workflow_state = ledger_state
     effective_review_state = ledger.get("reviewState")
@@ -182,7 +184,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         open_pr=open_pr,
         workflow_state=effective_workflow_state,
         pr_ledger=ledger.get("pr") or {},
-        inter_review_agent_review=reviews["claudeCode"],
+        inter_review_agent_review=get_review(reviews, "internalReview"),
         inter_review_agent_job=ws._summarize_job(job_map.get(ws.WORKFLOW_WATCHDOG_JOB_NAME)),
         local_head_sha=local_head_sha,
         implementation_commits_ahead=worktree_commits_ahead,
@@ -190,7 +192,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
     )
     if (
         ws.INTER_REVIEW_AGENT_FREEZE_CODER_WHILE_RUNNING
-        and ws._inter_review_agent_is_running_on_head(reviews.get("claudeCode"), local_head_sha)
+        and ws._inter_review_agent_is_running_on_head(get_review(reviews, "internalReview"), local_head_sha)
     ):
         session_action_recommendation = {
             "action": "no-action",
@@ -337,7 +339,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
     status = ws.build_status()
     ledger = ws.load_ledger()
     previous_workflow_state = ledger.get("workflowState") or "unknown"
-    previous_claude_review = ((ledger.get("reviews") or {}).get("claudeCode") or {}).copy()
+    previous_claude_review = get_review(ledger.get("reviews"), "internalReview").copy()
     jobs_payload = ws.load_jobs()
     changed = {"ledger": False, "jobs": False}
 
@@ -361,8 +363,8 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
     if (
         open_pr
         and open_pr.get("isDraft")
-        and ws._current_inter_review_agent_matches_local_head(reviews.get("claudeCode"), impl.get("localHeadSha"))
-        and (reviews.get("claudeCode") or {}).get("verdict") == "PASS_CLEAN"
+        and ws._current_inter_review_agent_matches_local_head(get_review(reviews, "internalReview"), impl.get("localHeadSha"))
+        and get_review(reviews, "internalReview").get("verdict") == "PASS_CLEAN"
         and ws._mark_pr_ready_for_review(open_pr.get("number"))
     ):
         ws.audit("reconcile", "Marked draft PR ready for review after clean pre-publish Claude gate", prNumber=open_pr.get("number"), headSha=impl.get("localHeadSha"))
@@ -403,7 +405,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         actor_labels=ws._actor_labels_payload(codex_model),
         reviews=reviews,
     )
-    ws._audit_inter_review_agent_transition(previous_claude_review, reviews["claudeCode"])
+    ws._audit_inter_review_agent_transition(previous_claude_review, get_review(reviews, "internalReview"))
     adapter_status.apply_ledger_implementation_merge(
         ledger,
         active_lane=active_lane,

--- a/workflows/code_review/orchestrator.py
+++ b/workflows/code_review/orchestrator.py
@@ -81,7 +81,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         codex_cloud = ws._fetch_codex_cloud_review(
             open_pr.get("number") if open_pr else None,
             open_pr.get("headRefOid") if open_pr else None,
-            existing_reviews.get("codexCloud"),
+            get_review(existing_reviews, "externalReview"),
         )
     elif open_pr and open_pr.get("isDraft"):
         codex_cloud = ws._codex_cloud_placeholder(
@@ -481,7 +481,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
             )
 
     resolved_codex_threads = ws._resolve_codex_superseded_threads(
-        reviews.get("codexCloud") or {},
+        get_review(reviews, "externalReview"),
         current_head_sha=(open_pr or {}).get("headRefOid"),
     )
     if resolved_codex_threads:
@@ -489,7 +489,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
             "at": now_iso,
             "headSha": (open_pr or {}).get("headRefOid"),
             "prNumber": (open_pr or {}).get("number"),
-            "signal": ((reviews.get("codexCloud") or {}).get("prBodySignal") or {}).get("content"),
+            "signal": (get_review(reviews, "externalReview").get("prBodySignal") or {}).get("content"),
             "threadIds": resolved_codex_threads,
         }
         ledger["codexCloudAutoResolved"] = resolution_event
@@ -500,7 +500,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
             activeLane=(active_lane or {}).get("number"),
             prNumber=(open_pr or {}).get("number"),
             headSha=(open_pr or {}).get("headRefOid"),
-            signal=((reviews.get("codexCloud") or {}).get("prBodySignal") or {}).get("content"),
+            signal=(get_review(reviews, "externalReview").get("prBodySignal") or {}).get("content"),
         )
         status = ws.build_status()
         reviews = status.get("reviews") or reviews

--- a/workflows/code_review/orchestrator.py
+++ b/workflows/code_review/orchestrator.py
@@ -508,7 +508,8 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         merge_blockers = status.get("derivedMergeBlockers") or merge_blockers
         merge_blocked = bool(status.get("derivedMergeBlocked"))
         ledger["reviewLoopState"] = review_loop_state
-        ledger["reviews"]["codexCloud"] = reviews["codexCloud"]
+        ledger["reviews"]["externalReview"] = get_review(reviews, "externalReview")
+        ledger["reviews"].pop("codexCloud", None)
         ledger["codexCloudAutoResolved"] = resolution_event
         if ledger.get("pr"):
             ledger["pr"]["mergeBlocked"] = merge_blocked

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -7,6 +7,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from workflows.code_review.migrations import get_review
+
 
 """YoYoPod Core review-policy helpers.
 
@@ -204,7 +206,7 @@ def classify_lane_failure(
     }
     if reason in session_failure_map:
         return {"failureClass": session_failure_map[reason], "detail": reason}
-    claude_review = reviews.get("claudeCode") or {}
+    claude_review = get_review(reviews, "internalReview")
     if claude_review.get("status") in {"failed", "timed_out"}:
         detail = claude_review.get("failureClass") or claude_review.get("status")
         return {"failureClass": f"claude_review_{claude_review.get('status')}", "detail": detail}
@@ -1348,7 +1350,7 @@ def maybe_dispatch_repair_handoff(
     claude_decision = should_dispatch_claude_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
-        claude_review=reviews.get("claudeCode"),
+        claude_review=get_review(reviews, "internalReview"),
         repair_brief=repair_brief,
         workflow_state=workflow_state,
         current_head_sha=impl.get("localHeadSha"),
@@ -1358,7 +1360,7 @@ def maybe_dispatch_repair_handoff(
         repair_payload = build_claude_repair_handoff_payload(
             session_action=session_action,
             issue=issue,
-            claude_review=reviews.get("claudeCode"),
+            claude_review=get_review(reviews, "internalReview"),
             repair_brief=repair_brief,
             lane_memo_path=lane_memo_path_str,
             lane_state_path=lane_state_path_str,
@@ -1366,7 +1368,7 @@ def maybe_dispatch_repair_handoff(
         )
         repair_prompt = render_claude_repair_handoff_prompt(
             issue=issue,
-            claude_review=reviews.get("claudeCode"),
+            claude_review=get_review(reviews, "internalReview"),
             repair_brief=repair_brief,
             lane_memo_path=lane_memo_path_obj,
             lane_state_path=lane_state_path_obj,
@@ -1494,7 +1496,7 @@ def build_reviews_block(
     using adapter-owned review normalizers. ``claude_seed_fn`` is optional; if
     not provided, a minimal pre-publish seed with the given model is used.
     """
-    existing_claude_review = existing_reviews.get("claudeCode")
+    existing_claude_review = get_review(existing_reviews, "internalReview")
     if publish_ready:
         return {
             "rockClaw": normalize_review(

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -1506,14 +1506,14 @@ def build_reviews_block(
                 agent_name=advisory_reviewer_agent_name,
                 agent_role="advisory_reviewer_agent",
             ),
-            "claudeCode": normalize_review(
+            "internalReview": normalize_review(
                 {**(existing_claude_review or {}), "model": (existing_claude_review or {}).get("model") or inter_review_agent_model},
                 required=False,
                 pending_summary="Claude pre-publish gate already completed before publication.",
                 agent_name=internal_reviewer_agent_name,
                 agent_role="internal_reviewer_agent",
             ),
-            "codexCloud": {
+            "externalReview": {
                 **codex_cloud,
                 "required": True,
                 "reviewScope": "postpublish-pr",
@@ -1533,14 +1533,14 @@ def build_reviews_block(
             agent_name=advisory_reviewer_agent_name,
             agent_role="advisory_reviewer_agent",
         ),
-        "claudeCode": normalize_review(
+        "internalReview": normalize_review(
             claude_seed,
             required=local_candidate_exists,
             pending_summary="Pending local unpublished branch review before publication.",
             agent_name=internal_reviewer_agent_name,
             agent_role="internal_reviewer_agent",
         ),
-        "codexCloud": {
+        "externalReview": {
             **codex_cloud,
             "agentName": codex_cloud.get("agentName") or external_reviewer_agent_name,
             "agentRole": codex_cloud.get("agentRole") or "external_reviewer_agent",

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -597,13 +597,13 @@ def synthesize_repair_brief(
     for source, review in (reviews or {}).items():
         if not review.get("required"):
             continue
-        if source == "codexCloud":
+        if source in ("externalReview", "codexCloud"):
             for thread in review.get("threads", []):
                 if thread.get("status") != "open" or thread.get("isOutdated"):
                     continue
                 item = {
-                    "id": f"codexCloud:{thread['id']}",
-                    "source": "codexCloud",
+                    "id": f"externalReview:{thread['id']}",
+                    "source": "externalReview",
                     "severity": thread["severity"],
                     "summary": thread["summary"],
                     "path": thread.get("path"),

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -185,7 +185,7 @@ def classify_lane_failure(
     implementation = implementation or {}
     reviews = reviews or {}
     preflight = preflight or {}
-    codex_review = reviews.get("codexCloud") or {}
+    codex_review = get_review(reviews, "externalReview")
     if (
         codex_review.get("reviewScope") == "postpublish-pr"
         and codex_review.get("status") == "completed"
@@ -1410,7 +1410,7 @@ def maybe_dispatch_repair_handoff(
     codex_cloud_decision = should_dispatch_codex_cloud_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
-        codex_review=reviews.get("codexCloud"),
+        codex_review=get_review(reviews, "externalReview"),
         repair_brief=repair_brief,
         workflow_state=workflow_state,
         current_head_sha=open_pr.get("headRefOid") or impl.get("localHeadSha"),
@@ -1420,7 +1420,7 @@ def maybe_dispatch_repair_handoff(
         repair_payload = build_codex_cloud_repair_handoff_payload(
             session_action=session_action,
             issue=issue,
-            codex_review=reviews.get("codexCloud"),
+            codex_review=get_review(reviews, "externalReview"),
             repair_brief=repair_brief,
             lane_memo_path=lane_memo_path_str,
             lane_state_path=lane_state_path_str,
@@ -1428,7 +1428,7 @@ def maybe_dispatch_repair_handoff(
         )
         repair_prompt = render_codex_cloud_repair_handoff_prompt(
             issue=issue,
-            codex_review=reviews.get("codexCloud"),
+            codex_review=get_review(reviews, "externalReview"),
             repair_brief=repair_brief,
             lane_memo_path=lane_memo_path_obj,
             lane_state_path=lane_state_path_obj,

--- a/workflows/code_review/sessions.py
+++ b/workflows/code_review/sessions.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from workflows.code_review.migrations import get_review
+
 
 """YoYoPod Core session and worktree helpers.
 
@@ -126,7 +128,7 @@ def should_escalate_codex_model(
     restart_state = lane_state.get("restart") or {}
     restart_count = int(restart_state.get("count") or 0)
     local_review_count = int(review_state.get("localClaudeReviewCount") or 0)
-    codex_review = (reviews or {}).get("codexCloud") or {}
+    codex_review = get_review(reviews, "externalReview")
     codex_open_findings = int(codex_review.get("openFindingCount") or 0)
     if restart_count >= escalate_restart_count:
         return True

--- a/workflows/code_review/status.py
+++ b/workflows/code_review/status.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from workflows.code_review.health import compute_health, compute_stale_lane_reasons
+from workflows.code_review.migrations import get_review
 from workflows.code_review.paths import (
     lane_memo_path,
     lane_state_path,
@@ -437,7 +438,7 @@ def assemble_status_payload(
             "sessionNudge": ledger.get("sessionNudge"),
             "repairBrief": effective_repair_brief,
             "codexModel": implementation.get("codexModel") or preferred_codex_model or (ledger.get("implementation") or {}).get("codexModel"),
-            "claudeModel": ledger.get("claudeModel") or ledger.get("interReviewAgentModel") or ((reviews.get("claudeCode") or {}).get("model")) or inter_review_agent_model,
+            "claudeModel": ledger.get("claudeModel") or ledger.get("interReviewAgentModel") or (get_review(reviews, "internalReview").get("model")) or inter_review_agent_model,
             "interReviewAgentModel": ledger.get("interReviewAgentModel") or ledger.get("claudeModel") or ((reviews.get("claudeCode") or {}).get("model")) or inter_review_agent_model,
             "workflowActors": ledger.get("workflowActors") or actor_labels,
         },

--- a/workflows/code_review/status.py
+++ b/workflows/code_review/status.py
@@ -239,7 +239,7 @@ def normalize_status(status: dict[str, Any], workflow_root: Path | None = None) 
     open_pr = normalized.get("openPr")
     ledger = normalized.get("ledger") or {}
     reviews = normalized.get("reviews") or {}
-    codex_cloud = reviews.get("codexCloud") or {}
+    codex_cloud = get_review(reviews, "externalReview")
 
     implementation["sessionActionRecommendation"] = decide_session_action(
         active_session_health=implementation.get("activeSessionHealth"),
@@ -513,7 +513,7 @@ def derive_latest_progress(
         "kind": (impl.get("status") or ledger.get("workflowState") or "unknown"),
         "at": impl.get("updatedAt") or now_iso,
     }
-    codex_review = reviews.get("codexCloud") or {}
+    codex_review = get_review(reviews, "externalReview")
     codex_updated_at = codex_review.get("updatedAt")
     if (
         open_pr
@@ -937,7 +937,7 @@ def write_lane_state(
             "currentInterReviewAgentStatus": ((reviews.get("claudeCode") or {}).get("status")),
             "currentInterReviewAgentTerminalState": ((reviews.get("claudeCode") or {}).get("terminalState")),
             "lastInterReviewAgentFailureClass": ((reviews.get("claudeCode") or {}).get("failureClass")),
-            "lastCodexCloudReviewedHeadSha": ((reviews.get("codexCloud") or {}).get("reviewedHeadSha")),
+            "lastCodexCloudReviewedHeadSha": (get_review(reviews, "externalReview").get("reviewedHeadSha")),
         },
         "failure": {
             "lastClass": failure_class,

--- a/workflows/code_review/status.py
+++ b/workflows/code_review/status.py
@@ -439,7 +439,7 @@ def assemble_status_payload(
             "repairBrief": effective_repair_brief,
             "codexModel": implementation.get("codexModel") or preferred_codex_model or (ledger.get("implementation") or {}).get("codexModel"),
             "claudeModel": ledger.get("claudeModel") or ledger.get("interReviewAgentModel") or (get_review(reviews, "internalReview").get("model")) or inter_review_agent_model,
-            "interReviewAgentModel": ledger.get("interReviewAgentModel") or ledger.get("claudeModel") or ((reviews.get("claudeCode") or {}).get("model")) or inter_review_agent_model,
+            "interReviewAgentModel": ledger.get("interReviewAgentModel") or ledger.get("claudeModel") or (get_review(reviews, "internalReview").get("model")) or inter_review_agent_model,
             "workflowActors": ledger.get("workflowActors") or actor_labels,
         },
         "implementation": {
@@ -466,7 +466,7 @@ def assemble_status_payload(
         },
         "reviews": {
             **reviews,
-            "interReviewAgent": reviews.get("claudeCode"),
+            "interReviewAgent": get_review(reviews, "internalReview") or None,
         },
         "derivedReviewLoopState": review_loop_state,
         "derivedMergeBlocked": merge_blocked,
@@ -550,8 +550,10 @@ def apply_ledger_reviews_and_header(
     ledger.setdefault("approval", {})
     ledger.setdefault("reviews", {})
     ledger["reviews"]["rockClaw"] = reviews["rockClaw"]
-    ledger["reviews"]["claudeCode"] = reviews["claudeCode"]
-    ledger["reviews"]["codexCloud"] = reviews["codexCloud"]
+    ledger["reviews"]["internalReview"] = reviews["internalReview"]
+    ledger["reviews"]["externalReview"] = reviews["externalReview"]
+    ledger["reviews"].pop("claudeCode", None)
+    ledger["reviews"].pop("codexCloud", None)
 
 
 def apply_ledger_implementation_merge(
@@ -639,7 +641,7 @@ def apply_active_lane_ledger_transition(
         "merged": False,
         "isDraft": (open_pr or {}).get("isDraft"),
     }
-    claude_review = reviews.get("claudeCode") or {}
+    claude_review = get_review(reviews, "internalReview")
     local_head_sha = implementation.get("localHeadSha")
     prepublish_gate_ready = (
         claude_review.get("verdict") == "PASS_CLEAN"
@@ -921,22 +923,22 @@ def write_lane_state(
         },
         "review": {
             "repairBriefHeadSha": (repair_brief or {}).get("forHeadSha"),
-            "lastClaudeReviewedHeadSha": ((reviews.get("claudeCode") or {}).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastClaudeReviewedHeadSha")),
-            "lastClaudeVerdict": ((reviews.get("claudeCode") or {}).get("verdict")) or ((existing.get("review") or {}).get("lastClaudeVerdict")),
-            "localClaudeReviewCount": local_inter_review_agent_review_count(reviews.get("claudeCode"), existing),
-            "currentClaudeRunId": ((reviews.get("claudeCode") or {}).get("runId")),
-            "currentClaudeTargetHeadSha": inter_review_agent_target_head(reviews.get("claudeCode")),
-            "currentClaudeStatus": ((reviews.get("claudeCode") or {}).get("status")),
-            "currentClaudeTerminalState": ((reviews.get("claudeCode") or {}).get("terminalState")),
-            "lastClaudeFailureClass": ((reviews.get("claudeCode") or {}).get("failureClass")),
-            "lastInterReviewAgentReviewedHeadSha": ((reviews.get("claudeCode") or {}).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastInterReviewAgentReviewedHeadSha")),
-            "lastInterReviewAgentVerdict": ((reviews.get("claudeCode") or {}).get("verdict")) or ((existing.get("review") or {}).get("lastInterReviewAgentVerdict")),
-            "localInterReviewAgentReviewCount": local_inter_review_agent_review_count(reviews.get("claudeCode"), existing),
-            "currentInterReviewAgentRunId": ((reviews.get("claudeCode") or {}).get("runId")),
-            "currentInterReviewAgentTargetHeadSha": inter_review_agent_target_head(reviews.get("claudeCode")),
-            "currentInterReviewAgentStatus": ((reviews.get("claudeCode") or {}).get("status")),
-            "currentInterReviewAgentTerminalState": ((reviews.get("claudeCode") or {}).get("terminalState")),
-            "lastInterReviewAgentFailureClass": ((reviews.get("claudeCode") or {}).get("failureClass")),
+            "lastClaudeReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastClaudeReviewedHeadSha")),
+            "lastClaudeVerdict": ((get_review(reviews, "internalReview")).get("verdict")) or ((existing.get("review") or {}).get("lastClaudeVerdict")),
+            "localClaudeReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
+            "currentClaudeRunId": ((get_review(reviews, "internalReview")).get("runId")),
+            "currentClaudeTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
+            "currentClaudeStatus": ((get_review(reviews, "internalReview")).get("status")),
+            "currentClaudeTerminalState": ((get_review(reviews, "internalReview")).get("terminalState")),
+            "lastClaudeFailureClass": ((get_review(reviews, "internalReview")).get("failureClass")),
+            "lastInterReviewAgentReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastInterReviewAgentReviewedHeadSha")),
+            "lastInterReviewAgentVerdict": ((get_review(reviews, "internalReview")).get("verdict")) or ((existing.get("review") or {}).get("lastInterReviewAgentVerdict")),
+            "localInterReviewAgentReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
+            "currentInterReviewAgentRunId": ((get_review(reviews, "internalReview")).get("runId")),
+            "currentInterReviewAgentTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
+            "currentInterReviewAgentStatus": ((get_review(reviews, "internalReview")).get("status")),
+            "currentInterReviewAgentTerminalState": ((get_review(reviews, "internalReview")).get("terminalState")),
+            "lastInterReviewAgentFailureClass": ((get_review(reviews, "internalReview")).get("failureClass")),
             "lastCodexCloudReviewedHeadSha": (get_review(reviews, "externalReview").get("reviewedHeadSha")),
         },
         "failure": {

--- a/workflows/code_review/workflow.py
+++ b/workflows/code_review/workflow.py
@@ -101,7 +101,7 @@ def derive_next_action(
             and workflow_state in {"implementing_local", "awaiting_claude_prepublish", "claude_prepublish_findings", "implementing"}
         ):
             return {
-                "type": "run_claude_review",
+                "type": "run_internal_review",
                 "reason": "prepublish-claude-required",
                 "headSha": claude_preflight.get("currentHeadSha"),
                 "issueNumber": active_lane.get("number"),
@@ -165,7 +165,7 @@ def derive_next_action(
 
     if claude_preflight.get("shouldRun"):
         return {
-            "type": "run_claude_review",
+            "type": "run_internal_review",
             "reason": "prepublish-claude-required",
             "headSha": claude_preflight.get("currentHeadSha"),
             "issueNumber": active_lane.get("number"),

--- a/workflows/code_review/workflow.py
+++ b/workflows/code_review/workflow.py
@@ -57,7 +57,7 @@ def derive_next_action(
     budget_state = lane_state.get("budget") or {}
     repair_brief = status.get("repairBrief") or {}
     reviews = status.get("reviews") or {}
-    codex_review = reviews.get("codexCloud") or {}
+    codex_review = get_review(reviews, "externalReview")
     current_postpublish_head = pr_head_sha or local_head_sha
 
     claude_review = get_review(reviews, "internalReview")

--- a/workflows/code_review/workflow.py
+++ b/workflows/code_review/workflow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from workflows.code_review.migrations import get_review
 from workflows.code_review.reviews import (
     has_local_candidate,
     inter_review_agent_is_running_on_head,
@@ -59,7 +60,7 @@ def derive_next_action(
     codex_review = reviews.get("codexCloud") or {}
     current_postpublish_head = pr_head_sha or local_head_sha
 
-    claude_review = (reviews or {}).get("claudeCode")
+    claude_review = get_review(reviews, "internalReview")
     if inter_review_agent_is_running_on_head(claude_review, local_head_sha):
         return {
             "type": "noop",
@@ -174,7 +175,7 @@ def derive_next_action(
     if should_dispatch_claude_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
-        claude_review=(reviews or {}).get("claudeCode"),
+        claude_review=get_review(reviews, "internalReview"),
         repair_brief=repair_brief,
         workflow_state=workflow_state,
         current_head_sha=local_head_sha,

--- a/workflows/code_review/workspace.py
+++ b/workflows/code_review/workspace.py
@@ -446,6 +446,8 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     cron_jobs_path = Path(config["cronJobsPath"])
     hermes_cron_jobs_path = Path(config.get("hermesCronJobsPath") or (Path.home() / ".hermes/cron/jobs.json"))
     ledger_path = Path(config["ledgerPath"])
+    from workflows.code_review.migrations import migrate_persisted_ledger
+    migrate_persisted_ledger(ledger_path)
     health_path = Path(config["healthPath"])
     audit_log_path = Path(config["auditLogPath"])
     sessions_state_path = workspace_root / "state/sessions"


### PR DESCRIPTION
## Summary

Phase D-1 of the model-agnostic rename pass. Migrates the two operator-visible `reviews.*` ledger keys to provider-neutral names. Other field renames + function-name renames are deferred to Phase D-2 (which depends on Phases B/C merging).

- **Field migration** (persisted ledger):
  - `reviews.claudeCode` → `reviews.internalReview`
  - `reviews.codexCloud` → `reviews.externalReview`
- **One-shot migration** runs on workspace bootstrap (atomic temp+rename, idempotent, missing-file safe). Live yoyopod ledger migrates cleanly: old keys gone, new keys present, untouched keys preserved.
- **Read-both / write-new semantics** in source code for one release. New `get_review(reviews_dict, new_key)` helper falls back to the legacy key when only the legacy key is present (defense in depth against unmigrated ledgers / restored backups).
- **Action-type literal** `run_claude_review` → `run_internal_review`. Producer (`pick_workflow_action`) emits the new literal; dispatcher accepts both for the back-compat window.
- **Repair-brief routing alias.** `synthesize_repair_brief` accepts both `externalReview` (canonical) and `codexCloud` (legacy) as source names so external-review findings are not silently dropped during the rename window.

## Out of scope (Phase D-2 + later)

- Other top-level ledger field renames: `claudeRepairHandoff`, `codexCloudRepairHandoff`, `codexCloudAutoResolved`, `claudeModel`, `interReviewAgentModel`, `lastClaudeVerdict`
- Function renames in `reviews.py` (`fetch_codex_cloud_review` → `fetch_external_review`, etc.) — depends on Phase B merging
- Internal helper injection rename `run_acpx_prompt_fn` → `run_prompt_fn`
- Drop Phase B's `render_codex_cloud_repair_handoff_prompt` alias and the deprecated top-level `codex-bot:` block fallback

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-26-rename-pass-phase-d-1-design.md`
- Plan: `docs/superpowers/plans/2026-04-26-rename-pass-phase-d-1.md`

## Test plan

- [x] 495 tests passing (477 baseline + 18 new)
- [x] Live yoyopod ledger migrates cleanly (smoke test in workflow): old keys removed, new keys present, untouched `rockClaw` etc. preserved
- [x] Read-both fallback verified: code paths still work on unmigrated ledgers
- [x] Write-new semantics verified: legacy keys dropped after writes (no double-key state)
- [x] Action-type alias verified: dispatcher accepts both `run_internal_review` and `run_claude_review`
- [x] Two-stage review per task; final reviewer caught a critical routing bug in `synthesize_repair_brief` that the rename had silently broken; fixed in 301110a with new test coverage
- [ ] Operator review of the migration section in `skills/operator/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)