### PR TITLE
docs: fill critical and partial documentation gaps

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,13 +81,18 @@ Every meaningful handoff should survive:
 
 ## 3.1 Core files
 - `__init__.py` — plugin registration
+- `plugin.yaml` — plugin manifest
 - `daedalus/schemas.py` — CLI/slash parser schema
 - `daedalus/tools.py` — operator surface and service helpers
 - `daedalus/runtime.py` — durable Daedalus engine
 - `daedalus/alerts.py` — outage alert logic
-- `plugin.yaml` — plugin manifest
-- `daedalus/skills/operator/SKILL.md` — operator usage guidance
+- `daedalus/watch.py` — TUI frame renderer for `/daedalus watch`
+- `daedalus/watch_sources.py` — watch source aggregation (lanes + alerts + events)
+- `daedalus/formatters.py` — inspection output formatting (status, doctor, shadow-report)
+- `daedalus/migration.py` — relay→daedalus filesystem migration
+- `daedalus/observability_overrides.py` — operator observability config overrides
 - `scripts/install.py` / `scripts/install.sh` — plugin installation
+- `scripts/migrate_config.py` — config path migration helper
 
 ## 3.2 Responsibility split
 
@@ -118,6 +123,20 @@ Implements the real orchestration model:
 
 ### `daedalus/alerts.py`
 Isolates outage alert decision logic from orchestration logic.
+
+### `daedalus/watch.py` + `watch_sources.py`
+Implements the `/daedalus watch` TUI. `watch_sources.py` aggregates three sources into a snapshot dict:
+- `active_lanes` — from SQLite
+- `alert_state` — from `alerts.py` output
+- `recent_events` — from JSONL tail
+
+`watch.py` renders the snapshot into a Rich panel layout. Supports both live mode (1s refresh) and one-shot mode (`--once`).
+
+### `daedalus/formatters.py`
+Human-readable panel renderer for all `/daedalus` inspection commands. Each command (`status`, `doctor`, `shadow-report`, `active-gate-status`, `service-status`, `get-observability`) has a dedicated formatter that builds `Section` + `Row` objects and calls `format_panel`. ANSI color is auto-detected; `--format json` bypasses formatting entirely.
+
+### `daedalus/migration.py` + `observability_overrides.py`
+`migration.py` handles relay→daedalus filesystem renames (idempotent). `observability_overrides.py` reads/writes the `observability-overrides.json` file that lets operators change GitHub-comments behavior without editing `workflow.yaml`.
 
 ---
 

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -1,0 +1,167 @@
+# Actions
+
+An **action** is the atomic unit of work Daedalus queues, executes, and tracks. The wrapper decides *what should happen*; Daedalus decides *how to orchestrate it durably* by translating wrapper semantic actions into execution actions.
+
+---
+
+## Two vocabularies
+
+| Wrapper semantic action | Daedalus execution action |
+|---|---|
+| `run_claude_review` | `request_internal_review` |
+| `publish_ready_pr` | `publish_pr` |
+| `merge_and_promote` | `merge_pr` |
+| `dispatch_codex_turn` | `dispatch_implementation_turn` |
+| `restart_actor_session` | `restart_actor_session` |
+| `dispatch_repair_handoff` | `dispatch_repair_handoff` |
+
+That translation boundary is deliberate. The wrapper speaks **workflow semantics**; Daedalus speaks **execution semantics**.
+
+---
+
+## Action types
+
+### Coder actions
+
+| Action | When dispatched |
+|---|---|
+| `dispatch_implementation_turn` | Lane has an active issue, no PR yet, and the coder session is ready. |
+| `dispatch_repair_handoff` | Reviewer (internal or external) returned findings; the coder must repair. |
+| `restart_actor_session` | Session is stale, wedged, or the operator requested a fresh start. |
+
+### Review actions
+
+| Action | When dispatched |
+|---|---|
+| `request_internal_review` | Local unpublished branch exists and needs Claude gate before publish. |
+
+### PR lifecycle actions
+
+| Action | When dispatched |
+|---|---|
+| `publish_pr` | Local gate passed; create or mark PR ready-for-review. |
+| `push_pr_update` | Coder made new commits after PR exists; push update. |
+| `merge_pr` | External review passed; merge and close issue. |
+
+---
+
+## Action row lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> shadow_requested: shadow tick derives action
+    [*] --> active_requested: active tick derives action
+    shadow_requested --> shadow_written: write shadow row
+    active_requested --> idempotency_check: check active idempotency key
+    idempotency_check --> active_written: key free → write active row
+    idempotency_check --> active_skipped: key taken → skip
+    active_written --> running: dispatch begins
+    running --> completed: success
+    running --> failed: exception / non-zero exit
+    failed --> retry_queued: retry budget remains
+    retry_queued --> active_requested: next tick retries
+    failed --> terminal_failed: retry budget exhausted
+    terminal_failed --> operator_attention: escalate
+```
+
+---
+
+## Idempotency
+
+Every active action has an **idempotency key**:
+
+```
+lane:<id>:<action_type>:<head_sha>
+```
+
+Example:
+```
+lane:220:request_internal_review:abc123def...
+```
+
+### Rules
+
+- **Shadow actions** have no idempotency check — they are purely speculative.
+- **Active actions** are blocked if an un-failed row with the same key exists.
+- **Failed actions** can requeue if `retry_count < max_retries` (see [failures.md](failures.md)).
+- **Completed actions** are ignored; the lane has moved on.
+
+This prevents:
+- Double-dispatching the same review on the same head
+- Re-running `merge_pr` after the PR is already merged
+- Spawning infinite coder sessions for a single issue
+
+---
+
+## Shadow vs active action rows
+
+| Property | Shadow | Active |
+|---|---|---|
+| Table | `lane_actions` (same table) | `lane_actions` (same table) |
+| `mode` column | `shadow` | `active` |
+| Idempotency check | ❌ none | ✅ enforced |
+| Side effects | ❌ none | ✅ dispatched to runtimes |
+| GitHub mutations | ❌ none | ✅ comments, merges, PRs |
+| Purpose | "what would happen" | "what actually happens" |
+
+Shadow rows are written so the operator can diff:
+
+```bash
+/daedalus shadow-report
+```
+
+This compares shadow plan vs active reality to catch policy regressions.
+
+---
+
+## Retry semantics
+
+See [failures.md](failures.md) for the full failure/retry model. At the action level:
+
+- `retry_count` starts at `0`.
+- Each retry attempt increments it.
+- `max_retries` is configured in `workflow.yaml` (default: `3`).
+- The retry reason is recorded: `stall_timeout`, `runtime_error`, `operator_reset`, etc.
+
+---
+
+## Action queue SQL
+
+### Show pending actions for a lane
+
+```sql
+select action_id, action_type, mode, status, retry_count, requested_at
+from lane_actions
+where lane_id='lane:220' and status in ('requested', 'running')
+order by requested_at desc;
+```
+
+### Show action history for a lane
+
+```sql
+select action_id, action_type, mode, status, retry_count, requested_at, completed_at, failed_at
+from lane_actions
+where lane_id='lane:220'
+order by requested_at desc;
+```
+
+### Check idempotency key collision
+
+```sql
+select action_id, status, retry_count
+from lane_actions
+where lane_id='lane:220'
+  and action_type='request_internal_review'
+  and head_sha='abc123def...';
+```
+
+---
+
+## Where this lives in code
+
+- Action dispatch: `daedalus/runtime.py` (look for `request_active_action`, `iterate_active`)
+- Idempotency: `daedalus/runtime.py` (look for `action_idempotency_key`, `can_requeue`)
+- Shadow vs active: `daedalus/runtime.py` (look for `Mode.SHADOW`, `Mode.ACTIVE`)
+- Action execution: `daedalus/workflows/code_review/dispatch.py`
+- Action primitives: `daedalus/workflows/code_review/actions.py`
+- Tests: `tests/test_workflows_code_review_actions.py`, `tests/test_stall_detection.py`

--- a/docs/concepts/comments.md
+++ b/docs/concepts/comments.md
@@ -1,0 +1,126 @@
+# GitHub Comments
+
+Daedalus can publish audit events as **comments on the active PR** (or issue, if no PR exists). This creates a visible audit trail in GitHub itself, so anyone browsing the issue/PR can see what the workflow did and when.
+
+---
+
+## Why comments
+
+- **Transparency:** Humans see workflow activity without running CLI commands.
+- **Debugging:** When something goes wrong, the comment history shows exactly which actions ran.
+- **Low friction:** No separate dashboard needed — the audit trail lives where the work happens.
+
+---
+
+## Enable it
+
+```yaml
+observability:
+  github-comments:
+    enabled: true
+    mode: edit-in-place
+    include-events:
+      - dispatch-implementation-turn
+      - internal-review-completed
+      - publish-ready-pr
+      - push-pr-update
+      - merge-and-promote
+      - operator-attention-transition
+      - operator-attention-recovered
+```
+
+### Resolution precedence
+
+1. **Override file** (`observability-overrides.json`) — set via `/daedalus set-observability`
+2. **`workflow.yaml`** `observability:` block
+3. **Hardcoded defaults** (everything off)
+
+See [observability.md](observability.md) for the full override surface.
+
+---
+
+## Modes
+
+| Mode | Behavior | Best for |
+|---|---|---|
+| `edit-in-place` | One comment per lane; edits it as events arrive. | Clean, compact history. |
+| `append` | New comment for every event. | Full audit trail (noisy). |
+
+### `edit-in-place` detail
+
+The publisher:
+1. Checks if a Daedalus comment already exists on the PR/issue.
+2. If yes: edits the existing comment, appending the new event.
+3. If no: creates a new comment with a header like `<!-- daedalus-comment -->`.
+
+The HTML comment marker makes it easy to find the comment later without relying on exact text matching.
+
+---
+
+## Event filtering
+
+Only events in `include-events` are published. The default whitelist matches design spec §5:
+
+```python
+_DEFAULT_INCLUDE_EVENTS = [
+    "dispatch-implementation-turn",
+    "internal-review-completed",
+    "publish-ready-pr",
+    "push-pr-update",
+    "merge-and-promote",
+    "operator-attention-transition",
+    "operator-attention-recovered",
+]
+```
+
+An **empty list** (`[]`) means firehose — every audit action is rendered. This is useful for debugging only.
+
+---
+
+## Comment format
+
+```markdown
+<!-- daedalus-comment -->
+**Daedalus audit trail**
+
+| Time | Action | Detail |
+|---|---|---|
+| 14:03 | dispatch-implementation-turn | coder-claude-1, 1342→506 tokens |
+| 14:15 | internal-review-completed | pass with 2 findings |
+| 14:20 | publish-ready-pr | PR #123 created |
+```
+
+The table is truncated at ~50 rows to avoid GitHub's comment length limits. Older events are archived to the JSONL log, not lost.
+
+---
+
+## Operator commands
+
+```text
+/daedalus set-observability --workflow code-review --github-comments on
+/daedalus set-observability --workflow code-review --github-comments off
+/daedalus get-observability --workflow code-review
+```
+
+`get-observability` shows:
+- Effective config
+- Which layer won (default / yaml / override)
+- Current mode and event whitelist
+
+---
+
+## Failure handling
+
+- **Comment API failure:** Logged, not retried. The next event will attempt to edit/create again.
+- **PR doesn't exist yet:** Comment is queued in memory and published once the PR exists.
+- **Rate limited:** GitHub API rate limits are respected; the publisher backs off and retries on the next tick.
+
+---
+
+## Where this lives in code
+
+- Comment formatting: `daedalus/workflows/code_review/comments.py`
+- Comment publishing: `daedalus/workflows/code_review/comments_publisher.py`
+- Observability config: `daedalus/workflows/code_review/observability.py`
+- Override surface: `daedalus/observability_overrides.py`
+- Tests: `tests/test_workflow_code_review_comments_*.py`

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -66,6 +66,46 @@ flowchart LR
 
 `workflows.code_review.event_taxonomy.canonicalize(event_type)` resolves either form to the current canonical name.
 
+## Event writer
+
+Events are appended by `daedalus/runtime.py::append_daedalus_event`. The function:
+
+1. Builds the event dict with `type`, `lane_id`, `at`, and `payload`
+2. Atomically appends one JSON line to `daedalus-events.jsonl`
+3. Never blocks on a full disk — if the write fails, the event is dropped and a warning is emitted
+
+### File rotation
+
+The JSONL file is **not rotated automatically**. For long-lived deployments:
+
+- Archive old logs: `mv daedalus-events.jsonl daedalus-events-$(date +%Y%m%d).jsonl`
+- The next event write creates a fresh `daedalus-events.jsonl`
+- No data is lost if you archive while the process is running (append is atomic)
+
+### Event schema
+
+All events share a common envelope:
+
+```json
+{
+  "type": "daedalus.turn_completed",
+  "lane_id": "lane:220",
+  "issue_number": 42,
+  "actor_id": "coder-claude-1",
+  "at": "2026-04-28T14:03:11Z",
+  "payload": { ... }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `type` | ✅ | Canonical event type. |
+| `lane_id` | ❌ | Present for lane-scoped events. |
+| `issue_number` | ❌ | Present for lane-scoped events. |
+| `actor_id` | ❌ | Present for actor-scoped events. |
+| `at` | ✅ | ISO-8601 UTC timestamp. |
+| `payload` | ✅ | Event-specific data. |
+
 ## Reading events efficiently
 
 The dashboard tails the last 20 events on every HTTP hit. Naïve `readlines()` is O(file size); the implementation in `daedalus/workflows/code_review/server/views.py::_read_events_tail` uses an 8 KiB reverse-chunked seek so request cost is bounded regardless of how big the log gets. Same algorithm if you write your own consumer.

--- a/docs/concepts/failures.md
+++ b/docs/concepts/failures.md
@@ -1,0 +1,160 @@
+# Failures
+
+Daedalus models failures as **first-class runtime state**, not as log lines to grep later. When an active action fails, the system persists enough context to decide — automatically or with operator guidance — what happens next.
+
+---
+
+## Why explicit failure state matters
+
+Without it, every retry decision becomes guesswork. With it, the system can answer:
+
+- Did this fail before?
+- Should we retry?
+- Did retry already happen?
+- Has this been superseded?
+- Are we stuck badly enough to require operator attention?
+
+That is the difference between a durable orchestrator and a deadlocked queue with nice branding.
+
+---
+
+## Failure lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> action_requested: tick derives action
+    action_requested --> action_running: dispatch begins
+    action_running --> action_completed: success
+    action_running --> action_failed: exception / non-zero exit
+    action_failed --> retry_queued: retry budget remains
+    retry_queued --> action_requested: next tick retries
+    action_failed --> operator_attention: retry budget exhausted
+    operator_attention --> action_requested: operator resets
+    operator_attention --> archived: operator abandons
+```
+
+States with no outgoing arrows (other than terminal `archived`) keep the lane alive — the loop never crashes, only the current attempt.
+
+---
+
+## Schema
+
+### `failures` table (SQLite)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `failure_id` | string | UUID v4. |
+| `lane_id` | string | FK → `lanes.lane_id`. |
+| `action_id` | string \| null | FK → `lane_actions.action_id`, if the failure originated from an action. |
+| `action_type` | string | e.g. `dispatch_implementation_turn`, `request_internal_review`. |
+| `head_sha` | string \| null | Git head the failure occurred against. |
+| `error_summary` | string | Human-readable one-liner. |
+| `error_detail` | string \| null | Full traceback or stderr. |
+| `retry_count` | int | How many times this action has been retried. |
+| `max_retries` | int | Configured ceiling (default: 3). |
+| `superseded_by` | string \| null | FK → another `failure_id` if this failure was superseded by a later one. |
+| `created_at` | timestamp | When the failure was first recorded. |
+| `resolved_at` | timestamp \| null | When the lane made forward progress again. |
+
+### `lane_actions` table (relevant columns)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `action_id` | string | UUID v4. |
+| `lane_id` | string | FK → `lanes`. |
+| `action_type` | string | Execution action name. |
+| `status` | enum | `requested` / `running` / `completed` / `failed`. |
+| `retry_count` | int | Incremented on each retry attempt. |
+| `idempotency_key` | string | Composite key: `lane_id:action_type:head_sha`. Prevents duplicate active rows. |
+| `requested_at` | timestamp | When the action was queued. |
+| `failed_at` | timestamp \| null | When the failure was recorded. |
+| `completed_at` | timestamp \| null | When success was recorded. |
+
+---
+
+## Idempotency and the lane-220 fix
+
+Two hardening fixes during lane 220 work changed how failures interact with the action queue:
+
+### Fix 1: Failed internal review no longer wedges wrapper state
+
+**Before:** `dispatch_claude_review()` failed after marking review `running` in the wrapper. The wrapper stayed stuck at `running` forever.
+
+**After:** Failure resets the Claude review back to a retryable `pending` state.
+
+### Fix 2: Failed active actions no longer consume the idempotency slot permanently
+
+**Before:** A failed `request_internal_review` action for head `abc123` wrote a `failed` row with idempotency key `lane:220:request_internal_review:abc123`. The next tick saw the key existed and skipped requeue — the lane was deadlocked.
+
+**After:** Failed actions can requeue with an incremented `retry_count`. The idempotency key is relaxed for failed rows: a new active action is allowed if the prior one failed and `retry_count < max_retries`.
+
+---
+
+## Retry policy
+
+Retries are governed by `workflow.yaml`:
+
+```yaml
+retry:
+  max-retries: 3
+  backoff-seconds: 60
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `retry.max-retries` | int ≥ 0 | `3` | `0` disables retries entirely. |
+| `retry.backoff-seconds` | int ≥ 0 | `60` | Minimum wall-clock seconds between retry attempts. |
+
+The backoff is **minimum**, not exact. The next tick after the backoff window expires will retry — so actual delay is `backoff-seconds` plus however long until the next tick.
+
+---
+
+## Failure → operator attention
+
+When `retry_count == max_retries`, the lane transitions to `operator_attention_required`. The operator can:
+
+- `/daedalus analyze-failure --failure-id <id>` — see full context
+- `/workflow code-review tick` — force another attempt (bypasses retry budget)
+- Edit the issue / PR to unblock the lane manually
+- `/workflow code-review pause` — stop processing this lane
+
+---
+
+## SQL debugging
+
+### Show recent failures for a lane
+
+```sql
+select failure_id, action_type, head_sha, retry_count, error_summary, created_at, resolved_at
+from failures
+where lane_id='lane:220'
+order by created_at desc;
+```
+
+### Show active actions that have failed
+
+```sql
+select action_id, action_type, status, retry_count, requested_at, failed_at
+from lane_actions
+where lane_id='lane:220' and status='failed'
+order by failed_at desc;
+```
+
+### Count unresolved failures per lane
+
+```sql
+select lane_id, count(*) as unresolved
+from failures
+where resolved_at is null
+group by lane_id;
+```
+
+---
+
+## Where this lives in code
+
+- Failure tracking: `daedalus/runtime.py` (look for `record_failure`, `resolve_failure`, `retry_eligible`)
+- Action queue: `daedalus/runtime.py` (look for `request_active_action`, `action_idempotency_key`)
+- Retry logic: `daedalus/workflows/code_review/dispatch.py`
+- Operator surface: `daedalus/tools.py` (`analyze-failure` command)
+- Tests: `tests/test_workflows_code_review_actions.py`, `tests/test_stall_detection.py`

--- a/docs/concepts/lanes.md
+++ b/docs/concepts/lanes.md
@@ -51,9 +51,58 @@ States with no outgoing arrows in this diagram (other than terminal `merged` / `
 
 `merged`, `closed`, and `archived` are terminal. The `workflows.code_review.server.views._TERMINAL_LANE_STATUSES` set keeps these out of the operator dashboard. Anything else is "active" for observability purposes.
 
+## Lane selection
+
+Not every labeled issue becomes a lane. `lane_selection.py` filters and ranks issues using the `lane-selection:` block in `workflow.yaml`.
+
+### Config schema
+
+```yaml
+lane-selection:
+  require-labels: ["bug", "ready"]      # must have ALL of these
+  allow-any-of: ["feature", "refactor"]  # must have AT LEAST ONE of these
+  exclude-labels: ["blocked"]            # must have NONE of these
+  priority: ["urgent", "security"]       # boost these to the front
+  tiebreak: "oldest"                     # "oldest" | "newest" | "random"
+```
+
+### Defaults
+
+| Field | Default | Notes |
+|---|---|---|
+| `require-labels` | `[]` | Empty = no required labels. |
+| `allow-any-of` | `[]` | Empty = no restriction. |
+| `exclude-labels` | `[<active-lane-label>]` | Auto-injected so currently-active lanes are never re-picked. |
+| `priority` | `[]` | Empty = no priority boost. |
+| `tiebreak` | `"oldest"` | How to rank candidates after filtering. |
+
+### Selection flow
+
+```mermaid
+flowchart TD
+  A[GitHub issues with active-lane label] --> B{has all require-labels?}
+  B -- no --> Z[skip]
+  B -- yes --> C{has at least one allow-any-of?}
+  C -- no --> Z
+  C -- yes --> D{has any exclude-label?}
+  D -- yes --> Z
+  D -- no --> E[rank by priority, then tiebreak]
+  E --> F[pick top N]
+```
+
+### Workspace binding
+
+Each lane is bound to a **workspace** (a temporary directory under `/tmp/`). The workspace holds:
+- A clone of the target repo
+- `.lane-state.json` — lane-local state
+- `.lane-memo.md` — handoff notes between actors
+
+---
+
 ## Where this lives in code
 
 - Schema: `daedalus/workflows/code_review/migrations.py` (lanes table)
-- Selection: `daedalus/workflows/code_review/lane_selection.py` (which issues become lanes)
+- Selection config: `daedalus/workflows/code_review/lane_selection.py`
+- Selection logic: `daedalus/workflows/code_review/lane_selection.py` + `workspace.py`
 - State transitions: `daedalus/workflows/code_review/workflow.py` + `dispatch.py`
 - Read views: `daedalus/workflows/code_review/server/views.py`

--- a/docs/concepts/migration.md
+++ b/docs/concepts/migration.md
@@ -1,0 +1,160 @@
+# Migration & Cutover
+
+Daedalus was previously known as **hermes-relay**. The rename introduced new state paths, new systemd unit names, and a new plugin registration model. This document covers how to migrate from relay-era deployments and how cutover between shadow and active modes works.
+
+---
+
+## What changed in the rename
+
+| Relay-era | Daedalus |
+|---|---|
+| `hermes-relay` | `daedalus` |
+| `relay.db` | `daedalus.db` |
+| `relay-events.jsonl` | `daedalus-events.jsonl` |
+| `relay-active@.service` | `daedalus-active@.service` |
+| `scripts/yoyopod_workflow.py` | `workflows/__main__.py` (plugin-owned) |
+| `relay/` directory | `daedalus/` directory |
+| `watchdog` terminology | `engine` / `runtime` terminology |
+
+---
+
+## Filesystem migration
+
+### One-shot command
+
+```bash
+/daedalus migrate-filesystem
+```
+
+This renames relay-era state files to daedalus paths:
+- `relay.db` → `daedalus.db`
+- `relay-events.jsonl` → `daedalus-events.jsonl`
+- Legacy control schema JSON → new ownership schema
+
+It is **idempotent** — running it twice is safe.
+
+### Manual fallback
+
+If the command is unavailable, the migration is a simple rename:
+
+```bash
+mv ~/.hermes/workflows/yoyopod/state/relay/relay.db \
+   ~/.hermes/workflows/yoyopod/state/daedalus/daedalus.db
+
+mv ~/.hermes/workflows/yoyopod/memory/relay-events.jsonl \
+   ~/.hermes/workflows/yoyopod/memory/daedalus-events.jsonl
+```
+
+---
+
+## Systemd migration
+
+### One-shot command
+
+```bash
+/daedalus migrate-systemd
+```
+
+This:
+1. Stops `relay-active@yoyopod.service`
+2. Disables it
+3. Installs `daedalus-active@yoyopod.service`
+4. Enables and starts it
+
+### Manual fallback
+
+```bash
+# Stop old
+systemctl --user stop relay-active@yoyopod.service
+systemctl --user disable relay-active@yoyopod.service
+
+# Install new
+python3 ~/.hermes/workflows/yoyopod/.hermes/plugins/daedalus/scripts/install.py
+
+# Start new
+systemctl --user enable daedalus-active@yoyopod.service
+systemctl --user start daedalus-active@yoyopod.service
+```
+
+---
+
+## Config migration
+
+The workflow wrapper CLI moved from `scripts/yoyopod_workflow.py` to `workflows/__main__.py`. If you have cron jobs or aliases pointing at the old path, update them:
+
+```bash
+# Old (retired)
+python3 scripts/yoyopod_workflow.py status --json
+
+# New
+python3 -m workflows --workflow-root ~/.hermes/workflows/yoyopod status --json
+```
+
+The `scripts/migrate_config.py` helper can rewrite paths in shell scripts and systemd units.
+
+---
+
+## Shadow → active cutover
+
+Daedalus runs in **shadow** mode by default after installation. It observes, derives actions, and writes shadow rows — but never dispatches to real runtimes.
+
+### Promotion sequence
+
+```mermaid
+sequenceDiagram
+    participant op as Operator
+    participant rt as Daedalus runtime
+    participant gate as Active gate
+
+    op->>rt: /daedalus status
+    rt-->>op: running (shadow mode)
+
+    op->>rt: /daedalus active-gate-status
+    rt-->>op: gate-ready report
+
+    op->>gate: open gate (manual)
+    op->>rt: /daedalus run-active
+    rt-->>op: running (active mode)
+```
+
+### Gate checks
+
+Before active mode is allowed, `active-gate-status` verifies:
+
+1. **Ownership posture** — `primary_owner = daedalus`
+2. **Active execution** — enabled in config
+3. **Runtime mode** — not already running active elsewhere
+4. **Legacy watchdog** — retired (no split-brain with relay)
+
+If any check fails, the gate is **BLOCKED** and the operator sees exactly why.
+
+---
+
+## Rollback
+
+If active mode causes problems:
+
+```bash
+# Stop active service
+/daedalus service-stop
+
+# Switch back to shadow
+/daedalus run-shadow
+
+# Or disable active execution entirely
+/daedalus set-active-execution --enabled false
+```
+
+The shadow rows remain, so you can diff "what shadow would do" vs "what active did" before attempting promotion again.
+
+---
+
+## Where this lives in code
+
+- Filesystem migration: `daedalus/migration.py`
+- Systemd templates: `daedalus/tools.py` (service-install helpers)
+- Migration scripts: `scripts/migrate_config.py`, `scripts/install.py`
+- Active gate: `daedalus/runtime.py::active_gate_status`
+- Shadow/active modes: `daedalus/runtime.py` (look for `Mode.SHADOW`, `Mode.ACTIVE`)
+- ADR: `docs/adr/ADR-0003-daedalus-rebrand.md`
+- Tests: `tests/test_daedalus_migration.py`, `tests/test_migrate_config.py`

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -1,0 +1,140 @@
+# Observability
+
+Daedalus exposes three operator-facing observability surfaces: the **TUI watch frame**, the **HTTP status server**, and **GitHub comments publishing**. All three read from the same canonical state (SQLite + JSONL events) but serve different consumption patterns.
+
+---
+
+## Three surfaces
+
+| Surface | Use case | Live? | Writable? |
+|---|---|---|---|
+| `/daedalus watch` | Human operator in terminal | Yes (1s refresh) | No |
+| HTTP status server | Dashboard, scripted health checks | Yes (on request) | No (read-only DB) |
+| GitHub comments | Audit trail on the PR/issue | No (event-driven) | Yes (publishes to GitHub) |
+
+---
+
+## TUI watch (`/daedalus watch`)
+
+### What it shows
+
+```
+┌─ Daedalus active lanes ──────────────────────────────────────────────┐
+│ Active lanes                                                         │
+│  Lane          State                GH Issue                           │
+│  lane:220      under_review         #220                             │
+│  lane:221      implementing_local     #221                             │
+│                                                                      │
+│ ⚠️  Active alerts                                                    │
+│  primary=daedalus watchdog=retired issues=active_execution_failures  │
+│                                                                      │
+│ Recent events                                                        │
+│  Time               Source     Event              Detail             │
+│  2026-04-28T14:03   daedalus   turn_completed     coder-claude-1     │
+│  2026-04-28T14:01   daedalus   stall_detected     lane:221           │
+```
+
+### Frame composition
+
+The watch frame is assembled from three sources:
+
+1. **`active_lanes`** — `SELECT * FROM lanes WHERE lane_status NOT IN ('merged', 'closed', 'archived')`
+2. **`alert_state`** — parsed from `daedalus/alerts.py` output
+3. **`recent_events`** — tail of `daedalus-events.jsonl` (last 20, reverse-chunked seek)
+
+### Modes
+
+- **Live mode** (`/daedalus watch`): Refreshes every second until Ctrl-C.
+- **One-shot mode** (`/daedalus watch --once`): Renders one frame and exits. Works in pipes and tests.
+
+### Stale handling
+
+If a source is unreadable, the frame prints `[stale]` in that section but keeps rendering the rest. The watch loop never crashes because one source is down.
+
+---
+
+## HTTP status server
+
+See [http-status.md](http-status.md) for full endpoint documentation. Summary:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/v1/state` | Snapshot — running + retrying lanes, totals, recent events |
+| `GET /api/v1/<identifier>` | Per-lane debug view (`#42`, `42`, or `lane_id`) |
+| `POST /api/v1/refresh` | Trigger immediate tick subprocess |
+| `GET /` | Minimal HTML dashboard |
+
+### Security
+
+- **Localhost only** (`127.0.0.1`). No auth — port access is the auth.
+- **Read-only DB** (`mode=ro` SQLite URI).
+- **Refresh is rate-limited by OS** (subprocess fork).
+
+---
+
+## GitHub comments publishing
+
+Daedalus can publish audit events as comments on the active PR (or issue, if no PR exists). This is **off by default**.
+
+### Enable it
+
+```yaml
+observability:
+  github-comments:
+    enabled: true
+    mode: edit-in-place   # or "append"
+    include-events:
+      - dispatch-implementation-turn
+      - internal-review-completed
+      - publish-ready-pr
+      - push-pr-update
+      - merge-and-promote
+      - operator-attention-transition
+      - operator-attention-recovered
+```
+
+### Resolution precedence
+
+1. **Override file** (`observability-overrides.json`) — set via `/daedalus set-observability`
+2. **`workflow.yaml`** `observability:` block
+3. **Hardcoded defaults** (everything off)
+
+### Modes
+
+| Mode | Behavior |
+|---|---|
+| `edit-in-place` | One comment per lane; edits it as events arrive. |
+| `append` | New comment for every event. |
+
+### Operator commands
+
+```text
+/daedalus set-observability --workflow code-review --github-comments on
+/daedalus set-observability --workflow code-review --github-comments off
+/daedalus get-observability --workflow code-review
+```
+
+---
+
+## Event log (`daedalus-events.jsonl`)
+
+All three surfaces consume the same append-only JSONL event log. Typical events:
+
+```json
+{"type": "daedalus.turn_completed", "lane_id": "lane:220", "actor_id": "coder-claude-1", "at": "2026-04-28T14:03:11Z", "payload": {"model": "opus", "input_tokens": 1342, "output_tokens": 506}}
+```
+
+See [events.md](events.md) for the full taxonomy.
+
+---
+
+## Where this lives in code
+
+- TUI frame renderer: `daedalus/watch.py`
+- Watch source aggregation: `daedalus/watch_sources.py`
+- HTTP server: `daedalus/workflows/code_review/server/`
+- GitHub comments: `daedalus/workflows/code_review/comments.py`, `comments_publisher.py`
+- Observability config: `daedalus/workflows/code_review/observability.py`
+- Override surface: `daedalus/observability_overrides.py`
+- Event writer: `daedalus/runtime.py::append_daedalus_event`
+- Tests: `tests/test_daedalus_watch_render.py`, `tests/test_daedalus_watch_sources.py`, `tests/test_status_server.py`, `tests/test_workflow_code_review_comments_*.py`

--- a/docs/concepts/reviewers.md
+++ b/docs/concepts/reviewers.md
@@ -1,0 +1,176 @@
+# Reviewers
+
+Daedalus orchestrates a **multi-stage review pipeline**. Each stage has a different reviewer role, different gating rules, and different handoff semantics. The goal: no code reaches `main` without passing the right gate at the right time.
+
+---
+
+## Reviewer roles
+
+| Role | Runtime | When active | Gate type |
+|---|---|---|---|
+| **Internal reviewer** | `claude-cli` | Before PR exists | Required |
+| **External reviewer** | `acpx-codex` (Codex Cloud) | After PR is published | Required |
+| **Advisory reviewer** | Varies (e.g., Rock Claw) | Any time | Informative only |
+
+### Internal reviewer (Claude)
+
+- **Runtime:** `claude-cli` (one-shot, no persistent session)
+- **Model:** `claude-sonnet-4-6` (configurable)
+- **Trigger:** Local unpublished branch exists and needs pre-publish gate
+- **Output:** JSON verdict with `verdict`, `findings`, `targetHeadSha`
+- **Gate:** Must pass before `publish_pr` is allowed
+
+### External reviewer (Codex Cloud)
+
+- **Runtime:** `acpx-codex` (resumable session)
+- **Model:** `gpt-5` (configurable)
+- **Trigger:** PR exists and is ready for review
+- **Output:** GitHub review threads + PR body signal
+- **Gate:** Must pass before `merge_pr` is allowed
+
+### Advisory reviewer
+
+- Optional additional reviewer
+- Can run in parallel with required reviewers
+- Findings are logged but do not block merge
+- Example: Rock Claw for security-focused review
+
+---
+
+## Review lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> internal_pending: local branch exists
+    internal_pending --> internal_running: dispatch_claude_review
+    internal_running --> internal_findings: reject
+    internal_findings --> coder_repair: repair handoff
+    coder_repair --> internal_pending: re-dispatch
+    internal_running --> internal_passed: approve
+    internal_passed --> publish_pr: create PR
+
+    publish_pr --> external_pending: PR ready
+    external_pending --> external_running: Codex Cloud review
+    external_running --> external_findings: reject
+    external_findings --> coder_repair2: repair handoff
+    coder_repair2 --> external_pending: push update + re-review
+    external_running --> external_passed: approve
+    external_passed --> merge_pr: merge
+```
+
+---
+
+## Findings format
+
+Reviewers return structured findings that the workflow uses for repair handoff:
+
+```json
+{
+  "verdict": "changes_requested",
+  "targetHeadSha": "abc123def...",
+  "findings": [
+    {
+      "file": "src/foo.py",
+      "line": 42,
+      "severity": 1,
+      "message": "Missing error handling for network timeout"
+    }
+  ],
+  "summary": "2 findings, both addressable"
+}
+```
+
+### Severity levels
+
+| Badge | Meaning |
+|---|---|
+| `P1` | Critical — blocks merge |
+| `P2` | Important — should fix |
+| `P3` | Minor — nice to have |
+
+The `SEVERITY_BADGE_RE` regex (`![P(\d+) Badge`) extracts these from review output for aggregation.
+
+---
+
+## Repair handoff
+
+When a reviewer returns `changes_requested`, the workflow dispatches a **repair handoff** back to the coder:
+
+1. Findings are deduplicated against `lane-state.json` handoff metadata
+2. New findings are appended to the lane memo
+3. Coder session receives the repair prompt
+4. Coder implements fixes and commits
+5. Reviewer re-evaluates the new head
+
+### Deduplication key
+
+```
+<target_head_sha>:<finding_file>:<finding_line>:<finding_message_hash>
+```
+
+This prevents the same finding from being re-reported after repair.
+
+---
+
+## Review state in SQLite
+
+### `lane_reviews` table
+
+| Field | Type | Meaning |
+|---|---|---|
+| `review_id` | string | UUID v4 |
+| `lane_id` | string | FK → lanes |
+| `reviewer_scope` | enum | `internal` / `external` / `advisory` |
+| `status` | enum | `pending` / `running` / `completed` |
+| `verdict` | enum | `pass` / `pass_with_findings` / `changes_requested` |
+| `requested_head_sha` | string | Head the review was requested against |
+| `reviewed_head_sha` | string \| null | Head actually reviewed (may differ if pushed mid-review) |
+| `findings_count` | int | Number of findings returned |
+| `requested_at` | timestamp | When review was dispatched |
+| `completed_at` | timestamp \| null | When verdict was received |
+
+---
+
+## SQL debugging
+
+### Show review history for a lane
+
+```sql
+select reviewer_scope, status, verdict, requested_head_sha, reviewed_head_sha, findings_count, requested_at, completed_at
+from lane_reviews
+where lane_id='lane:220'
+order by requested_at desc;
+```
+
+### Find lanes with open findings
+
+```sql
+select l.lane_id, l.issue_number, r.reviewer_scope, r.findings_count
+from lanes l
+join lane_reviews r on l.lane_id = r.lane_id
+where r.verdict = 'changes_requested'
+  and r.completed_at is not null;
+```
+
+### Check if internal gate blocks publish
+
+```sql
+select status, verdict
+from lane_reviews
+where lane_id='lane:220'
+  and reviewer_scope='internal'
+order by requested_at desc
+limit 1;
+```
+
+---
+
+## Where this lives in code
+
+- Review policy: `daedalus/workflows/code_review/reviews.py`
+- Reviewer implementations: `daedalus/workflows/code_review/reviewers/`
+- Review dispatch: `daedalus/workflows/code_review/dispatch.py`
+- Findings parsing: `daedalus/workflows/code_review/reviews.py` (look for `_extract_json_object`, `SEVERITY_BADGE_RE`)
+- Repair handoff: `daedalus/workflows/code_review/actions.py`
+- Review state schema: `daedalus/workflows/code_review/migrations.py`
+- Tests: `tests/test_workflows_code_review_reviews.py`, `tests/test_external_reviewer_phase_b.py`

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -20,8 +20,8 @@ class Runtime(Protocol):
 
 ## Adapter shape comparison
 
-| | `claude-cli` | `acpx-codex` | `hermes-agent` |
-|---|---|---|---|
+|| | `claude-cli` | `acpx-codex` | `hermes-agent` |
+|---|---|---|---|---|
 | Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot |
 | `ensure_session` | no-op | `acpx codex sessions ensure` | no-op |
 | `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | requires `command:` override |
@@ -53,6 +53,20 @@ agents:
 ```
 
 The preflight pass walks `runtimes.<name>.kind` and `agents.external-reviewer.kind` to confirm every referenced runtime resolves to a registered adapter before a tick dispatches.
+
+### `hermes-agent` runtime
+
+The `hermes-agent` runtime delegates turns to a local Hermes agent process. It is **one-shot** (no persistent session) and requires a `command:` override in `workflow.yaml` because the exact invocation depends on the agent's entry point.
+
+```yaml
+runtimes:
+  my-agent-runtime:
+    kind: hermes-agent
+    command: ["python3", "-m", "my_agent", "--workflow-root", "{{workflow_root}}"]
+    timeout-seconds: 1200
+```
+
+Because it is one-shot, `assess_health` always returns healthy and `last_activity_ts` records the subprocess start/end timestamps.
 
 ## Adding a new runtime
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -1,0 +1,126 @@
+# Sessions
+
+A **session** is the runtime's handle to a persistent or one-shot actor process. Daedalus tracks sessions per lane so it knows which actor owns which worktree, whether the session is still alive, and when it last did something useful.
+
+---
+
+## Session model
+
+Sessions are owned by the **runtime adapter**, not by Daedalus directly. Daedalus asks the runtime: "do you have a session for lane X?" and the runtime answers yes/no/healthy/stale.
+
+### Session lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> created: ensure_session
+    created --> running: first prompt dispatched
+    running --> idle: prompt completed
+    idle --> running: next prompt dispatched
+    running --> terminated: stall timeout
+    idle --> terminated: idle timeout (acpx-codex only)
+    terminated --> [*]
+```
+
+### Session properties
+
+| Property | Meaning |
+|---|---|
+| `session_name` | Human-readable name, e.g. `coder-claude-1`. |
+| `session_id` | Runtime-specific handle. For acpx-codex: the Codex session UUID. For claude-cli: always `None` (one-shot). |
+| `worktree` | Path to the lane's workspace clone. |
+| `model` | Model string used for this session. |
+| `resume_session_id` | If restarting, the old session ID to resume from. |
+
+---
+
+## Runtime-specific session behavior
+
+### `claude-cli` (one-shot)
+
+- No persistent session.
+- `ensure_session` is a no-op.
+- `run_prompt` spawns `claude --print …` as a subprocess.
+- `assess_health` always returns healthy.
+- `close_session` is a no-op.
+
+### `acpx-codex` (resumable)
+
+- Persistent session across multiple turns.
+- `ensure_session` calls `acpx codex sessions ensure`.
+- `run_prompt` calls `acpx codex prompt -s <name>`.
+- `assess_health` checks session freshness against `session-idle-freshness-seconds` and `session-idle-grace-seconds`.
+- `close_session` calls `acpx codex sessions close`.
+- `last_activity_ts` returns the most recent prompt start or completion time.
+
+### `hermes-agent` (one-shot)
+
+- No persistent session.
+- Requires a `command:` override in `workflow.yaml`.
+- `assess_health` always returns healthy.
+- `last_activity_ts` records subprocess start/end timestamps.
+
+---
+
+## Session health
+
+The `assess_health` protocol returns:
+
+```python
+class SessionHealth:
+    status: "healthy" | "stale" | "unknown"
+    reason: str | None
+    last_activity_ts: float | None
+```
+
+| Status | Meaning | Action |
+|---|---|---|
+| `healthy` | Session is responsive and recent. | Continue dispatching. |
+| `stale` | Session hasn't been active longer than the freshness threshold. | Emit `daedalus.stall_detected`, terminate, retry. |
+| `unknown` | Runtime doesn't implement health checks. | Skip stall detection for this session. |
+
+---
+
+## Session naming convention
+
+Sessions are named per lane and role:
+
+```
+<role>-<backend>-<lane_short_id>
+```
+
+Examples:
+- `coder-claude-220` — Coder session for lane 220
+- `reviewer-codex-220` — External reviewer session for lane 220
+
+The `lane_short_id` is the issue number (or a hash if the lane has no issue). This makes session names human-readable and unique.
+
+---
+
+## SQL debugging
+
+### Show actor sessions for a lane
+
+```sql
+select actor_id, backend_identity, runtime_status, session_action_recommendation, last_used_at, can_continue, can_nudge
+from lane_actors
+where lane_id='lane:220';
+```
+
+### Find stale sessions
+
+```sql
+select lane_id, actor_id, last_used_at
+from lane_actors
+where can_continue = false
+   or (can_nudge = true and datetime(last_used_at, '+15 minutes') < datetime('now'));
+```
+
+---
+
+## Where this lives in code
+
+- Session protocol: `daedalus/workflows/code_review/sessions.py`
+- Runtime adapters: `daedalus/workflows/code_review/runtimes/{claude_cli,acpx_codex,hermes_agent}.py`
+- Health checks: `daedalus/workflows/code_review/health.py`
+- Stall detection: `daedalus/workflows/code_review/stall.py`
+- Tests: `tests/test_workflows_code_review_sessions.py`, `tests/test_workflows_code_review_session_runtime.py`

--- a/docs/concepts/webhooks.md
+++ b/docs/concepts/webhooks.md
@@ -1,0 +1,125 @@
+# Webhooks
+
+Webhooks are **pluggable outbound subscribers** for audit events. When something happens in a lane (dispatch, review, merge, operator attention), Daedalus can fan out the event to any number of configured webhooks — Slack, HTTP JSON endpoint, or a no-op disabled stub.
+
+---
+
+## Why webhooks
+
+The event log (`daedalus-events.jsonl`) is great for post-hoc analysis, but real-time notifications need a push mechanism. Webhooks bridge that gap without coupling the workflow to any specific chat platform.
+
+---
+
+## Config schema
+
+```yaml
+webhooks:
+  - name: "slack-alerts"
+    kind: slack-incoming
+    url: "https://hooks.slack.com/services/..."
+    enabled: true
+    event-globs:
+      - "operator-attention-*"
+      - "merge-and-promote"
+
+  - name: "http-json"
+    kind: http-json
+    url: "https://my-monitoring.example.com/daedalus"
+    enabled: true
+    # No event-globs = match all events
+
+  - name: "disabled-stub"
+    kind: disabled
+    enabled: false
+```
+
+### Fields
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `name` | ✅ | — | Human-readable identifier. |
+| `kind` | ✅ | — | `slack-incoming`, `http-json`, `disabled`. |
+| `url` | ✅ (unless `disabled`) | — | Target URL. Only `http://` and `https://` schemes allowed (SSRF guard). |
+| `enabled` | ❌ | `true` | `false` forces `kind=disabled`. |
+| `event-globs` | ❌ | `[]` (match all) | fnmatch globs against `action` field. Empty list = firehose. |
+
+---
+
+## Built-in kinds
+
+### `slack-incoming`
+
+Posts a compact Slack message with:
+- Action name
+- Lane/issue context
+- Summary
+- Timestamp
+
+Uses `urllib.request` (stdlib only) with a 10-second timeout.
+
+### `http-json`
+
+POSTs the full audit event dict as `application/json` to the configured URL. Also stdlib-only.
+
+### `disabled`
+
+No-op. Swallows all events silently. Useful for temporarily disabling a webhook without deleting config.
+
+---
+
+## Event matching
+
+```python
+event_matches(audit_event, event_globs)
+```
+
+- `action` field is matched against each glob using `fnmatch.fnmatchcase`.
+- `None` or empty `event_globs` → match all (implicit `['*']`).
+- If any glob matches, the webhook receives the event.
+
+---
+
+## Fan-out behavior
+
+```python
+compose_audit_subscribers(subscribers)
+```
+
+Returns a callable that:
+1. Builds the audit event dict (`{"at": ..., "action": ..., "summary": ..., **extra}`)
+2. Iterates over all subscribers
+3. Catches and swallows per-subscriber exceptions
+4. Never blocks workflow execution on a slow/broken webhook
+
+This is the same contract used by `workspace._make_audit_fn`.
+
+---
+
+## Adding a new webhook kind
+
+1. Implement the `Webhook` Protocol:
+   - `name: str`
+   - `deliver(audit_event: dict) -> None`
+   - `matches(audit_event: dict) -> bool`
+2. Decorate with `@register("your-kind")` from `workflows.code_review.webhooks`.
+3. Add the kind to `schema.yaml`.
+4. Lazy-import in `build_webhooks` so side-effect registration happens.
+
+---
+
+## Security
+
+- **SSRF guard:** Only `http://` and `https://` URLs are allowed. `file://`, `gopher://`, `ftp://`, etc. are rejected to prevent leaking audit events to local resources.
+- **Timeout:** All built-in kinds use a 10-second socket timeout.
+- **Best-effort:** Exceptions are swallowed. A compromised webhook endpoint cannot crash the workflow.
+
+---
+
+## Where this lives in code
+
+- Protocol + factory: `daedalus/workflows/code_review/webhooks/__init__.py`
+- Slack implementation: `daedalus/workflows/code_review/webhooks/slack_incoming.py`
+- HTTP JSON implementation: `daedalus/workflows/code_review/webhooks/http_json.py`
+- Disabled stub: `daedalus/workflows/code_review/webhooks/disabled.py`
+- Fan-out: `daedalus/workflows/code_review/webhooks/__init__.py::compose_audit_subscribers`
+- Tests: `tests/test_webhooks_phase_c.py`, `tests/test_webhooks_schema.py`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,127 @@
+# Contributing to Daedalus
+
+So you want to hack on Daedalus? Welcome. This doc covers how to run tests, add a new runtime, add a workflow stage, and keep the docs in sync.
+
+---
+
+## Quick start
+
+```bash
+# Clone
+git clone https://github.com/attmous/daedalus.git
+cd daedalus
+
+# Install (into your Hermes home)
+./scripts/install.sh
+
+# Run tests
+pytest
+
+# Run one test file
+pytest tests/test_stall_detection.py -v
+
+# Run with coverage
+pytest --cov=daedalus --cov-report=term-missing
+```
+
+---
+
+## Test conventions
+
+### File naming
+
+- `test_<module_name>.py` — unit tests for a single module
+- `test_<feature>_phase_<letter>.py` — integration tests for a feature phase
+- `test_workflows_code_review_<topic>.py` — workflow-specific tests
+
+### Test categories
+
+| Category | Count | Example |
+|---|---|---|
+| Unit tests | ~40 | `test_config_snapshot.py`, `test_stall_detection.py` |
+| Integration tests | ~25 | `test_external_reviewer_phase_b.py` |
+| Formatter tests | ~10 | `test_formatters_shadow_report.py` |
+| Schema tests | ~8 | `test_workflow_code_review_schema.py` |
+
+### Running the full suite
+
+```bash
+pytest -x  # stop on first failure
+pytest -n auto  # parallel (requires pytest-xdist)
+```
+
+---
+
+## Adding a new runtime
+
+1. **Implement the Protocol** in `daedalus/workflows/code_review/runtimes/your_runtime.py`:
+   ```python
+   from workflows.code_review.runtimes import register
+
+   @register("your-kind")
+   class YourRuntime:
+       def ensure_session(self, *, worktree, session_name, model, resume_session_id): ...
+       def run_prompt(self, *, worktree, session_name, prompt, model): ...
+       def assess_health(self, session_meta, *, worktree, now_epoch): ...
+       def close_session(self, *, worktree, session_name): ...
+       def last_activity_ts(self) -> float | None: ...
+   ```
+
+2. **Add to schema** in `daedalus/workflows/code_review/schema.yaml`:
+   ```yaml
+   runtimes:
+     your-runtime:
+       kind: your-kind
+       timeout-seconds: 1200
+   ```
+
+3. **Add tests** in `tests/test_workflows_code_review_runtimes_your_runtime.py`.
+
+4. **Document** in `docs/concepts/runtimes.md`.
+
+---
+
+## Adding a workflow stage
+
+The current code-review workflow has stages: `implementing` → `awaiting_claude_prepublish` → `ready_to_publish` → `under_review` → `approved` → `merged`.
+
+To add a new stage:
+
+1. **Add the state** to the workflow state machine in `daedalus/workflows/code_review/workflow.py`.
+2. **Add the transition logic** in `daedalus/workflows/code_review/dispatch.py`.
+3. **Add the action type** in `daedalus/workflows/code_review/actions.py`.
+4. **Update the schema** in `daedalus/workflows/code_review/migrations.py` (if new DB columns needed).
+5. **Add tests** in `tests/test_workflows_code_review_actions.py`.
+6. **Document** in `docs/concepts/lanes.md` and `docs/concepts/actions.md`.
+
+---
+
+## Keeping docs in sync
+
+Every code change that affects operator-facing behavior must update docs:
+
+| Change type | Docs to update |
+|---|---|
+| New slash command | `docs/operator/slash-commands.md`, `docs/operator/cheat-sheet.md` |
+| New concept | `docs/concepts/<new-concept>.md`, `docs/architecture.md` |
+| Schema change | `docs/concepts/lanes.md`, `docs/concepts/actions.md` |
+| Config change | `docs/concepts/hot-reload.md`, `docs/operator/cheat-sheet.md` |
+| Rename/refactor | All docs + ADR in `docs/adr/` |
+
+---
+
+## Code style
+
+- **Type hints everywhere.** `from __future__ import annotations` at the top of every file.
+- **No external deps in core.** The runtime must work with stdlib + SQLite only. Rich is allowed for TUI rendering.
+- **Fail soft.** Every subscriber, webhook, and observer must catch its own exceptions. Never let a side-effect failure crash the tick.
+- `--json` is the default operator dialect. Humans read formatters, scripts read JSON.
+
+---
+
+## Where to get help
+
+- Read the operator cheat sheet: `docs/operator/cheat-sheet.md`
+- Check the architecture doc: `docs/architecture.md`
+- Run `/daedalus doctor` inside Hermes
+- Open an issue with the output of `/daedalus status --format json`

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -303,6 +303,60 @@ python3 ~/\.hermes/workflows/yoyopod/.hermes/plugins/daedalus/runtime.py request
 
 ---
 
+## 11.5. Webhook debugging
+
+### Show configured webhooks
+```bash
+python3 ~/\.hermes/workflows/yoyopod/.hermes/plugins/daedalus/workflows/__main__.py \
+  --workflow-root ~/\.hermes/workflows/yoyopod status --json | jq '.webhooks'
+```
+
+### Test a webhook manually
+```bash
+# Trigger a test event to all configured webhooks
+python3 ~/\.hermes/workflows/yoyopod/.hermes/plugins/daedalus/workflows/__main__.py \
+  --workflow-root ~/\.hermes/workflows/yoyopod dispatch-test-webhook --event action=test
+```
+
+---
+
+## 11.6. Comments debugging
+
+### Show comment publisher state
+```bash
+python3 ~/\.hermes/workflows/yoyopod/.hermes/plugins/daedalus/workflows/__main__.py \
+  --workflow-root ~/\.hermes/workflows/yoyopod status --json | jq '.comments'
+```
+
+### Force a comment sync
+```bash
+/daedalus set-observability --workflow code-review --github-comments on
+# Then trigger any action; the comment will update on the next tick.
+```
+
+---
+
+## 11.7. Config hot-reload debugging
+
+### Check if a bad workflow.yaml is being ignored
+```bash
+/daedalus doctor
+```
+Look for `config_reload_failed` in the event tail or doctor output.
+
+### Force a config re-read
+```bash
+# Touch the file; the next tick will pick it up.
+touch ~/.hermes/workflows/yoyopod/workflow.yaml
+```
+
+### Show effective config (merged layers)
+```bash
+/daedalus get-observability --workflow code-review
+```
+
+---
+
 ## 12. Common failure signatures
 
 ### A. Wrapper says `run_claude_review`, Daedalus returns `[]`

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -175,28 +175,42 @@ Daedalus service
 
 ## `/workflow` — per-workflow operations
 
-| Command | What it does |
-|---|---|
-| `/workflow` | List installed workflows |
-| `/workflow <name>` | Show that workflow's `--help` |
-| `/workflow <name> <cmd> [args]` | Route to that workflow's CLI |
+|| Command | What it does |
+|---|---|---|
+|| `/workflow` | List installed workflows |
+|| `/workflow <name>` | Show that workflow's `--help` |
+|| `/workflow <name> <cmd> [args]` | Route to that workflow's CLI |
 
 ### `code-review` workflow shortcuts (the common ones)
 
-| Command | What it does |
-|---|---|
-| `/workflow code-review status` | Lane state + `nextAction` |
-| `/workflow code-review tick` | One workflow tick |
-| `/workflow code-review show-active-lane` | Current active GitHub issue |
-| `/workflow code-review show-lane-state` | `.lane-state.json` contents |
-| `/workflow code-review show-lane-memo` | `.lane-memo.md` contents |
-| `/workflow code-review dispatch-implementation-turn` | Force a coder turn |
-| `/workflow code-review dispatch-claude-review` | Force an internal Claude review |
-| `/workflow code-review publish-ready-pr` | Force PR publish |
-| `/workflow code-review merge-and-promote` | Force merge + promote next lane |
-| `/workflow code-review reconcile` | Repair stale ledger state |
-| `/workflow code-review pause` | Disable lane processing |
-| `/workflow code-review resume` | Re-enable |
+|| Command | What it does |
+|---|---|---|
+|| `/workflow code-review status` | Lane state + `nextAction` |
+|| `/workflow code-review tick` | One workflow tick |
+|| `/workflow code-review show-active-lane` | Current active GitHub issue |
+|| `/workflow code-review show-lane-state` | `.lane-state.json` contents |
+|| `/workflow code-review show-lane-memo` | `.lane-memo.md` contents |
+|| `/workflow code-review dispatch-implementation-turn` | Force a coder turn |
+|| `/workflow code-review dispatch-claude-review` | Force an internal Claude review |
+|| `/workflow code-review publish-ready-pr` | Force PR publish |
+|| `/workflow code-review merge-and-promote` | Force merge + promote next lane |
+|| `/workflow code-review reconcile` | Repair stale ledger state |
+|| `/workflow code-review pause` | Disable lane processing |
+|| `/workflow code-review resume` | Re-enable |
+
+### Webhook commands
+
+|| Command | What it does |
+|---|---|---|
+|| `/workflow code-review webhooks status` | Show configured webhook subscribers |
+|| `/workflow code-review webhooks test` | Fire a test event to all webhooks |
+
+### Comments commands
+
+|| Command | What it does |
+|---|---|---|
+|| `/workflow code-review comments status` | Show comment publisher state |
+|| `/workflow code-review comments sync` | Force a comment sync for current lane |
 
 ## Most useful day-to-day, in order
 


### PR DESCRIPTION
Adds comprehensive documentation for core Daedalus concepts:

**New docs (9 files):**
-  — failure lifecycle, schema, idempotency fixes, retry policy
-  — action types, shadow vs active rows, idempotency keys
-  — TUI watch, HTTP server, GitHub comments, event log
-  — relay→daedalus rename, filesystem/systemd/config migration
-  — internal/external/advisory roles, review lifecycle, repair handoff
-  — session model, runtime-specific behavior, health checks
-  — webhook config, built-in kinds, fan-out, SSRF guard
-  — GitHub comments publishing, modes, event filtering
-  — dev setup, test conventions, adding runtimes/stages

**Updated docs (6 files):**
-  — adds lane selection config, schema, flow diagram
-  — adds hermes-agent runtime section
-  — adds event writer details, file rotation, schema envelope
-  — adds webhook, comments, hot-reload debugging
-  — adds webhook and comments commands
-  — adds watch, formatters, migration, observability overrides

**Stats:** 15 files changed, +1521 insertions, -24 deletions