### PR TITLE
Phase D-5: lane-state nested field migration

### DIFF
--- a/docs/superpowers/plans/2026-04-27-rename-pass-phase-d-5.md
+++ b/docs/superpowers/plans/2026-04-27-rename-pass-phase-d-5.md
@@ -1,0 +1,384 @@
+# Rename Pass Phase D-5 Implementation Plan
+
+**Goal:** Migrate lane-state nested fields (`lastClaudeReviewedHeadSha`, `localClaudeReviewCount`) at `ledger.implementation.laneState.review.*`. Auto-migration on bootstrap; read-both/write-new for one release.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-rename-pass-phase-d-5-design.md`
+
+**Worktree:** `/home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-5` from main `a24fd46`. Baseline 581 passing. Use `/usr/bin/python3`.
+
+---
+
+## Task 1: Migration extension
+
+**Files:**
+- Modify: `workflows/code_review/migrations.py`
+- Test: `tests/test_rename_pass_phase_d_5.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_rename_pass_phase_d_5.py`:
+
+```python
+"""Phase D-5 tests: lane-state nested field migration."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_migrate_lane_state_review_keys_renames_legacy():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastClaudeReviewedHeadSha": "abc123",
+                    "localClaudeReviewCount": 5,
+                    "otherField": "preserved",
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is True
+    review = out["implementation"]["laneState"]["review"]
+    assert review["lastInternalReviewedHeadSha"] == "abc123"
+    assert review["localInternalReviewCount"] == 5
+    assert review["otherField"] == "preserved"
+    assert "lastClaudeReviewedHeadSha" not in review
+    assert "localClaudeReviewCount" not in review
+
+
+def test_migrate_lane_state_review_keys_handles_missing_path():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    # No implementation block
+    out, changed = migrate_lane_state_review_keys({"reviews": {}})
+    assert changed is False
+
+    # No laneState
+    out, changed = migrate_lane_state_review_keys({"implementation": {}})
+    assert changed is False
+
+    # No review
+    out, changed = migrate_lane_state_review_keys({"implementation": {"laneState": {}}})
+    assert changed is False
+
+
+def test_migrate_lane_state_review_keys_idempotent():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastInternalReviewedHeadSha": "abc",
+                    "localInternalReviewCount": 1,
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is False
+
+
+def test_migrate_lane_state_review_keys_new_key_wins():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastClaudeReviewedHeadSha": "old",
+                    "lastInternalReviewedHeadSha": "new",
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is True  # old key was dropped
+    assert out["implementation"]["laneState"]["review"]["lastInternalReviewedHeadSha"] == "new"
+    assert "lastClaudeReviewedHeadSha" not in out["implementation"]["laneState"]["review"]
+
+
+def test_migrate_persisted_ledger_runs_all_three_migrations(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "l.json"
+    p.write_text(json.dumps({
+        "reviews": {"claudeCode": {"v": 1}},
+        "claudeRepairHandoff": {"v": 2},
+        "implementation": {
+            "laneState": {"review": {"lastClaudeReviewedHeadSha": "abc"}},
+        },
+    }, indent=2))
+    migrate_persisted_ledger(p)
+    out = json.loads(p.read_text())
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert out["internalReviewRepairHandoff"] == {"v": 2}
+    assert out["implementation"]["laneState"]["review"]["lastInternalReviewedHeadSha"] == "abc"
+
+
+def test_get_lane_state_review_field_returns_new_when_present():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"lastInternalReviewedHeadSha": "x"}, "lastInternalReviewedHeadSha") == "x"
+
+
+def test_get_lane_state_review_field_falls_back_to_legacy():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"lastClaudeReviewedHeadSha": "x"}, "lastInternalReviewedHeadSha") == "x"
+    assert get_lane_state_review_field({"localClaudeReviewCount": 5}, "localInternalReviewCount") == 5
+
+
+def test_get_lane_state_review_field_returns_none_for_unknown_key():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"x": 1}, "made-up") is None
+
+
+def test_existing_yoyopod_ledger_lane_state_migration(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+    src = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json"))
+    if not src.exists():
+        pytest.skip("yoyopod ledger not present")
+    dst = tmp_path / "l.json"
+    dst.write_text(src.read_text())
+    migrate_persisted_ledger(dst)
+    out = json.loads(dst.read_text())
+    review = (out.get("implementation") or {}).get("laneState", {}).get("review") or {}
+    assert "lastClaudeReviewedHeadSha" not in review
+    assert "localClaudeReviewCount" not in review
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-5
+/usr/bin/python3 -m pytest tests/test_rename_pass_phase_d_5.py -v
+```
+
+- [ ] **Step 3: Extend `migrations.py`**
+
+Append to `workflows/code_review/migrations.py`:
+
+```python
+LANE_STATE_REVIEW_KEY_RENAMES: dict[str, str] = {
+    "lastClaudeReviewedHeadSha": "lastInternalReviewedHeadSha",
+    "localClaudeReviewCount": "localInternalReviewCount",
+}
+
+_LEGACY_LANE_STATE_REVIEW_KEY_FOR: dict[str, str] = {
+    v: k for k, v in LANE_STATE_REVIEW_KEY_RENAMES.items()
+}
+
+
+def migrate_lane_state_review_keys(ledger: dict) -> tuple[dict, bool]:
+    """Rewrite ledger.implementation.laneState.review.<key> per
+    LANE_STATE_REVIEW_KEY_RENAMES. Returns (ledger, was_changed)."""
+    impl = ledger.get("implementation")
+    if not isinstance(impl, dict):
+        return ledger, False
+    lane_state = impl.get("laneState")
+    if not isinstance(lane_state, dict):
+        return ledger, False
+    review = lane_state.get("review")
+    if not isinstance(review, dict):
+        return ledger, False
+
+    changed = False
+    for old, new in LANE_STATE_REVIEW_KEY_RENAMES.items():
+        if old in review:
+            if new not in review:
+                review[new] = review[old]
+            del review[old]
+            changed = True
+    return ledger, changed
+
+
+def get_lane_state_review_field(state_review: dict | None, new_key: str):
+    """Read lane-state review field by new key with legacy fallback (one release)."""
+    state_review = state_review or {}
+    if new_key in state_review:
+        return state_review[new_key]
+    legacy = _LEGACY_LANE_STATE_REVIEW_KEY_FOR.get(new_key)
+    if legacy and legacy in state_review:
+        return state_review[legacy]
+    return None
+```
+
+- [ ] **Step 4: Update `migrate_persisted_ledger` to run all three**
+
+Find the body (currently runs `migrate_review_keys` + `migrate_top_level_keys`). Add a third call:
+
+```python
+    _, c1 = migrate_review_keys(ledger)
+    _, c2 = migrate_top_level_keys(ledger)
+    _, c3 = migrate_lane_state_review_keys(ledger)
+    if not (c1 or c2 or c3):
+        return False
+```
+
+- [ ] **Step 5: Run target + full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/test_rename_pass_phase_d_5.py -v
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 9 in target, 590 total.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(migrations): add lane-state nested-path key migration
+
+Extends migrate_persisted_ledger with migrate_lane_state_review_keys
+and get_lane_state_review_field helpers. Renames
+ledger.implementation.laneState.review.{lastClaudeReviewedHeadSha,
+localClaudeReviewCount} to provider-neutral names.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Read sites + write sites
+
+**Files:**
+- Modify: `workflows/code_review/reviews.py` (lines 284-285)
+- Modify: `workflows/code_review/sessions.py` (line 130)
+- Modify: `workflows/code_review/status.py` (lines 926, 928)
+
+- [ ] **Step 1: Update read sites**
+
+In `workflows/code_review/reviews.py:284-285`, replace:
+```python
+count = int(state_review.get("localClaudeReviewCount") or 0)
+last_head = state_review.get("lastClaudeReviewedHeadSha")
+```
+with:
+```python
+count = int(get_lane_state_review_field(state_review, "localInternalReviewCount") or 0)
+last_head = get_lane_state_review_field(state_review, "lastInternalReviewedHeadSha")
+```
+
+Add `get_lane_state_review_field` to the existing migrations import in reviews.py.
+
+In `workflows/code_review/sessions.py:130`, replace:
+```python
+local_review_count = int(review_state.get("localClaudeReviewCount") or 0)
+```
+with:
+```python
+local_review_count = int(get_lane_state_review_field(review_state, "localInternalReviewCount") or 0)
+```
+
+Add `from workflows.code_review.migrations import get_lane_state_review_field` to sessions.py.
+
+- [ ] **Step 2: Update write sites in `status.py`**
+
+At lines 926, 928, the dict-literal builds the lane-state review block. Replace:
+```python
+"lastClaudeReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastClaudeReviewedHeadSha")),
+...
+"localClaudeReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
+```
+with:
+```python
+"lastInternalReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or get_lane_state_review_field(existing.get("review"), "lastInternalReviewedHeadSha"),
+...
+"localInternalReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
+```
+
+Add `get_lane_state_review_field` import to status.py.
+
+- [ ] **Step 3: Update `local_inter_review_agent_review_count` callees if needed**
+
+The function (in `reviews.py:281-...`) takes `state_review` and reads `localClaudeReviewCount`. Already addressed in Step 1. But verify the function signature still matches what `status.py:928` passes — it might be passing the full `existing` dict expecting the function to dig.
+
+```bash
+grep -n "def local_inter_review_agent_review_count\|def local_claude_review_count" workflows/code_review/reviews.py
+```
+
+If the function name says `local_claude_*`, also rename to `local_internal_*`. Add an alias for one release.
+
+- [ ] **Step 4: Run full suite**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -10
+```
+Expected: 590 passing. Existing tests asserting on `lastClaudeReviewedHeadSha` / `localClaudeReviewCount` keys in status output need updating — likely in `test_workflows_code_review_adapter_status.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: rename lane-state review keys to internal review names
+
+reviews.py / sessions.py read via get_lane_state_review_field
+(legacy fallback for one release). status.py writes the new keys
+in its lane-state review block.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Operator docs
+
+**Files:**
+- Modify: `skills/operator/SKILL.md`
+
+- [ ] **Step 1: Append section**
+
+```markdown
+## Lane-state migration (Phase D-5)
+
+Two nested lane-state fields renamed for provider neutrality:
+- `ledger.implementation.laneState.review.lastClaudeReviewedHeadSha` → `lastInternalReviewedHeadSha`
+- `ledger.implementation.laneState.review.localClaudeReviewCount` → `localInternalReviewCount`
+
+**Migration is automatic** on workspace bootstrap (extends D-1/D-3 mechanism).
+**Read-both / write-new** for one release via `get_lane_state_review_field` helper.
+**Status output keys also renamed** — external tooling reading `lastClaudeReviewedHeadSha` / `localClaudeReviewCount` from `yoyopod-workflow-status.json` should switch to the new names.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+git add -A
+git commit -m "docs(operator): note Phase D-5 lane-state field migration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+```bash
+cd /home/radxa/WS/hermes-relay/.claude/worktrees/rename-pass-phase-d-5
+/usr/bin/python3 -m pytest tests/ 2>&1 | tail -3
+```
+Expected: 590 passing.
+
+Live yoyopod ledger smoke test:
+```bash
+/usr/bin/python3 -c "
+import json, shutil, tempfile
+from pathlib import Path
+from workflows.code_review.migrations import migrate_persisted_ledger
+src = Path.home() / '.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json'
+with tempfile.TemporaryDirectory() as td:
+    dst = Path(td) / 'l.json'
+    shutil.copy2(src, dst)
+    changed = migrate_persisted_ledger(dst)
+    out = json.loads(dst.read_text())
+    review = (out.get('implementation') or {}).get('laneState', {}).get('review') or {}
+    print('lane-state migrated:', 'lastClaudeReviewedHeadSha' not in review and 'localClaudeReviewCount' not in review)
+"
+```

--- a/docs/superpowers/specs/2026-04-27-rename-pass-phase-d-5-design.md
+++ b/docs/superpowers/specs/2026-04-27-rename-pass-phase-d-5-design.md
@@ -1,0 +1,111 @@
+# Rename Pass Phase D-5 — Lane-State Field Migration
+
+**Status:** Approved
+**Date:** 2026-04-27
+**Branch:** `claude/rename-pass-phase-d-5` from main `a24fd46`. Baseline 581 tests passing.
+
+## Problem
+
+Two `Claude*` fields persist in lane-state, nested at `ledger.implementation.laneState.review.<key>`:
+- `lastClaudeReviewedHeadSha`
+- `localClaudeReviewCount`
+
+These are the last operator-visible legacy names in the persisted ledger. Phases D-1/D-3 migrated top-level keys (`reviews.*`, `claudeRepairHandoff`, etc.); D-5 finishes the cleanup at the lane-state nesting depth.
+
+## Scope
+
+### In scope
+1. **Lane-state field renames** with auto-migration:
+   - `lastClaudeReviewedHeadSha` → `lastInternalReviewedHeadSha`
+   - `localClaudeReviewCount` → `localInternalReviewCount`
+
+2. **Migration extension** in `workflows/code_review/migrations.py`:
+   - New `LANE_STATE_REVIEW_KEY_RENAMES` dict
+   - New `migrate_lane_state_review_keys(ledger)` helper that walks the nested path
+   - `migrate_persisted_ledger` runs all three migrations (review keys, top-level keys, lane-state keys)
+   - New `get_lane_state_review_field(state_review, new_key)` helper with one-release legacy fallback
+
+3. **Source-code updates**:
+   - `reviews.py:284-285`: read `localInternalReviewCount` / `lastInternalReviewedHeadSha` via `get_lane_state_review_field`
+   - `sessions.py:130`: same pattern
+   - `status.py:926, 928`: write new keys + `existing.get("review", {})` reads via the helper
+
+### Out of scope (D-6)
+- 73 cosmetic variable-name references (`claude_review`, `existing_claude_review`, `previous_claude_review`, `codex_review`, `codex_cloud_review`)
+
+## Architecture
+
+### Migration helper (nested-aware)
+```python
+LANE_STATE_REVIEW_KEY_RENAMES: dict[str, str] = {
+    "lastClaudeReviewedHeadSha": "lastInternalReviewedHeadSha",
+    "localClaudeReviewCount": "localInternalReviewCount",
+}
+
+_LEGACY_LANE_STATE_REVIEW_KEY_FOR: dict[str, str] = {
+    v: k for k, v in LANE_STATE_REVIEW_KEY_RENAMES.items()
+}
+
+
+def migrate_lane_state_review_keys(ledger: dict) -> tuple[dict, bool]:
+    """Rewrite ledger.implementation.laneState.review.<key> per
+    LANE_STATE_REVIEW_KEY_RENAMES. Returns (ledger, was_changed).
+    """
+    impl = ledger.get("implementation")
+    if not isinstance(impl, dict):
+        return ledger, False
+    lane_state = impl.get("laneState")
+    if not isinstance(lane_state, dict):
+        return ledger, False
+    review = lane_state.get("review")
+    if not isinstance(review, dict):
+        return ledger, False
+
+    changed = False
+    for old, new in LANE_STATE_REVIEW_KEY_RENAMES.items():
+        if old in review:
+            if new not in review:
+                review[new] = review[old]
+            del review[old]
+            changed = True
+    return ledger, changed
+
+
+def get_lane_state_review_field(state_review: dict | None, new_key: str):
+    """Read lane-state review field by new key with legacy fallback for one release."""
+    state_review = state_review or {}
+    if new_key in state_review:
+        return state_review[new_key]
+    legacy = _LEGACY_LANE_STATE_REVIEW_KEY_FOR.get(new_key)
+    if legacy and legacy in state_review:
+        return state_review[legacy]
+    return None
+```
+
+### Read sites
+- `reviews.py:284`: `int(state_review.get("localClaudeReviewCount") or 0)` → `int(get_lane_state_review_field(state_review, "localInternalReviewCount") or 0)`
+- `reviews.py:285`: `state_review.get("lastClaudeReviewedHeadSha")` → `get_lane_state_review_field(state_review, "lastInternalReviewedHeadSha")`
+- `sessions.py:130`: `int(review_state.get("localClaudeReviewCount") or 0)` → same pattern
+
+### Write sites
+- `status.py:926`: dict-literal output key `"lastClaudeReviewedHeadSha"` → `"lastInternalReviewedHeadSha"`. Inner `existing.get("review", {}).get("lastClaudeReviewedHeadSha")` → use `get_lane_state_review_field` for legacy fallback.
+- `status.py:928`: dict-literal output key `"localClaudeReviewCount"` → `"localInternalReviewCount"`.
+
+## Tests
+
+New file `tests/test_rename_pass_phase_d_5.py`:
+- `test_migrate_lane_state_review_keys_renames_legacy`
+- `test_migrate_lane_state_review_keys_handles_missing_path` — ledger without `implementation` / `laneState` / `review`.
+- `test_migrate_lane_state_review_keys_idempotent`
+- `test_migrate_lane_state_review_keys_new_key_wins_when_both_present`
+- `test_migrate_persisted_ledger_runs_all_three_migrations` — combined behavior on a ledger with all three legacy shapes.
+- `test_get_lane_state_review_field_returns_new_when_present`
+- `test_get_lane_state_review_field_falls_back_to_legacy`
+- `test_get_lane_state_review_field_returns_none_for_unknown_key`
+- `test_existing_yoyopod_ledger_lane_state_migration` — live ledger smoke test.
+
+Target: 581 + 9 new = 590 passing.
+
+## Risks
+- Nested-path migration: if `implementation` or `laneState` is missing/wrong type, helper returns `(ledger, False)` cleanly. Standard pattern.
+- Status output shape change: external tooling that parsed `lastClaudeReviewedHeadSha` / `localClaudeReviewCount` from `yoyopod-workflow-status.json` should switch to new names. Operator doc updated.

--- a/skills/operator/SKILL.md
+++ b/skills/operator/SKILL.md
@@ -290,3 +290,13 @@ The Phase D-2 / D-3 one-release back-compat aliases have been removed:
 - Per-thread `"source": "codexCloud"` review-thread label is now `"externalReview"`. Threads are rebuilt from GitHub data each tick, so old labels self-heal.
 
 Migration helpers (`migrate_review_keys`, `migrate_top_level_keys`, `migrate_persisted_ledger`) remain — they run idempotently on bootstrap and protect against stale state from backups.
+
+## Lane-state migration (Phase D-5)
+
+Two nested lane-state fields renamed for provider neutrality:
+- `ledger.implementation.laneState.review.lastClaudeReviewedHeadSha` → `lastInternalReviewedHeadSha`
+- `ledger.implementation.laneState.review.localClaudeReviewCount` → `localInternalReviewCount`
+
+**Migration is automatic** on workspace bootstrap (extends D-1/D-3 mechanism).
+**Read-both / write-new** for one release via `get_lane_state_review_field` helper.
+**Status output keys also renamed** — external tooling reading `lastClaudeReviewedHeadSha` / `localClaudeReviewCount` from `yoyopod-workflow-status.json` should switch to the new names.

--- a/tests/test_rename_pass_phase_d_5.py
+++ b/tests/test_rename_pass_phase_d_5.py
@@ -1,0 +1,132 @@
+"""Phase D-5 tests: lane-state nested field migration."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_migrate_lane_state_review_keys_renames_legacy():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastClaudeReviewedHeadSha": "abc123",
+                    "localClaudeReviewCount": 5,
+                    "otherField": "preserved",
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is True
+    review = out["implementation"]["laneState"]["review"]
+    assert review["lastInternalReviewedHeadSha"] == "abc123"
+    assert review["localInternalReviewCount"] == 5
+    assert review["otherField"] == "preserved"
+    assert "lastClaudeReviewedHeadSha" not in review
+    assert "localClaudeReviewCount" not in review
+
+
+def test_migrate_lane_state_review_keys_handles_missing_path():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    # No implementation block
+    out, changed = migrate_lane_state_review_keys({"reviews": {}})
+    assert changed is False
+
+    # No laneState
+    out, changed = migrate_lane_state_review_keys({"implementation": {}})
+    assert changed is False
+
+    # No review
+    out, changed = migrate_lane_state_review_keys({"implementation": {"laneState": {}}})
+    assert changed is False
+
+
+def test_migrate_lane_state_review_keys_idempotent():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastInternalReviewedHeadSha": "abc",
+                    "localInternalReviewCount": 1,
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is False
+
+
+def test_migrate_lane_state_review_keys_new_key_wins():
+    from workflows.code_review.migrations import migrate_lane_state_review_keys
+
+    ledger = {
+        "implementation": {
+            "laneState": {
+                "review": {
+                    "lastClaudeReviewedHeadSha": "old",
+                    "lastInternalReviewedHeadSha": "new",
+                },
+            },
+        },
+    }
+    out, changed = migrate_lane_state_review_keys(ledger)
+    assert changed is True  # old key was dropped
+    assert out["implementation"]["laneState"]["review"]["lastInternalReviewedHeadSha"] == "new"
+    assert "lastClaudeReviewedHeadSha" not in out["implementation"]["laneState"]["review"]
+
+
+def test_migrate_persisted_ledger_runs_all_three_migrations(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+
+    p = tmp_path / "l.json"
+    p.write_text(json.dumps({
+        "reviews": {"claudeCode": {"v": 1}},
+        "claudeRepairHandoff": {"v": 2},
+        "implementation": {
+            "laneState": {"review": {"lastClaudeReviewedHeadSha": "abc"}},
+        },
+    }, indent=2))
+    migrate_persisted_ledger(p)
+    out = json.loads(p.read_text())
+    assert out["reviews"]["internalReview"] == {"v": 1}
+    assert out["internalReviewRepairHandoff"] == {"v": 2}
+    assert out["implementation"]["laneState"]["review"]["lastInternalReviewedHeadSha"] == "abc"
+
+
+def test_get_lane_state_review_field_returns_new_when_present():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"lastInternalReviewedHeadSha": "x"}, "lastInternalReviewedHeadSha") == "x"
+
+
+def test_get_lane_state_review_field_falls_back_to_legacy():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"lastClaudeReviewedHeadSha": "x"}, "lastInternalReviewedHeadSha") == "x"
+    assert get_lane_state_review_field({"localClaudeReviewCount": 5}, "localInternalReviewCount") == 5
+
+
+def test_get_lane_state_review_field_returns_none_for_unknown_key():
+    from workflows.code_review.migrations import get_lane_state_review_field
+    assert get_lane_state_review_field({"x": 1}, "made-up") is None
+
+
+def test_existing_yoyopod_ledger_lane_state_migration(tmp_path):
+    from workflows.code_review.migrations import migrate_persisted_ledger
+    src = Path(os.path.expanduser("~/.hermes/workflows/yoyopod/memory/yoyopod-workflow-status.json"))
+    if not src.exists():
+        pytest.skip("yoyopod ledger not present")
+    dst = tmp_path / "l.json"
+    dst.write_text(src.read_text())
+    migrate_persisted_ledger(dst)
+    out = json.loads(dst.read_text())
+    review = (out.get("implementation") or {}).get("laneState", {}).get("review") or {}
+    assert "lastClaudeReviewedHeadSha" not in review
+    assert "localClaudeReviewCount" not in review

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -153,6 +153,27 @@ def test_single_pass_local_claude_gate_satisfied_handles_pass_clean_and_pass_wit
     assert rework is False
 
 
+def test_single_pass_local_claude_gate_satisfied_handles_new_key_shape():
+    """Phase D-5: post-migration lane-state with the new key shape works."""
+    reviews_module = load_module("daedalus_workflows_code_review_reviews_test", "workflows/code_review/reviews.py")
+
+    pass_clean = reviews_module.single_pass_local_claude_gate_satisfied(
+        {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "abc", "verdict": "PASS_CLEAN"},
+        "abc",
+        {"review": {"lastInternalReviewedHeadSha": "abc", "lastInternalVerdict": "PASS_CLEAN"}},
+        pass_with_findings_reviews=1,
+    )
+    pass_with_findings = reviews_module.single_pass_local_claude_gate_satisfied(
+        {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "old-head", "verdict": "PASS_WITH_FINDINGS"},
+        "new-head",
+        {"review": {"localInternalReviewCount": 0, "lastInternalReviewedHeadSha": "older-head", "lastInternalVerdict": "PASS_WITH_FINDINGS"}},
+        pass_with_findings_reviews=1,
+    )
+
+    assert pass_clean is True
+    assert pass_with_findings is True
+
+
 def test_determine_review_loop_state_handles_pending_findings_and_rework():
     reviews_module = load_module("daedalus_workflows_code_review_reviews_test", "workflows/code_review/reviews.py")
 

--- a/workflows/code_review/migrations.py
+++ b/workflows/code_review/migrations.py
@@ -71,7 +71,8 @@ def migrate_persisted_ledger(path: Path | str) -> bool:
 
     _, c1 = migrate_review_keys(ledger)
     _, c2 = migrate_top_level_keys(ledger)
-    if not (c1 or c2):
+    _, c3 = migrate_lane_state_review_keys(ledger)
+    if not (c1 or c2 or c3):
         return False
 
     # Atomic temp-file + rename in the same directory.
@@ -134,3 +135,47 @@ def migrate_top_level_keys(ledger: dict) -> tuple[dict, bool]:
 def get_ledger_field(ledger: dict | None, new_key: str):
     """Read a top-level ledger field. Returns None if absent."""
     return (ledger or {}).get(new_key)
+
+
+LANE_STATE_REVIEW_KEY_RENAMES: dict[str, str] = {
+    "lastClaudeReviewedHeadSha": "lastInternalReviewedHeadSha",
+    "localClaudeReviewCount": "localInternalReviewCount",
+}
+
+_LEGACY_LANE_STATE_REVIEW_KEY_FOR: dict[str, str] = {
+    v: k for k, v in LANE_STATE_REVIEW_KEY_RENAMES.items()
+}
+
+
+def migrate_lane_state_review_keys(ledger: dict) -> tuple[dict, bool]:
+    """Rewrite ledger.implementation.laneState.review.<key> per
+    LANE_STATE_REVIEW_KEY_RENAMES. Returns (ledger, was_changed)."""
+    impl = ledger.get("implementation")
+    if not isinstance(impl, dict):
+        return ledger, False
+    lane_state = impl.get("laneState")
+    if not isinstance(lane_state, dict):
+        return ledger, False
+    review = lane_state.get("review")
+    if not isinstance(review, dict):
+        return ledger, False
+
+    changed = False
+    for old, new in LANE_STATE_REVIEW_KEY_RENAMES.items():
+        if old in review:
+            if new not in review:
+                review[new] = review[old]
+            del review[old]
+            changed = True
+    return ledger, changed
+
+
+def get_lane_state_review_field(state_review: dict | None, new_key: str):
+    """Read lane-state review field by new key with legacy fallback (one release)."""
+    state_review = state_review or {}
+    if new_key in state_review:
+        return state_review[new_key]
+    legacy = _LEGACY_LANE_STATE_REVIEW_KEY_FOR.get(new_key)
+    if legacy and legacy in state_review:
+        return state_review[legacy]
+    return None

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -304,7 +304,7 @@ def single_pass_local_claude_gate_satisfied(
     state = lane_state or {}
     state_review = state.get("review") or {}
     review_count = local_inter_review_agent_review_count(review, state)
-    latest_reviewed_head = state_review.get("lastClaudeReviewedHeadSha")
+    latest_reviewed_head = get_lane_state_review_field(state_review, "lastInternalReviewedHeadSha")
     latest_verdict = state_review.get("lastInternalVerdict")
     if review.get("reviewScope") == "local-prepublish" and review.get("status") == "completed":
         latest_reviewed_head = review.get("reviewedHeadSha") or latest_reviewed_head

--- a/workflows/code_review/reviews.py
+++ b/workflows/code_review/reviews.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Callable
 
-from workflows.code_review.migrations import get_review
+from workflows.code_review.migrations import get_lane_state_review_field, get_review
 
 
 """YoYoPod Core review-policy helpers.
@@ -281,8 +281,8 @@ def current_inter_review_agent_matches_local_head(review: dict[str, Any] | None,
 def local_inter_review_agent_review_count(review: dict[str, Any] | None, lane_state: dict[str, Any] | None = None) -> int:
     state = lane_state or {}
     state_review = state.get("review") or {}
-    count = int(state_review.get("localClaudeReviewCount") or 0)
-    last_head = state_review.get("lastClaudeReviewedHeadSha")
+    count = int(get_lane_state_review_field(state_review, "localInternalReviewCount") or 0)
+    last_head = get_lane_state_review_field(state_review, "lastInternalReviewedHeadSha")
     review = review or {}
     if review.get("reviewScope") == "local-prepublish" and review.get("status") == "completed":
         reviewed_head = review.get("reviewedHeadSha")

--- a/workflows/code_review/sessions.py
+++ b/workflows/code_review/sessions.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from workflows.code_review.migrations import get_review
+from workflows.code_review.migrations import get_lane_state_review_field, get_review
 
 
 """YoYoPod Core session and worktree helpers.
@@ -127,7 +127,7 @@ def should_escalate_codex_model(
     review_state = lane_state.get("review") or {}
     restart_state = lane_state.get("restart") or {}
     restart_count = int(restart_state.get("count") or 0)
-    local_review_count = int(review_state.get("localClaudeReviewCount") or 0)
+    local_review_count = int(get_lane_state_review_field(review_state, "localInternalReviewCount") or 0)
     codex_review = get_review(reviews, "externalReview")
     codex_open_findings = int(codex_review.get("openFindingCount") or 0)
     if restart_count >= escalate_restart_count:

--- a/workflows/code_review/status.py
+++ b/workflows/code_review/status.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from workflows.code_review.health import compute_health, compute_stale_lane_reasons
-from workflows.code_review.migrations import get_ledger_field, get_review
+from workflows.code_review.migrations import get_lane_state_review_field, get_ledger_field, get_review
 from workflows.code_review.paths import (
     lane_memo_path,
     lane_state_path,
@@ -923,9 +923,9 @@ def write_lane_state(
         },
         "review": {
             "repairBriefHeadSha": (repair_brief or {}).get("forHeadSha"),
-            "lastClaudeReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastClaudeReviewedHeadSha")),
+            "lastInternalReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or get_lane_state_review_field(existing.get("review"), "lastInternalReviewedHeadSha"),
             "lastInternalVerdict": ((get_review(reviews, "internalReview")).get("verdict")) or ((existing.get("review") or {}).get("lastInternalVerdict")),
-            "localClaudeReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
+            "localInternalReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
             "currentClaudeRunId": ((get_review(reviews, "internalReview")).get("runId")),
             "currentClaudeTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
             "currentClaudeStatus": ((get_review(reviews, "internalReview")).get("status")),


### PR DESCRIPTION
## Summary

Phase D-5 migrates two nested lane-state fields. Last operator-visible legacy names in the persisted ledger.

### Field renames (with auto-migration)
- `ledger.implementation.laneState.review.lastClaudeReviewedHeadSha` → `lastInternalReviewedHeadSha`
- `ledger.implementation.laneState.review.localClaudeReviewCount` → `localInternalReviewCount`

### Migration mechanics
- New `migrate_lane_state_review_keys` (nested-path-aware) in `workflows/code_review/migrations.py`
- New `get_lane_state_review_field(state_review, new_key)` reader with one-release legacy fallback
- `migrate_persisted_ledger` now runs **all three** migrations on bootstrap (D-1 reviews keys + D-3 top-level keys + D-5 lane-state keys)

### Read/write site updates
- `reviews.py:284-285, 307`: lane-state reads via helper
- `sessions.py:130`: same
- `status.py:926, 928`: dict-literal output keys renamed; legacy fallback for `existing.get("review")` carry-over uses helper

### Reviewer-caught bug
Final code reviewer caught a missed read at `reviews.py:307` (`single_pass_local_claude_gate_satisfied`) — would have silently broken the gate for PASS_CLEAN/PASS_WITH_FINDINGS states post-migration. Fixed in 2ffc748 with parallel new-key-shape test.

## Out of scope (D-6 if pursued)
- 73 cosmetic variable-name renames (`claude_review`, `existing_claude_review`, etc.) — pure stylistic, not operator-visible

## Spec & plan
- Spec: `docs/superpowers/specs/2026-04-27-rename-pass-phase-d-5-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-rename-pass-phase-d-5.md`

## Test plan
- [x] 591 tests passing (581 baseline + 10 new)
- [x] Live yoyopod ledger smoke test passes
- [x] All three migrations exercised in composite test
- [x] Final reviewer caught critical missed read site; fixed with regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)