### PR TITLE
S-4: Event vocabulary alignment (Symphony §10.4)

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -14,6 +14,22 @@ from workflows.code_review.paths import (
     runtime_paths as yoyopod_runtime_paths,
     yoyopod_cli_argv,
 )
+from workflows.code_review.event_taxonomy import (
+    DAEDALUS_ACTIVE_ACTION_COMPLETED,
+    DAEDALUS_ACTIVE_ACTION_FAILED,
+    DAEDALUS_ACTIVE_ACTION_REQUESTED,
+    DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED,
+    DAEDALUS_ERROR_ANALYSIS_COMPLETED,
+    DAEDALUS_ERROR_ANALYSIS_REQUESTED,
+    DAEDALUS_FAILURE_DETECTED,
+    DAEDALUS_LANE_PROMOTED,
+    DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
+    DAEDALUS_RECOVERY_REQUESTED,
+    DAEDALUS_RUNTIME_HEARTBEAT,
+    DAEDALUS_RUNTIME_STARTED,
+    DAEDALUS_SHADOW_ACTION_REQUESTED,
+    canonicalize as canonicalize_event_type,
+)
 from workflows.code_review.status import build_status as build_yoyopod_core_status
 import sys
 
@@ -751,7 +767,7 @@ def set_execution_control(
         event_log_path=paths["event_log_path"],
         event={
             "event_id": f"evt:active_execution_control_updated:{int(bool(active_execution_enabled))}:{now_iso}",
-            "event_type": "active_execution_control_updated",
+            "event_type": DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
@@ -839,7 +855,7 @@ def bootstrap_runtime(
         conn.close()
     event = {
         "event_id": f"evt:daedalus_runtime_started:{instance_id}:{now_iso}",
-        "event_type": "daedalus_runtime_started",
+        "event_type": DAEDALUS_RUNTIME_STARTED,
         "event_version": 1,
         "created_at": now_iso,
         "producer": "Daedalus_Runtime",
@@ -1134,7 +1150,7 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
         event_log_path=paths["event_log_path"],
         event={
             "event_id": f"evt:lane_promoted:{lane_id}:{now_iso}",
-            "event_type": "lane_promoted",
+            "event_type": DAEDALUS_LANE_PROMOTED,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Legacy_Watchdog_Shadow",
@@ -1363,7 +1379,7 @@ def persist_shadow_actions(*, workflow_root: Path, lane_id: str, now_iso: str | 
                 persisted.append({**action, "action_id": action_id})
                 events_to_emit.append({
                     "event_id": f"evt:shadow_action_requested:{lane_id}:{action['action_type']}:{now_iso}:{idx}",
-                    "event_type": "shadow_action_requested",
+                    "event_type": DAEDALUS_SHADOW_ACTION_REQUESTED,
                     "event_version": 1,
                     "created_at": now_iso,
                     "producer": "Workflow_Orchestrator",
@@ -1497,7 +1513,7 @@ def request_active_actions_for_lane(*, workflow_root: Path, lane_id: str, now_is
                 persisted.append(persisted_action)
                 events_to_emit.append({
                     "event_id": f"evt:active_action_requested:{lane_id}:{action['action_type']}:{now_iso}:{idx}",
-                    "event_type": "active_action_requested",
+                    "event_type": DAEDALUS_ACTIVE_ACTION_REQUESTED,
                     "event_version": 1,
                     "created_at": now_iso,
                     "producer": "Workflow_Orchestrator",
@@ -1917,7 +1933,7 @@ def reap_stuck_dispatched_actions(*, workflow_root: Path, lane_id: str, now_iso:
                 events_to_emit.append(
                     {
                         "event_id": f"evt:recovery_requested:dispatch-timeout:{failure_id}:{now_iso}",
-                        "event_type": "recovery_requested",
+                        "event_type": DAEDALUS_RECOVERY_REQUESTED,
                         "event_version": 1,
                         "created_at": now_iso,
                         "producer": "Workflow_Orchestrator",
@@ -1951,7 +1967,7 @@ def reap_stuck_dispatched_actions(*, workflow_root: Path, lane_id: str, now_iso:
                 events_to_emit.append(
                     {
                         "event_id": f"evt:operator_attention_required:dispatch-timeout:{failure_id}:{now_iso}",
-                        "event_type": "operator_attention_required",
+                        "event_type": DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
                         "event_version": 1,
                         "created_at": now_iso,
                         "producer": "Workflow_Orchestrator",
@@ -1972,7 +1988,7 @@ def reap_stuck_dispatched_actions(*, workflow_root: Path, lane_id: str, now_iso:
             events_to_emit.append(
                 {
                     "event_id": f"evt:active_action_failed:dispatch-timeout:{failure_id}:{now_iso}",
-                    "event_type": "active_action_failed",
+                    "event_type": DAEDALUS_ACTIVE_ACTION_FAILED,
                     "event_version": 1,
                     "created_at": now_iso,
                     "producer": "Workflow_Orchestrator",
@@ -2764,7 +2780,7 @@ def _analyze_ambiguous_failure(
     events = [
         {
             "event_id": f"evt:error_analysis_requested:{failure_id}:{now_iso}",
-            "event_type": "error_analysis_requested",
+            "event_type": DAEDALUS_ERROR_ANALYSIS_REQUESTED,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
@@ -2810,7 +2826,7 @@ def _analyze_ambiguous_failure(
     events.append(
         {
             "event_id": f"evt:error_analysis_completed:{failure_id}:{now_iso}",
-            "event_type": "error_analysis_completed",
+            "event_type": DAEDALUS_ERROR_ANALYSIS_COMPLETED,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
@@ -3145,7 +3161,7 @@ def execute_requested_action(
             event_log_path=paths["event_log_path"],
             event={
                 "event_id": f"evt:active_action_failed:{action_id}:{now_iso}",
-                "event_type": "active_action_failed",
+                "event_type": DAEDALUS_ACTIVE_ACTION_FAILED,
                 "event_version": 1,
                 "created_at": now_iso,
                 "producer": "Workflow_Orchestrator",
@@ -3163,7 +3179,7 @@ def execute_requested_action(
             event_log_path=paths["event_log_path"],
             event={
                 "event_id": f"evt:failure_detected:{action_id}:{now_iso}",
-                "event_type": "failure_detected",
+                "event_type": DAEDALUS_FAILURE_DETECTED,
                 "event_version": 1,
                 "created_at": now_iso,
                 "producer": "Workflow_Orchestrator",
@@ -3198,7 +3214,7 @@ def execute_requested_action(
                 event_log_path=paths["event_log_path"],
                 event={
                     "event_id": f"evt:active_action_requested:{recovery_action['action_id']}:{now_iso}",
-                    "event_type": "active_action_requested",
+                    "event_type": DAEDALUS_ACTIVE_ACTION_REQUESTED,
                     "event_version": 1,
                     "created_at": now_iso,
                     "producer": "Workflow_Orchestrator",
@@ -3222,7 +3238,7 @@ def execute_requested_action(
                 event_log_path=paths["event_log_path"],
                 event={
                     "event_id": f"evt:operator_attention_required:{action_id}:{now_iso}",
-                    "event_type": "operator_attention_required",
+                    "event_type": DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
                     "event_version": 1,
                     "created_at": now_iso,
                     "producer": "Workflow_Orchestrator",
@@ -3247,7 +3263,7 @@ def execute_requested_action(
         event_log_path=paths["event_log_path"],
         event={
             "event_id": f"evt:active_action_completed:{action_id}:{now_iso}",
-            "event_type": "active_action_completed",
+            "event_type": DAEDALUS_ACTIVE_ACTION_COMPLETED,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
@@ -3332,7 +3348,7 @@ def refresh_runtime_lease(*, workflow_root: Path, instance_id: str, now_iso: str
         event_log_path=paths["event_log_path"],
         event={
             "event_id": f"evt:daedalus_runtime_heartbeat:{instance_id}:{now_iso}",
-            "event_type": "daedalus_runtime_heartbeat",
+            "event_type": DAEDALUS_RUNTIME_HEARTBEAT,
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Daedalus_Runtime",
@@ -3418,7 +3434,7 @@ def reconcile_stalled_recoveries(*, workflow_root: Path, lane_id: str, now_iso: 
                 events_to_emit.append(
                     {
                         "event_id": f"evt:operator_attention_required:stalled:{failure.get('failure_id')}:{now_iso}",
-                        "event_type": "operator_attention_required",
+                        "event_type": DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
                         "event_version": 1,
                         "created_at": now_iso,
                         "producer": "Workflow_Orchestrator",

--- a/runtime.py
+++ b/runtime.py
@@ -2424,7 +2424,7 @@ def _recent_relay_events_for_lane(*, event_log_path: Path, lane_id: str | None, 
         selected.append(
             {
                 "event_id": entry.get("event_id"),
-                "event_type": entry.get("event_type"),
+                "event_type": canonicalize_event_type(entry.get("event_type") or ""),
                 "created_at": entry.get("created_at"),
                 "causal_action_id": entry.get("causal_action_id"),
             }

--- a/tests/test_event_taxonomy.py
+++ b/tests/test_event_taxonomy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 def test_canonical_constants_present():
     from workflows.code_review import event_taxonomy as et
 
-    # Symphony bare names
+    # Symphony bare names (forward-use; no current writer emits these)
     assert et.SESSION_STARTED == "session_started"
     assert et.TURN_COMPLETED == "turn_completed"
     assert et.TURN_FAILED == "turn_failed"
@@ -21,11 +21,24 @@ def test_daedalus_native_constants_have_prefix():
     from workflows.code_review import event_taxonomy as et
 
     daedalus_natives = [
-        et.DAEDALUS_LANE_CLAIMED, et.DAEDALUS_LANE_RELEASED,
-        et.DAEDALUS_REPAIR_HANDOFF, et.DAEDALUS_REVIEW_LANDED,
-        et.DAEDALUS_VERDICT_PUBLISHED, et.DAEDALUS_CONFIG_RELOADED,
-        et.DAEDALUS_CONFIG_RELOAD_FAILED, et.DAEDALUS_DISPATCH_SKIPPED,
-        et.DAEDALUS_STALL_DETECTED, et.DAEDALUS_STALL_TERMINATED,
+        et.DAEDALUS_RUNTIME_STARTED,
+        et.DAEDALUS_RUNTIME_HEARTBEAT,
+        et.DAEDALUS_LANE_PROMOTED,
+        et.DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED,
+        et.DAEDALUS_SHADOW_ACTION_REQUESTED,
+        et.DAEDALUS_ACTIVE_ACTION_REQUESTED,
+        et.DAEDALUS_ACTIVE_ACTION_COMPLETED,
+        et.DAEDALUS_ACTIVE_ACTION_FAILED,
+        et.DAEDALUS_RECOVERY_REQUESTED,
+        et.DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
+        et.DAEDALUS_FAILURE_DETECTED,
+        et.DAEDALUS_ERROR_ANALYSIS_REQUESTED,
+        et.DAEDALUS_ERROR_ANALYSIS_COMPLETED,
+        et.DAEDALUS_CONFIG_RELOADED,
+        et.DAEDALUS_CONFIG_RELOAD_FAILED,
+        et.DAEDALUS_DISPATCH_SKIPPED,
+        et.DAEDALUS_STALL_DETECTED,
+        et.DAEDALUS_STALL_TERMINATED,
         et.DAEDALUS_REFRESH_REQUESTED,
     ]
     for name in daedalus_natives:
@@ -33,21 +46,30 @@ def test_daedalus_native_constants_have_prefix():
 
 
 def test_canonicalize_passes_canonical_names_through():
-    from workflows.code_review.event_taxonomy import canonicalize, TURN_COMPLETED
+    from workflows.code_review.event_taxonomy import canonicalize, TURN_COMPLETED, DAEDALUS_LANE_PROMOTED
 
     assert canonicalize(TURN_COMPLETED) == TURN_COMPLETED
+    assert canonicalize(DAEDALUS_LANE_PROMOTED) == DAEDALUS_LANE_PROMOTED
     assert canonicalize("session_started") == "session_started"
 
 
 def test_canonicalize_resolves_legacy_aliases():
+    """Pre-rename Daedalus orchestration names get resolved to daedalus.* canonical."""
     from workflows.code_review.event_taxonomy import canonicalize
 
-    assert canonicalize("claude_review_started") == "session_started"
-    assert canonicalize("claude_review_completed") == "turn_completed"
-    assert canonicalize("claude_review_failed") == "turn_failed"
-    assert canonicalize("codex_handoff_dispatched") == "daedalus.repair_handoff_dispatched"
-    assert canonicalize("internal_review_started") == "session_started"
-    assert canonicalize("internal_review_completed") == "turn_completed"
+    assert canonicalize("daedalus_runtime_started") == "daedalus.runtime_started"
+    assert canonicalize("daedalus_runtime_heartbeat") == "daedalus.runtime_heartbeat"
+    assert canonicalize("lane_promoted") == "daedalus.lane_promoted"
+    assert canonicalize("active_execution_control_updated") == "daedalus.active_execution_control_updated"
+    assert canonicalize("shadow_action_requested") == "daedalus.shadow_action_requested"
+    assert canonicalize("active_action_requested") == "daedalus.active_action_requested"
+    assert canonicalize("active_action_completed") == "daedalus.active_action_completed"
+    assert canonicalize("active_action_failed") == "daedalus.active_action_failed"
+    assert canonicalize("recovery_requested") == "daedalus.recovery_requested"
+    assert canonicalize("operator_attention_required") == "daedalus.operator_attention_required"
+    assert canonicalize("failure_detected") == "daedalus.failure_detected"
+    assert canonicalize("error_analysis_requested") == "daedalus.error_analysis_requested"
+    assert canonicalize("error_analysis_completed") == "daedalus.error_analysis_completed"
 
 
 def test_canonicalize_unknown_passthrough():
@@ -57,48 +79,50 @@ def test_canonicalize_unknown_passthrough():
 
 
 def test_event_aliases_table_integrity():
-    """Every legacy name maps to a known canonical."""
+    """Every legacy alias resolves to a string starting with 'daedalus.' (the
+    canonical namespace for Daedalus-native orchestration events that this
+    rename pass formalizes)."""
     from workflows.code_review import event_taxonomy as et
 
-    canonical_names = {
-        v for k, v in vars(et).items()
-        if isinstance(v, str) and (v == k.lower() or v.startswith("daedalus."))
-    }
     for legacy, canonical in et.EVENT_ALIASES.items():
-        assert canonical in canonical_names or canonical.startswith("daedalus.") or "_" in canonical, \
-            f"alias {legacy!r} -> {canonical!r} not a known canonical name"
+        assert canonical.startswith("daedalus."), \
+            f"alias {legacy!r} -> {canonical!r} must resolve to a daedalus.* canonical"
 
 
 def test_round_trip_canonical_writer_reader(tmp_path):
-    """Writer writes canonical; reader reads canonical via canonicalize."""
+    """Writer writes canonical; reader reads canonical via canonicalize.
+
+    Daedalus's append_daedalus_event uses field 'event_type' (not 'type');
+    test mirrors that schema.
+    """
     import json
     from workflows.code_review.event_taxonomy import (
-        canonicalize, TURN_COMPLETED, DAEDALUS_LANE_CLAIMED,
+        canonicalize, DAEDALUS_LANE_PROMOTED, DAEDALUS_RUNTIME_STARTED,
     )
 
     log = tmp_path / "events.jsonl"
     with log.open("w") as f:
-        f.write(json.dumps({"type": TURN_COMPLETED}) + "\n")
-        f.write(json.dumps({"type": DAEDALUS_LANE_CLAIMED}) + "\n")
+        f.write(json.dumps({"event_type": DAEDALUS_LANE_PROMOTED}) + "\n")
+        f.write(json.dumps({"event_type": DAEDALUS_RUNTIME_STARTED}) + "\n")
 
     seen = []
     for line in log.read_text().splitlines():
         e = json.loads(line)
-        seen.append(canonicalize(e["type"]))
-    assert seen == [TURN_COMPLETED, DAEDALUS_LANE_CLAIMED]
+        seen.append(canonicalize(e["event_type"]))
+    assert seen == [DAEDALUS_LANE_PROMOTED, DAEDALUS_RUNTIME_STARTED]
 
 
 def test_legacy_log_lines_canonicalize_on_read(tmp_path):
-    """Old jsonl files with legacy names still resolve through canonicalize."""
+    """Old jsonl files with bare Daedalus names still resolve through canonicalize."""
     import json
     from workflows.code_review.event_taxonomy import (
-        canonicalize, SESSION_STARTED, DAEDALUS_REPAIR_HANDOFF,
+        canonicalize, DAEDALUS_LANE_PROMOTED, DAEDALUS_RUNTIME_STARTED,
     )
 
     log = tmp_path / "events.jsonl"
     log.write_text(
-        json.dumps({"type": "claude_review_started"}) + "\n" +
-        json.dumps({"type": "codex_handoff_dispatched"}) + "\n"
+        json.dumps({"event_type": "lane_promoted"}) + "\n" +
+        json.dumps({"event_type": "daedalus_runtime_started"}) + "\n"
     )
-    canon = [canonicalize(json.loads(l)["type"]) for l in log.read_text().splitlines()]
-    assert canon == [SESSION_STARTED, DAEDALUS_REPAIR_HANDOFF]
+    canon = [canonicalize(json.loads(l)["event_type"]) for l in log.read_text().splitlines()]
+    assert canon == [DAEDALUS_LANE_PROMOTED, DAEDALUS_RUNTIME_STARTED]

--- a/tests/test_event_taxonomy.py
+++ b/tests/test_event_taxonomy.py
@@ -126,3 +126,45 @@ def test_legacy_log_lines_canonicalize_on_read(tmp_path):
     )
     canon = [canonicalize(json.loads(l)["event_type"]) for l in log.read_text().splitlines()]
     assert canon == [DAEDALUS_LANE_PROMOTED, DAEDALUS_RUNTIME_STARTED]
+
+
+def test_runtime_py_emits_only_canonical_event_types():
+    """AST scan of runtime.py: every dict literal {"event_type": "..."}
+    has its value supplied by an event_taxonomy constant, never a bare
+    string literal. Regression for the S-4 rename pass.
+    """
+    import ast
+    import pathlib
+    from workflows.code_review import event_taxonomy as et
+
+    canonical_values = {
+        v for v in vars(et).values()
+        if isinstance(v, str) and (v.startswith("daedalus.") or "_" not in v or v in {
+            et.SESSION_STARTED, et.TURN_COMPLETED, et.TURN_FAILED,
+            et.TURN_CANCELLED, et.TURN_INPUT_REQUIRED, et.NOTIFICATION,
+            et.UNSUPPORTED_TOOL_CALL, et.MALFORMED, et.STARTUP_FAILED,
+        })
+    }
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    runtime_src = (repo_root / "runtime.py").read_text()
+    tree = ast.parse(runtime_src)
+
+    bare_literal_sites: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "event_type"
+                    and isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                ):
+                    if value.value not in canonical_values:
+                        bare_literal_sites.append((value.lineno, value.value))
+
+    assert bare_literal_sites == [], (
+        f"runtime.py contains bare event_type string literals that aren't "
+        f"event_taxonomy canonicals: {bare_literal_sites}. Use a DAEDALUS_* "
+        f"constant from workflows.code_review.event_taxonomy instead."
+    )

--- a/tests/test_event_taxonomy.py
+++ b/tests/test_event_taxonomy.py
@@ -67,3 +67,38 @@ def test_event_aliases_table_integrity():
     for legacy, canonical in et.EVENT_ALIASES.items():
         assert canonical in canonical_names or canonical.startswith("daedalus.") or "_" in canonical, \
             f"alias {legacy!r} -> {canonical!r} not a known canonical name"
+
+
+def test_round_trip_canonical_writer_reader(tmp_path):
+    """Writer writes canonical; reader reads canonical via canonicalize."""
+    import json
+    from workflows.code_review.event_taxonomy import (
+        canonicalize, TURN_COMPLETED, DAEDALUS_LANE_CLAIMED,
+    )
+
+    log = tmp_path / "events.jsonl"
+    with log.open("w") as f:
+        f.write(json.dumps({"type": TURN_COMPLETED}) + "\n")
+        f.write(json.dumps({"type": DAEDALUS_LANE_CLAIMED}) + "\n")
+
+    seen = []
+    for line in log.read_text().splitlines():
+        e = json.loads(line)
+        seen.append(canonicalize(e["type"]))
+    assert seen == [TURN_COMPLETED, DAEDALUS_LANE_CLAIMED]
+
+
+def test_legacy_log_lines_canonicalize_on_read(tmp_path):
+    """Old jsonl files with legacy names still resolve through canonicalize."""
+    import json
+    from workflows.code_review.event_taxonomy import (
+        canonicalize, SESSION_STARTED, DAEDALUS_REPAIR_HANDOFF,
+    )
+
+    log = tmp_path / "events.jsonl"
+    log.write_text(
+        json.dumps({"type": "claude_review_started"}) + "\n" +
+        json.dumps({"type": "codex_handoff_dispatched"}) + "\n"
+    )
+    canon = [canonicalize(json.loads(l)["type"]) for l in log.read_text().splitlines()]
+    assert canon == [SESSION_STARTED, DAEDALUS_REPAIR_HANDOFF]

--- a/tests/test_event_taxonomy.py
+++ b/tests/test_event_taxonomy.py
@@ -1,0 +1,69 @@
+"""S-4 tests: event vocabulary alignment — Symphony §10.4."""
+from __future__ import annotations
+
+
+def test_canonical_constants_present():
+    from workflows.code_review import event_taxonomy as et
+
+    # Symphony bare names
+    assert et.SESSION_STARTED == "session_started"
+    assert et.TURN_COMPLETED == "turn_completed"
+    assert et.TURN_FAILED == "turn_failed"
+    assert et.TURN_CANCELLED == "turn_cancelled"
+    assert et.TURN_INPUT_REQUIRED == "turn_input_required"
+    assert et.NOTIFICATION == "notification"
+    assert et.UNSUPPORTED_TOOL_CALL == "unsupported_tool_call"
+    assert et.MALFORMED == "malformed"
+    assert et.STARTUP_FAILED == "startup_failed"
+
+
+def test_daedalus_native_constants_have_prefix():
+    from workflows.code_review import event_taxonomy as et
+
+    daedalus_natives = [
+        et.DAEDALUS_LANE_CLAIMED, et.DAEDALUS_LANE_RELEASED,
+        et.DAEDALUS_REPAIR_HANDOFF, et.DAEDALUS_REVIEW_LANDED,
+        et.DAEDALUS_VERDICT_PUBLISHED, et.DAEDALUS_CONFIG_RELOADED,
+        et.DAEDALUS_CONFIG_RELOAD_FAILED, et.DAEDALUS_DISPATCH_SKIPPED,
+        et.DAEDALUS_STALL_DETECTED, et.DAEDALUS_STALL_TERMINATED,
+        et.DAEDALUS_REFRESH_REQUESTED,
+    ]
+    for name in daedalus_natives:
+        assert name.startswith("daedalus."), f"{name!r} missing daedalus. prefix"
+
+
+def test_canonicalize_passes_canonical_names_through():
+    from workflows.code_review.event_taxonomy import canonicalize, TURN_COMPLETED
+
+    assert canonicalize(TURN_COMPLETED) == TURN_COMPLETED
+    assert canonicalize("session_started") == "session_started"
+
+
+def test_canonicalize_resolves_legacy_aliases():
+    from workflows.code_review.event_taxonomy import canonicalize
+
+    assert canonicalize("claude_review_started") == "session_started"
+    assert canonicalize("claude_review_completed") == "turn_completed"
+    assert canonicalize("claude_review_failed") == "turn_failed"
+    assert canonicalize("codex_handoff_dispatched") == "daedalus.repair_handoff_dispatched"
+    assert canonicalize("internal_review_started") == "session_started"
+    assert canonicalize("internal_review_completed") == "turn_completed"
+
+
+def test_canonicalize_unknown_passthrough():
+    from workflows.code_review.event_taxonomy import canonicalize
+
+    assert canonicalize("totally_unknown_event") == "totally_unknown_event"
+
+
+def test_event_aliases_table_integrity():
+    """Every legacy name maps to a known canonical."""
+    from workflows.code_review import event_taxonomy as et
+
+    canonical_names = {
+        v for k, v in vars(et).items()
+        if isinstance(v, str) and (v == k.lower() or v.startswith("daedalus."))
+    }
+    for legacy, canonical in et.EVENT_ALIASES.items():
+        assert canonical in canonical_names or canonical.startswith("daedalus.") or "_" in canonical, \
+            f"alias {legacy!r} -> {canonical!r} not a known canonical name"

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -236,7 +236,7 @@ def test_request_active_actions_event_payload_uses_retry_count(runtime_module, t
     assert actions[0]["recovery_attempt_count"] == 1
 
     event_lines = paths["event_log_path"].read_text(encoding="utf-8").strip().splitlines()
-    active_action_requested = [json.loads(line) for line in event_lines if json.loads(line).get("event_type") == "active_action_requested"]
+    active_action_requested = [json.loads(line) for line in event_lines if json.loads(line).get("event_type") == "daedalus.active_action_requested"]
     assert active_action_requested[-1]["payload"]["retry_count"] == 1
     assert active_action_requested[-1]["payload"]["recovery_attempt_count"] == 1
 

--- a/workflows/code_review/event_taxonomy.py
+++ b/workflows/code_review/event_taxonomy.py
@@ -5,16 +5,24 @@ emit only constants from this module; readers (status.py, observability.py,
 watch.py, server views) wrap event-type reads in `canonicalize()` so old
 log files keep working during the one-release alias window.
 
-Design:
-- Symphony's bare session/turn lifecycle names (session_started, …)
-- Daedalus-native orchestration events under `daedalus.*` prefix
-- EVENT_ALIASES maps legacy Daedalus event names to their new canonical
-  equivalents. Readers consult this map; writers do not.
+Design notes:
+- Daedalus's existing orchestration events (`daedalus_runtime_started`,
+  `lane_promoted`, `active_action_requested`, etc.) are renamed under the
+  `daedalus.*` namespace so they don't collide with Symphony's bare
+  session/turn names that may be added later.
+- Symphony's bare session/turn lifecycle constants (`session_started`,
+  `turn_completed`, …) are defined here for FORWARD use by future
+  agent-runner integration. Today's `runtime.py` writers don't emit
+  them — they emit Daedalus-orchestration events. Code that wraps
+  Codex / Claude session lifecycles will adopt these names later.
+- `EVENT_ALIASES` maps legacy bare names (the strings actually present in
+  log files written before this rename) to canonical `daedalus.*` forms.
 """
 from __future__ import annotations
 
 
-# ---- Symphony §10.4 session/turn-level events ----
+# ---- Symphony §10.4 session/turn-level events (forward use; not emitted
+#      by runtime.py today — reserved for future agent-runner integration) ----
 SESSION_STARTED       = "session_started"
 TURN_COMPLETED        = "turn_completed"
 TURN_FAILED           = "turn_failed"
@@ -25,33 +33,53 @@ UNSUPPORTED_TOOL_CALL = "unsupported_tool_call"
 MALFORMED             = "malformed"
 STARTUP_FAILED        = "startup_failed"
 
-# ---- Daedalus-native events (no Symphony equivalent) ----
-DAEDALUS_LANE_CLAIMED         = "daedalus.lane_claimed"
-DAEDALUS_LANE_RELEASED        = "daedalus.lane_released"
-DAEDALUS_REPAIR_HANDOFF       = "daedalus.repair_handoff_dispatched"
-DAEDALUS_REVIEW_LANDED        = "daedalus.review_landed"
-DAEDALUS_VERDICT_PUBLISHED    = "daedalus.verdict_published"
-DAEDALUS_CONFIG_RELOADED      = "daedalus.config_reloaded"
-DAEDALUS_CONFIG_RELOAD_FAILED = "daedalus.config_reload_failed"
-DAEDALUS_DISPATCH_SKIPPED     = "daedalus.dispatch_skipped"
-DAEDALUS_STALL_DETECTED       = "daedalus.stall_detected"
-DAEDALUS_STALL_TERMINATED     = "daedalus.stall_terminated"
-DAEDALUS_REFRESH_REQUESTED    = "daedalus.refresh_requested"
+
+# ---- Daedalus-native orchestration events (canonical, prefixed). ----
+# These cover the 13 distinct event_type literals currently emitted by
+# runtime.py via append_daedalus_event.
+DAEDALUS_RUNTIME_STARTED              = "daedalus.runtime_started"
+DAEDALUS_RUNTIME_HEARTBEAT            = "daedalus.runtime_heartbeat"
+DAEDALUS_LANE_PROMOTED                = "daedalus.lane_promoted"
+DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED = "daedalus.active_execution_control_updated"
+DAEDALUS_SHADOW_ACTION_REQUESTED      = "daedalus.shadow_action_requested"
+DAEDALUS_ACTIVE_ACTION_REQUESTED      = "daedalus.active_action_requested"
+DAEDALUS_ACTIVE_ACTION_COMPLETED      = "daedalus.active_action_completed"
+DAEDALUS_ACTIVE_ACTION_FAILED         = "daedalus.active_action_failed"
+DAEDALUS_RECOVERY_REQUESTED           = "daedalus.recovery_requested"
+DAEDALUS_OPERATOR_ATTENTION_REQUIRED  = "daedalus.operator_attention_required"
+DAEDALUS_FAILURE_DETECTED             = "daedalus.failure_detected"
+DAEDALUS_ERROR_ANALYSIS_REQUESTED     = "daedalus.error_analysis_requested"
+DAEDALUS_ERROR_ANALYSIS_COMPLETED     = "daedalus.error_analysis_completed"
+
+# Daedalus-native events introduced by other Symphony-conformance phases
+# (declared here for the single-source-of-truth invariant; emitted by
+# code added in S-2 / S-3 / S-5 / S-6).
+DAEDALUS_CONFIG_RELOADED              = "daedalus.config_reloaded"
+DAEDALUS_CONFIG_RELOAD_FAILED         = "daedalus.config_reload_failed"
+DAEDALUS_DISPATCH_SKIPPED             = "daedalus.dispatch_skipped"
+DAEDALUS_STALL_DETECTED               = "daedalus.stall_detected"
+DAEDALUS_STALL_TERMINATED             = "daedalus.stall_terminated"
+DAEDALUS_REFRESH_REQUESTED            = "daedalus.refresh_requested"
 
 
-# ---- One-release alias window: legacy -> canonical ----
+# ---- One-release alias window: legacy bare names -> canonical prefixed. ----
+# Pre-rename log files contain the bare Daedalus names; readers normalize
+# via canonicalize() so dashboards, observability filters, and tests
+# that consume daedalus-events.jsonl keep working across the rollout.
 EVENT_ALIASES: dict[str, str] = {
-    "claude_review_started":     SESSION_STARTED,
-    "claude_review_completed":   TURN_COMPLETED,
-    "claude_review_failed":      TURN_FAILED,
-    "codex_handoff_dispatched":  DAEDALUS_REPAIR_HANDOFF,
-    "internal_review_started":   SESSION_STARTED,
-    "internal_review_completed": TURN_COMPLETED,
-    "internal_review_failed":    TURN_FAILED,
-    "external_review_landed":    DAEDALUS_REVIEW_LANDED,
-    "verdict_published":         DAEDALUS_VERDICT_PUBLISHED,
-    "lane_claimed":              DAEDALUS_LANE_CLAIMED,
-    "lane_released":             DAEDALUS_LANE_RELEASED,
+    "daedalus_runtime_started":            DAEDALUS_RUNTIME_STARTED,
+    "daedalus_runtime_heartbeat":          DAEDALUS_RUNTIME_HEARTBEAT,
+    "lane_promoted":                       DAEDALUS_LANE_PROMOTED,
+    "active_execution_control_updated":    DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED,
+    "shadow_action_requested":             DAEDALUS_SHADOW_ACTION_REQUESTED,
+    "active_action_requested":             DAEDALUS_ACTIVE_ACTION_REQUESTED,
+    "active_action_completed":             DAEDALUS_ACTIVE_ACTION_COMPLETED,
+    "active_action_failed":                DAEDALUS_ACTIVE_ACTION_FAILED,
+    "recovery_requested":                  DAEDALUS_RECOVERY_REQUESTED,
+    "operator_attention_required":         DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
+    "failure_detected":                    DAEDALUS_FAILURE_DETECTED,
+    "error_analysis_requested":            DAEDALUS_ERROR_ANALYSIS_REQUESTED,
+    "error_analysis_completed":            DAEDALUS_ERROR_ANALYSIS_COMPLETED,
 }
 
 
@@ -59,5 +87,7 @@ def canonicalize(event_type: str) -> str:
     """Resolve a possibly-legacy event-type string to its canonical form.
 
     Idempotent for already-canonical names. Unknown names pass through
-    unchanged so readers don't lose information."""
+    unchanged so readers don't lose information about events emitted by
+    code paths added after the alias map was last updated.
+    """
     return EVENT_ALIASES.get(event_type, event_type)

--- a/workflows/code_review/event_taxonomy.py
+++ b/workflows/code_review/event_taxonomy.py
@@ -1,0 +1,63 @@
+"""Symphony §10.4-aligned event taxonomy.
+
+Single source of truth for canonical event names. Writers (in runtime.py)
+emit only constants from this module; readers (status.py, observability.py,
+watch.py, server views) wrap event-type reads in `canonicalize()` so old
+log files keep working during the one-release alias window.
+
+Design:
+- Symphony's bare session/turn lifecycle names (session_started, …)
+- Daedalus-native orchestration events under `daedalus.*` prefix
+- EVENT_ALIASES maps legacy Daedalus event names to their new canonical
+  equivalents. Readers consult this map; writers do not.
+"""
+from __future__ import annotations
+
+
+# ---- Symphony §10.4 session/turn-level events ----
+SESSION_STARTED       = "session_started"
+TURN_COMPLETED        = "turn_completed"
+TURN_FAILED           = "turn_failed"
+TURN_CANCELLED        = "turn_cancelled"
+TURN_INPUT_REQUIRED   = "turn_input_required"
+NOTIFICATION          = "notification"
+UNSUPPORTED_TOOL_CALL = "unsupported_tool_call"
+MALFORMED             = "malformed"
+STARTUP_FAILED        = "startup_failed"
+
+# ---- Daedalus-native events (no Symphony equivalent) ----
+DAEDALUS_LANE_CLAIMED         = "daedalus.lane_claimed"
+DAEDALUS_LANE_RELEASED        = "daedalus.lane_released"
+DAEDALUS_REPAIR_HANDOFF       = "daedalus.repair_handoff_dispatched"
+DAEDALUS_REVIEW_LANDED        = "daedalus.review_landed"
+DAEDALUS_VERDICT_PUBLISHED    = "daedalus.verdict_published"
+DAEDALUS_CONFIG_RELOADED      = "daedalus.config_reloaded"
+DAEDALUS_CONFIG_RELOAD_FAILED = "daedalus.config_reload_failed"
+DAEDALUS_DISPATCH_SKIPPED     = "daedalus.dispatch_skipped"
+DAEDALUS_STALL_DETECTED       = "daedalus.stall_detected"
+DAEDALUS_STALL_TERMINATED     = "daedalus.stall_terminated"
+DAEDALUS_REFRESH_REQUESTED    = "daedalus.refresh_requested"
+
+
+# ---- One-release alias window: legacy -> canonical ----
+EVENT_ALIASES: dict[str, str] = {
+    "claude_review_started":     SESSION_STARTED,
+    "claude_review_completed":   TURN_COMPLETED,
+    "claude_review_failed":      TURN_FAILED,
+    "codex_handoff_dispatched":  DAEDALUS_REPAIR_HANDOFF,
+    "internal_review_started":   SESSION_STARTED,
+    "internal_review_completed": TURN_COMPLETED,
+    "internal_review_failed":    TURN_FAILED,
+    "external_review_landed":    DAEDALUS_REVIEW_LANDED,
+    "verdict_published":         DAEDALUS_VERDICT_PUBLISHED,
+    "lane_claimed":              DAEDALUS_LANE_CLAIMED,
+    "lane_released":             DAEDALUS_LANE_RELEASED,
+}
+
+
+def canonicalize(event_type: str) -> str:
+    """Resolve a possibly-legacy event-type string to its canonical form.
+
+    Idempotent for already-canonical names. Unknown names pass through
+    unchanged so readers don't lose information."""
+    return EVENT_ALIASES.get(event_type, event_type)


### PR DESCRIPTION
## Summary

Phase S-4 of the [Symphony-conformance pass](https://github.com/attmous/daedalus/pull/16). Aligns Daedalus's event vocabulary with Symphony §10.4 — Daedalus-native orchestration events move under the \`daedalus.*\` namespace; Symphony bare names (\`session_started\`, \`turn_completed\`, …) are reserved for forward use by future agent-runner integration.

- New module \`workflows/code_review/event_taxonomy.py\` — canonical constants + \`canonicalize()\` shim
- 17 \`event_type\` literals in \`runtime.py\` replaced with \`DAEDALUS_*\` constants
- Reader site in \`runtime.py::_recent_relay_events_for_lane\` wraps \`event["event_type"]\` reads in \`canonicalize()\`
- One existing test updated from bare to prefixed canonical (\`active_action_requested\` → \`daedalus.active_action_requested\`)
- 9 new tests in \`tests/test_event_taxonomy.py\` including an **AST regression** that walks \`runtime.py\` and rejects any \`{"event_type": "..."}\` literal whose value isn't an \`event_taxonomy\` canonical

## Plan-vs-reality fix

The original plan's \`EVENT_ALIASES\` listed speculative legacy names (\`claude_review_started\`, \`codex_handoff_dispatched\`, …) that did not exist in \`runtime.py\`. The implementer subagent correctly stopped at S-4.3 per the brief, and the controller corrected \`event_taxonomy.py\` (commit \`c6c89cb\`) with the actual 13 literals from \`runtime.py\` plus the corresponding bare → prefixed alias map. Refactor + AST regression then completed cleanly.

## Files

| File | Change |
|---|---|
| \`workflows/code_review/event_taxonomy.py\` | new (~95 LOC) |
| \`runtime.py\` | 17 literals → constants; 1 reader call site canonicalized; +14 imports |
| \`tests/test_event_taxonomy.py\` | new (9 tests including AST regression) |
| \`tests/test_runtime_tools_alerts.py\` | one bare-name assertion updated to canonical |

## Test plan

- [x] \`tests/test_event_taxonomy.py\` — 9 passed
- [x] AST regression: \`tests/test_event_taxonomy.py::test_runtime_py_emits_only_canonical_event_types\` PASSED
- [x] Full suite — 607 passed (598 prior + 9 new). Pre-existing test_runtime_tools_alerts failure unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)