### PR TITLE
feat(install): add curl-pipe bootstrap script

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Curl-pipe installer for Daedalus.
+# Clones the repo to a cache directory and runs scripts/install.sh.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/attmous/daedalus/main/scripts/bootstrap.sh | bash
+#
+# Pass install flags through:
+#   curl -fsSL .../bootstrap.sh | bash -s -- --hermes-home /path
+#
+# Environment overrides:
+#   DAEDALUS_HOME       clone destination (default: $HOME/.local/share/daedalus)
+#   DAEDALUS_REPO_URL   repo URL (default: upstream)
+
+set -euo pipefail
+
+REPO_URL="${DAEDALUS_REPO_URL:-https://github.com/attmous/daedalus.git}"
+DEST="${DAEDALUS_HOME:-$HOME/.local/share/daedalus}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "error: git is required but not installed" >&2
+  exit 1
+fi
+
+if [ -d "$DEST/.git" ]; then
+  echo "Updating Daedalus at $DEST..."
+  git -C "$DEST" pull --ff-only --quiet
+else
+  echo "Cloning Daedalus to $DEST..."
+  mkdir -p "$(dirname "$DEST")"
+  git clone --depth 1 --quiet "$REPO_URL" "$DEST"
+fi
+
+echo "Running installer..."
+exec "$DEST/scripts/install.sh" "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/bootstrap.sh` so Daedalus can be installed with a single curl one-liner instead of the manual `git clone` + `cd` + `./scripts/install.sh` flow.
- Bootstrap clones (or fast-forwards) the repo to `$HOME/.local/share/daedalus` by default, then exec's the existing `scripts/install.sh` — no changes to the installer itself.

## Usage

Default install:

```bash
curl -fsSL https://raw.githubusercontent.com/attmous/daedalus/main/scripts/bootstrap.sh | bash
```

Pass installer flags through:

```bash
curl -fsSL .../bootstrap.sh | bash -s -- --hermes-home /path/to/hermes-home
```

Override clone destination or repo URL via env vars (useful for forks/CI):

```bash
DAEDALUS_HOME=/opt/daedalus curl -fsSL .../bootstrap.sh | bash
```

## What's not in this PR

- README copy is unchanged. Once this lands, update the install section to lead with the curl one-liner and demote the manual `git clone` flow to a fallback (e.g. inside a `<details>` block).
- A vanity URL (`https://daedalus.dev/install` redirecting to the raw GitHub URL) — needs a domain first.

## Test plan

- [x] `bash -n scripts/bootstrap.sh` — syntax OK
- [x] `shellcheck scripts/bootstrap.sh` — no warnings
- [ ] `DAEDALUS_HOME=/tmp/daedalus-test bash scripts/bootstrap.sh` — end-to-end clone + install on a fresh machine
- [ ] Re-run on existing clone to confirm `git pull --ff-only` path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)