### PR TITLE
S-2: ConfigWatcher (hot-reload primitive)

### DIFF
--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -209,3 +209,18 @@ def test_watcher_poll_detects_size_change_at_same_mtime(tmp_path):
     reloads = [t for t, _ in events if t == "daedalus.config_reloaded"]
     assert len(reloads) == 1, f"Expected size-change to trigger reload, got events={events}"
     assert ref.get() is not initial  # snapshot replaced
+
+
+def test_watcher_poll_missing_file_keeps_lkg_no_event(tmp_path):
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    p.unlink()
+    w.poll()
+    assert ref.get() is initial
+    assert events == []  # missing-during-rename is silent

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -121,3 +121,41 @@ def test_watcher_poll_no_change_is_noop(tmp_path):
     w.poll()
     assert ref.get() is initial
     assert events == []
+
+
+def test_watcher_poll_invalid_yaml_keeps_lkg_and_emits_failure(tmp_path):
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    p.write_text("workflow: [unclosed\n")
+    os.utime(p, (initial.source_mtime + 5, initial.source_mtime + 5))
+
+    w.poll()
+    assert ref.get() is initial
+    assert any(t == "daedalus.config_reload_failed" for t, _ in events)
+
+
+def test_watcher_poll_schema_invalid_keeps_lkg_and_emits_failure(tmp_path):
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    p.write_text("workflow: code-review\n")  # schema-invalid (missing required fields)
+    os.utime(p, (initial.source_mtime + 5, initial.source_mtime + 5))
+
+    w.poll()
+    assert ref.get() is initial
+    failures = [d for t, d in events if t == "daedalus.config_reload_failed"]
+    assert len(failures) == 1
+    assert "schema validation" in failures[0]["error"]

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -1,0 +1,79 @@
+"""S-2 tests: ConfigWatcher (mtime-poll hot-reload) — Symphony §6.2."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+_VALID_YAML = textwrap.dedent("""\
+    workflow: code-review
+    schema-version: 1
+    instance:
+      name: test-instance
+      engine-owner: hermes
+    repository:
+      local-path: /tmp/test
+      github-slug: org/repo
+      active-lane-label: active-lane
+    runtimes:
+      r1:
+        kind: claude-cli
+        max-turns-per-invocation: 4
+        timeout-seconds: 60
+    agents:
+      coder:
+        t1:
+          name: coder
+          model: claude
+          runtime: r1
+      internal-reviewer:
+        name: internal
+        model: claude
+        runtime: r1
+      external-reviewer:
+        enabled: false
+        name: external
+    gates:
+      internal-review: {}
+      external-review: {}
+      merge: {}
+    triggers:
+      lane-selector:
+        type: github-issue-label
+        label: active-lane
+    storage:
+      ledger: ledger.json
+      health: health.json
+      audit-log: audit.log
+""")
+
+
+def test_parse_and_validate_returns_snapshot(tmp_path):
+    from workflows.code_review.config_watcher import parse_and_validate
+
+    p = tmp_path / "workflow.yaml"
+    p.write_text(_VALID_YAML)
+    snap = parse_and_validate(p)
+    assert snap.config["workflow"] == "code-review"
+    assert snap.source_mtime == p.stat().st_mtime
+    assert snap.loaded_at > 0
+
+
+def test_parse_and_validate_raises_on_yaml_syntax_error(tmp_path):
+    from workflows.code_review.config_watcher import parse_and_validate, ParseError
+
+    p = tmp_path / "workflow.yaml"
+    p.write_text("workflow: [unclosed\n")
+    with pytest.raises(ParseError):
+        parse_and_validate(p)
+
+
+def test_parse_and_validate_raises_on_schema_violation(tmp_path):
+    from workflows.code_review.config_watcher import parse_and_validate, ValidationError
+
+    p = tmp_path / "workflow.yaml"
+    p.write_text("workflow: code-review\n")  # missing required fields
+    with pytest.raises(ValidationError):
+        parse_and_validate(p)

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -224,3 +224,91 @@ def test_watcher_poll_missing_file_keeps_lkg_no_event(tmp_path):
     w.poll()
     assert ref.get() is initial
     assert events == []  # missing-during-rename is silent
+
+
+def test_watcher_post_init_detects_drift_between_bootstrap_and_construction(tmp_path):
+    """Codex P2 on PR #19: workflow.yaml may change between bootstrap parse
+    and ConfigWatcher construction. The watcher must seed _last_key from
+    the snapshot's recorded (mtime, size), NOT the live file — otherwise
+    the drifted-but-current bytes look "fresh" and never get reloaded.
+    """
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+
+    # Simulate the race: file changes (size + mtime) between snapshot
+    # construction and ConfigWatcher construction.
+    drifted_yaml = p.read_text() + "\n# drift between bootstrap and construction\n"
+    p.write_text(drifted_yaml)
+
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+    # First poll MUST detect the drift and reload, not return early.
+    w.poll()
+
+    reloads = [t for t, _ in events if t == "daedalus.config_reloaded"]
+    assert len(reloads) == 1, (
+        f"Expected drift detection on first poll; events={events}. "
+        f"If this fails, the watcher seeded _last_key from the live file "
+        f"instead of the snapshot — drifted bytes will never be reloaded."
+    )
+    assert ref.get() is not initial
+
+
+def test_watcher_poll_handles_unicode_decode_error(tmp_path):
+    """Codex P1 on PR #19: poll() must catch UnicodeDecodeError too.
+
+    Otherwise binary content slipping into workflow.yaml crashes the
+    watcher loop instead of preserving last-known-good config.
+    """
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    # Write invalid UTF-8. Don't replace the whole file with binary;
+    # we want stat() to succeed and read_text(encoding="utf-8") to fail.
+    p.write_bytes(b"\xff\xfe\x00\x00 not utf-8 \xc0\xc1")
+
+    # Must NOT raise — should emit failure event and keep LKG.
+    w.poll()
+    assert ref.get() is initial
+    failures = [t for t, _ in events if t == "daedalus.config_reload_failed"]
+    assert len(failures) == 1
+
+
+def test_watcher_poll_handles_oserror_during_read(tmp_path, monkeypatch):
+    """Codex P1 on PR #19: poll() must catch OSError too.
+
+    parse_and_validate calls read_text() which can raise OSError if the
+    file disappears between stat() and read_text(). Without this catch
+    the watcher crashes the daemon.
+    """
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+    from workflows.code_review import config_watcher as cw_mod
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    # Bump mtime so poll() thinks there's a change to read.
+    p.write_text(p.read_text() + "\n# perturb size\n")
+
+    def _raise_oserror(path):
+        raise OSError("simulated read race")
+
+    monkeypatch.setattr(cw_mod, "parse_and_validate", _raise_oserror)
+
+    # Must NOT raise — should emit failure event and keep LKG.
+    w.poll()
+    assert ref.get() is initial
+    failures = [t for t, _ in events if t == "daedalus.config_reload_failed"]
+    assert len(failures) == 1

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -77,3 +77,47 @@ def test_parse_and_validate_raises_on_schema_violation(tmp_path):
     p.write_text("workflow: code-review\n")  # missing required fields
     with pytest.raises(ValidationError):
         parse_and_validate(p)
+
+
+def _seed_snapshot(tmp_path: Path):
+    """Helper: write valid yaml + return (path, snapshot)."""
+    from workflows.code_review.config_watcher import parse_and_validate
+
+    p = tmp_path / "workflow.yaml"
+    p.write_text(_VALID_YAML)
+    return p, parse_and_validate(p)
+
+
+def test_watcher_poll_swaps_on_mtime_change(tmp_path):
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    # Edit file with a future mtime
+    new_yaml = _VALID_YAML.replace("test-instance", "edited-instance")
+    p.write_text(new_yaml)
+    os.utime(p, (initial.source_mtime + 5, initial.source_mtime + 5))
+
+    w.poll()
+    assert ref.get().config["instance"]["name"] == "edited-instance"
+    assert any(t == "daedalus.config_reloaded" for t, _ in events)
+
+
+def test_watcher_poll_no_change_is_noop(tmp_path):
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    w.poll()
+    w.poll()
+    assert ref.get() is initial
+    assert events == []

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -180,3 +180,32 @@ def test_watcher_poll_does_not_re_emit_for_same_broken_mtime(tmp_path):
 
     failures = [t for t, _ in events if t == "daedalus.config_reload_failed"]
     assert len(failures) == 1  # only the first tick re-attempted parsing
+
+
+def test_watcher_poll_detects_size_change_at_same_mtime(tmp_path):
+    """Bytes changed but mtime preserved (e.g. rsync -t). Must reload."""
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    # Force first poll to record current key
+    w.poll()
+    events.clear()
+
+    # Rewrite with longer content but force-restore the original mtime
+    new_yaml = p.read_text() + "\n# trailing comment to bump size\n"
+    original_mtime = p.stat().st_mtime
+    p.write_text(new_yaml)
+    os.utime(p, (original_mtime, original_mtime))
+
+    # mtime is unchanged but size grew. Watcher must still re-parse.
+    w.poll()
+
+    reloads = [t for t, _ in events if t == "daedalus.config_reloaded"]
+    assert len(reloads) == 1, f"Expected size-change to trigger reload, got events={events}"
+    assert ref.get() is not initial  # snapshot replaced

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -159,3 +159,24 @@ def test_watcher_poll_schema_invalid_keeps_lkg_and_emits_failure(tmp_path):
     failures = [d for t, d in events if t == "daedalus.config_reload_failed"]
     assert len(failures) == 1
     assert "schema validation" in failures[0]["error"]
+
+
+def test_watcher_poll_does_not_re_emit_for_same_broken_mtime(tmp_path):
+    import os
+    from workflows.code_review.config_snapshot import AtomicRef
+    from workflows.code_review.config_watcher import ConfigWatcher
+
+    p, initial = _seed_snapshot(tmp_path)
+    ref = AtomicRef(initial)
+    events: list[tuple[str, dict]] = []
+    w = ConfigWatcher(p, ref, lambda t, d: events.append((t, d)))
+
+    p.write_text("workflow: [unclosed\n")
+    os.utime(p, (initial.source_mtime + 5, initial.source_mtime + 5))
+
+    w.poll()
+    w.poll()
+    w.poll()
+
+    failures = [t for t, _ in events if t == "daedalus.config_reload_failed"]
+    assert len(failures) == 1  # only the first tick re-attempted parsing

--- a/workflows/code_review/config_snapshot.py
+++ b/workflows/code_review/config_snapshot.py
@@ -52,6 +52,11 @@ class ConfigSnapshot:
     prompts: Mapping[str, Any]
     loaded_at: float
     source_mtime: float
+    # Codex P2 on PR #19: track on-disk size at snapshot-construction time so
+    # ConfigWatcher can seed its (mtime, size) change-detection key from the
+    # snapshot without re-stat()ing the live file. Defaults to -1 (sentinel)
+    # for back-compat with existing call sites that don't supply it.
+    source_size: int = -1
 
     def __post_init__(self) -> None:
         # Wrap incoming dicts in read-only views so callers cannot mutate

--- a/workflows/code_review/config_watcher.py
+++ b/workflows/code_review/config_watcher.py
@@ -55,11 +55,13 @@ def parse_and_validate(workflow_yaml_path: Path) -> ConfigSnapshot:
         raise ValidationError(f"schema validation failed: {exc.message}") from exc
 
     prompts = config.get("prompts") or {}
+    st = workflow_yaml_path.stat()
     return ConfigSnapshot(
         config=config,
         prompts=prompts,
         loaded_at=time.monotonic(),
-        source_mtime=workflow_yaml_path.stat().st_mtime,
+        source_mtime=st.st_mtime,
+        source_size=st.st_size,
     )
 
 
@@ -74,16 +76,14 @@ class ConfigWatcher:
 
     def __post_init__(self) -> None:
         snap = self.snapshot_ref.get()
-        # Seed with the real on-disk (mtime, size) so the first poll is a
-        # true no-op when nothing changed since the bootstrap parse. If
-        # the file vanished between bootstrap and watcher construction,
-        # fall back to the snapshot's mtime + size=-1 (next poll will
-        # reload as soon as the file reappears).
-        try:
-            st = self.workflow_yaml_path.stat()
-            self._last_key = (st.st_mtime, st.st_size)
-        except OSError:
-            self._last_key = (snap.source_mtime, -1)
+        # Codex P2 on PR #19: seed _last_key from the snapshot's recorded
+        # (mtime, size), NOT the live file. If workflow.yaml changed between
+        # bootstrap parse and watcher construction, the snapshot still holds
+        # the OLD config; seeding from the LIVE file would convince poll()
+        # the new bytes are "current" and the watcher would never reload
+        # until the next edit. Seeding from the snapshot's recorded values
+        # ensures the next poll detects the drift and reloads.
+        self._last_key = (snap.source_mtime, snap.source_size)
 
     def poll(self) -> None:
         """One tick of the watcher loop. Cheap when no change.
@@ -100,12 +100,22 @@ class ConfigWatcher:
         if key == self._last_key:
             return
 
+        # Codex P1 on PR #19: catch the full set of failures parse_and_validate
+        # can raise. OSError covers "file disappeared between stat() and
+        # read_text()", UnicodeDecodeError covers binary content / encoding
+        # mismatch, ParseError/ValidationError cover YAML syntax + schema.
+        # An uncaught exception here would propagate out of poll() and crash
+        # the watcher loop instead of preserving last-known-good config.
         try:
             new_snapshot = parse_and_validate(self.workflow_yaml_path)
-        except (ParseError, ValidationError) as exc:
+        except (ParseError, ValidationError, OSError, UnicodeDecodeError) as exc:
             self.emit_event(
                 "daedalus.config_reload_failed",
-                {"error": str(exc), "mtime": st.st_mtime, "size": st.st_size},
+                {
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "mtime": st.st_mtime,
+                    "size": st.st_size,
+                },
             )
             self._last_key = key  # suppress retrying same broken bytes
             return

--- a/workflows/code_review/config_watcher.py
+++ b/workflows/code_review/config_watcher.py
@@ -74,11 +74,16 @@ class ConfigWatcher:
 
     def __post_init__(self) -> None:
         snap = self.snapshot_ref.get()
-        # Initialize from the loaded snapshot's mtime; size unknown at boot,
-        # so a first poll will always detect a change and re-stat. That's
-        # fine — re-parse on first tick is cheap and validates the on-disk
-        # bytes match the snapshot we booted with.
-        self._last_key = (snap.source_mtime, -1)
+        # Seed with the real on-disk (mtime, size) so the first poll is a
+        # true no-op when nothing changed since the bootstrap parse. If
+        # the file vanished between bootstrap and watcher construction,
+        # fall back to the snapshot's mtime + size=-1 (next poll will
+        # reload as soon as the file reappears).
+        try:
+            st = self.workflow_yaml_path.stat()
+            self._last_key = (st.st_mtime, st.st_size)
+        except OSError:
+            self._last_key = (snap.source_mtime, -1)
 
     def poll(self) -> None:
         """One tick of the watcher loop. Cheap when no change.

--- a/workflows/code_review/config_watcher.py
+++ b/workflows/code_review/config_watcher.py
@@ -1,0 +1,113 @@
+"""Hot-reload of workflow.yaml (Symphony §6.2).
+
+`ConfigWatcher.poll()` is called every tick. It mtime-checks the
+workflow file; on change, reparses + validates and swaps the
+`AtomicRef[ConfigSnapshot]`. On failure, the last-known-good snapshot
+is kept and `daedalus.config_reload_failed` is emitted.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import yaml
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import ValidationError as _JSValidationError
+
+from workflows.code_review.config_snapshot import AtomicRef, ConfigSnapshot
+
+
+class ParseError(Exception):
+    """Raised when workflow.yaml cannot be parsed as YAML."""
+
+
+class ValidationError(Exception):
+    """Raised when workflow.yaml parses but violates schema.yaml."""
+
+
+_SCHEMA_PATH = Path(__file__).resolve().parent / "schema.yaml"
+
+
+def _load_schema() -> dict:
+    return yaml.safe_load(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def parse_and_validate(workflow_yaml_path: Path) -> ConfigSnapshot:
+    """Parse `workflow.yaml`, validate against `schema.yaml`, return snapshot.
+
+    Raises:
+        ParseError: yaml.YAMLError or non-dict top-level.
+        ValidationError: schema validation failure.
+    """
+    try:
+        text = workflow_yaml_path.read_text(encoding="utf-8")
+        config = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ParseError(f"YAML parse error: {exc}") from exc
+    if not isinstance(config, dict):
+        raise ParseError(f"workflow.yaml top-level must be a mapping, got {type(config).__name__}")
+
+    try:
+        Draft7Validator(_load_schema()).validate(config)
+    except _JSValidationError as exc:
+        raise ValidationError(f"schema validation failed: {exc.message}") from exc
+
+    prompts = config.get("prompts") or {}
+    return ConfigSnapshot(
+        config=config,
+        prompts=prompts,
+        loaded_at=time.monotonic(),
+        source_mtime=workflow_yaml_path.stat().st_mtime,
+    )
+
+
+@dataclass
+class ConfigWatcher:
+    """mtime-polled config-reload driver. Call `.poll()` once per tick."""
+
+    workflow_yaml_path: Path
+    snapshot_ref: AtomicRef[ConfigSnapshot]
+    emit_event: Callable[[str, dict], None]
+    _last_key: tuple[float, int] = (0.0, 0)
+
+    def __post_init__(self) -> None:
+        snap = self.snapshot_ref.get()
+        # Initialize from the loaded snapshot's mtime; size unknown at boot,
+        # so a first poll will always detect a change and re-stat. That's
+        # fine — re-parse on first tick is cheap and validates the on-disk
+        # bytes match the snapshot we booted with.
+        self._last_key = (snap.source_mtime, -1)
+
+    def poll(self) -> None:
+        """One tick of the watcher loop. Cheap when no change.
+
+        Uses (st_mtime, st_size) as the change-detection key. mtime alone
+        is insufficient on filesystems with coarse timestamp resolution
+        or mtime-preserving copies (NFS, rsync -t, overlayfs).
+        """
+        try:
+            st = self.workflow_yaml_path.stat()
+        except OSError:
+            return  # file vanished mid-poll (atomic rename); keep last-known-good
+        key = (st.st_mtime, st.st_size)
+        if key == self._last_key:
+            return
+
+        try:
+            new_snapshot = parse_and_validate(self.workflow_yaml_path)
+        except (ParseError, ValidationError) as exc:
+            self.emit_event(
+                "daedalus.config_reload_failed",
+                {"error": str(exc), "mtime": st.st_mtime, "size": st.st_size},
+            )
+            self._last_key = key  # suppress retrying same broken bytes
+            return
+
+        self.snapshot_ref.set(new_snapshot)
+        self._last_key = key
+        self.emit_event(
+            "daedalus.config_reloaded",
+            {"loaded_at": new_snapshot.loaded_at, "source_mtime": st.st_mtime, "size": st.st_size},
+        )


### PR DESCRIPTION
## Summary

Phase S-2 of the [Symphony-conformance pass](https://github.com/attmous/daedalus/pull/16). Implements the `(mtime, size)`-keyed config watcher (Symphony §6.2 hot-reload primitive). Reparses `workflow.yaml` on change, atomically swaps the `ConfigSnapshot`, falls back to last-known-good on bad reload.

- New `workflows/code_review/config_watcher.py` — `ConfigWatcher` class + `parse_and_validate()` helper
- New `tests/test_config_watcher.py` — 10 tests covering: change-detection swap, no-change no-op, broken YAML, broken schema, retry suppression on repeat broken bytes, **size-change at unchanged mtime** (Codex P2 from PR #16), file vanish silent no-op
- Uses `(st_mtime, st_size)` tuple as the change key — robust on filesystems with coarse mtime resolution / mtime-preserving copies (NFS, rsync `-t`, overlayfs)
- Bad-reload paths emit `daedalus.config_reload_failed` and keep last-known-good without crashing the watcher

## Tick-loop integration deferred

The plan's final task wired `ConfigWatcher.poll()` into the tick. Investigation shows the actual tick is a one-shot CLI invocation (`python3 -m workflows.code_review tick`) — there's no long-running daemon to call `.poll()` from. Daedalus's existing CLI invocation already reloads `workflow.yaml` on every tick, so Symphony §6.2 "detect changes and re-apply without restart" is **already satisfied** by the CLI architecture.

This PR ships `ConfigWatcher` as a primitive ready for a future daemon-mode entry point (e.g. `daedalus serve` for the HTTP status surface in S-6). Until then, the implicit hot-reload from per-tick CLI invocation provides equivalent semantics.

## Plan-vs-reality fix landed in S-2.2

`ConfigWatcher.__post_init__` was changed from `_last_key = (snap.source_mtime, -1)` (plan literal) to seeding from a real `stat()` call. The plan's literal made `test_watcher_poll_no_change_is_noop` impossible to satisfy (first poll always detected a "change" since size != -1). Documented in commit `b0c9b94`.

## Test plan

- [x] `tests/test_config_watcher.py` — 10 passed (covers all bad-reload paths + Codex P2 size-change regression)
- [x] Full suite — 608 passed (598 prior + 10 new). No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)