### PR TITLE
docs(architecture): rewrite architecture.md with diagrams and visual narrative

### DIFF
--- a/assets/daedalus-architecture-diagram.html
+++ b/assets/daedalus-architecture-diagram.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Daedalus Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #020617;
+      min-height: 100vh;
+      padding: 2rem;
+      color: white;
+    }
+    .container { max-width: 1400px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot {
+      width: 14px; height: 14px; background: #22d3ee; border-radius: 50%;
+      animation: pulse 2s infinite; box-shadow: 0 0 12px #22d3ee;
+    }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+    h1 { font-size: 1.75rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.9rem; margin-left: 1.75rem; }
+    .diagram-container {
+      background: rgba(15, 23, 42, 0.5); border-radius: 1rem;
+      border: 1px solid #1e293b; padding: 1.5rem; overflow-x: auto; margin-bottom: 2rem;
+    }
+    svg { width: 100%; min-width: 1200px; display: block; }
+    .cards {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 1rem; margin-top: 2rem;
+    }
+    .card {
+      background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem;
+      border: 1px solid #1e293b; padding: 1.25rem;
+    }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; box-shadow: 0 0 8px #22d3ee; }
+    .card-dot.emerald { background: #34d399; box-shadow: 0 0 8px #34d399; }
+    .card-dot.violet { background: #a78bfa; box-shadow: 0 0 8px #a78bfa; }
+    .card-dot.amber { background: #fbbf24; box-shadow: 0 0 8px #fbbf24; }
+    .card-dot.rose { background: #fb7185; box-shadow: 0 0 8px #fb7185; }
+    .card h3 { font-size: 0.9rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.8rem; }
+    .card li { margin-bottom: 0.4rem; line-height: 1.4; }
+    .card li strong { color: #e2e8f0; font-weight: 500; }
+    .footer { text-align: center; margin-top: 2rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Daedalus Architecture</h1>
+      </div>
+      <p class="subtitle">Durable orchestration for agentic SDLC lanes — shadow → active → ship</p>
+    </div>
+
+    <!-- Main Diagram -->
+    <div class="diagram-container">
+      <svg viewBox="0 0 1200 900">
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <marker id="arrowhead-cyan" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#22d3ee" />
+          </marker>
+          <marker id="arrowhead-emerald" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#34d399" />
+          </marker>
+          <marker id="arrowhead-rose" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#fb7185" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+          <linearGradient id="glow-cyan" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.1"/>
+            <stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/>
+          </linearGradient>
+          <linearGradient id="glow-emerald" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#34d399" stop-opacity="0.1"/>
+            <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+
+        <!-- Background Grid -->
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- ============================================ -->
+        <!-- LAYER 1: EXTERNAL TRIGGERS (Top)             -->
+        <!-- ============================================ -->
+        <text x="600" y="30" fill="#64748b" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="2">EXTERNAL TRIGGERS</text>
+        
+        <!-- GitHub Issue -->
+        <rect x="200" y="45" width="140" height="55" rx="8" fill="rgba(30, 41, 59, 0.6)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="270" y="68" fill="white" font-size="12" font-weight="600" text-anchor="middle">GitHub Issue</text>
+        <text x="270" y="85" fill="#94a3b8" font-size="9" text-anchor="middle">#42 · active-lane label</text>
+
+        <!-- Operator -->
+        <rect x="530" y="45" width="140" height="55" rx="8" fill="rgba(136, 19, 55, 0.3)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="600" y="68" fill="white" font-size="12" font-weight="600" text-anchor="middle">Operator</text>
+        <text x="600" y="85" fill="#94a3b8" font-size="9" text-anchor="middle">/daedalus commands</text>
+
+        <!-- Config -->
+        <rect x="860" y="45" width="140" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="930" y="68" fill="white" font-size="12" font-weight="600" text-anchor="middle">workflow.yaml</text>
+        <text x="930" y="85" fill="#94a3b8" font-size="9" text-anchor="middle">Hot-reload config</text>
+
+        <!-- ============================================ -->
+        <!-- LAYER 2: DAEDALUS ENGINE (Center-Left)        -->
+        <!-- ============================================ -->
+        <rect x="50" y="130" width="520" height="420" rx="16" fill="rgba(8, 51, 68, 0.08)" stroke="#22d3ee" stroke-width="2" stroke-dasharray="12,6"/>
+        <text x="70" y="155" fill="#22d3ee" font-size="13" font-weight="700" letter-spacing="1">DAEDALUS ENGINE</text>
+        <text x="70" y="170" fill="#22d3ee" font-size="9" opacity="0.7">Orchestration Runtime</text>
+
+        <!-- Runtime Loop -->
+        <rect x="80" y="190" width="200" height="80" rx="10" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="2"/>
+        <text x="180" y="215" fill="white" font-size="13" font-weight="700" text-anchor="middle">Runtime Loop</text>
+        <text x="180" y="235" fill="#94a3b8" font-size="9" text-anchor="middle">Tick → Ingest → Derive</text>
+        <text x="180" y="250" fill="#94a3b8" font-size="9" text-anchor="middle">→ Dispatch → Record</text>
+
+        <!-- Leases -->
+        <rect x="340" y="190" width="200" height="55" rx="8" fill="rgba(8, 51, 68, 0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="440" y="215" fill="white" font-size="12" font-weight="600" text-anchor="middle">Leases</text>
+        <text x="440" y="232" fill="#94a3b8" font-size="9" text-anchor="middle">Heartbeat · TTL · Recovery</text>
+
+        <!-- SQLite -->
+        <rect x="80" y="300" width="200" height="70" rx="8" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="2"/>
+        <text x="180" y="325" fill="white" font-size="13" font-weight="700" text-anchor="middle">SQLite</text>
+        <text x="180" y="342" fill="#94a3b8" font-size="9" text-anchor="middle">Canonical State</text>
+        <text x="180" y="357" fill="#a78bfa" font-size="8" text-anchor="middle">lanes · actions · reviews · failures</text>
+
+        <!-- JSONL -->
+        <rect x="340" y="300" width="200" height="70" rx="8" fill="rgba(76, 29, 149, 0.3)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="440" y="325" fill="white" font-size="13" font-weight="600" text-anchor="middle">JSONL Event Log</text>
+        <text x="440" y="342" fill="#94a3b8" font-size="9" text-anchor="middle">Append-Only History</text>
+        <text x="440" y="357" fill="#a78bfa" font-size="8" text-anchor="middle">turn_started · turn_completed · stall</text>
+
+        <!-- Shadow Mode -->
+        <rect x="80" y="400" width="200" height="55" rx="8" fill="rgba(120, 53, 15, 0.2)" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="6,3"/>
+        <text x="180" y="422" fill="white" font-size="12" font-weight="600" text-anchor="middle">Shadow Mode</text>
+        <text x="180" y="440" fill="#94a3b8" font-size="9" text-anchor="middle">Observe · Plan · No Side Effects</text>
+
+        <!-- Active Mode -->
+        <rect x="340" y="400" width="200" height="55" rx="8" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="2"/>
+        <text x="440" y="422" fill="white" font-size="12" font-weight="600" text-anchor="middle">Active Mode</text>
+        <text x="440" y="440" fill="#94a3b8" font-size="9" text-anchor="middle">Execute · Dispatch · Real Side Effects</text>
+
+        <!-- Operator Surfaces -->
+        <rect x="80" y="480" width="460" height="50" rx="8" fill="rgba(136, 19, 55, 0.2)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="310" y="500" fill="white" font-size="12" font-weight="600" text-anchor="middle">Operator Surfaces</text>
+        <text x="310" y="518" fill="#94a3b8" font-size="9" text-anchor="middle">/daedalus status · doctor · watch · shadow-report · active-gate</text>
+
+        <!-- ============================================ -->
+        <!-- LAYER 3: WORKFLOW WRAPPER (Center-Right)      -->
+        <!-- ============================================ -->
+        <rect x="620" y="130" width="530" height="420" rx="16" fill="rgba(6, 78, 59, 0.08)" stroke="#34d399" stroke-width="2" stroke-dasharray="12,6"/>
+        <text x="640" y="155" fill="#34d399" font-size="13" font-weight="700" letter-spacing="1">WORKFLOW WRAPPER</text>
+        <text x="640" y="170" fill="#34d399" font-size="9" opacity="0.7">Semantic Policy Brain</text>
+
+        <!-- Status / Read Model -->
+        <rect x="650" y="190" width="220" height="60" rx="8" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="2"/>
+        <text x="760" y="215" fill="white" font-size="13" font-weight="700" text-anchor="middle">Status / Read Model</text>
+        <text x="760" y="235" fill="#94a3b8" font-size="9" text-anchor="middle">nextAction · health · reviewLoopState</text>
+
+        <!-- Policy Engine -->
+        <rect x="910" y="190" width="220" height="60" rx="8" fill="rgba(6, 78, 59, 0.3)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="1020" y="215" fill="white" font-size="13" font-weight="600" text-anchor="middle">Policy Engine</text>
+        <text x="1020" y="235" fill="#94a3b8" font-size="9" text-anchor="middle">publish · merge · promote rules</text>
+
+        <!-- Actors -->
+        <rect x="650" y="280" width="140" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="720" y="302" fill="white" font-size="11" font-weight="600" text-anchor="middle">Internal Coder</text>
+        <text x="720" y="320" fill="#94a3b8" font-size="9" text-anchor="middle">Codex · acpx</text>
+
+        <rect x="820" y="280" width="140" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="890" y="302" fill="white" font-size="11" font-weight="600" text-anchor="middle">Internal Reviewer</text>
+        <text x="890" y="320" fill="#94a3b8" font-size="9" text-anchor="middle">Claude · claude-cli</text>
+
+        <rect x="990" y="280" width="140" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="1060" y="302" fill="white" font-size="11" font-weight="600" text-anchor="middle">External Reviewer</text>
+        <text x="1060" y="320" fill="#94a3b8" font-size="9" text-anchor="middle">Codex Cloud</text>
+
+        <!-- Lane State Machine -->
+        <rect x="650" y="360" width="480" height="80" rx="10" fill="rgba(6, 78, 59, 0.2)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="890" y="382" fill="white" font-size="12" font-weight="600" text-anchor="middle">Lane State Machine</text>
+        <text x="890" y="405" fill="#94a3b8" font-size="9" text-anchor="middle">implementing → awaiting_claude_prepublish → ready_to_publish</text>
+        <text x="890" y="422" fill="#94a3b8" font-size="9" text-anchor="middle">→ under_review → findings_open → approved → merged</text>
+
+        <!-- Handoffs -->
+        <rect x="650" y="465" width="480" height="55" rx="8" fill="rgba(6, 78, 59, 0.15)" stroke="#34d399" stroke-width="1" stroke-dasharray="4,4"/>
+        <text x="890" y="485" fill="#34d399" font-size="11" font-weight="600" text-anchor="middle">Handoffs: Orchestrator → Coder → Reviewer → Publish → Merge</text>
+        <text x="890" y="505" fill="#94a3b8" font-size="9" text-anchor="middle">Explicit role handoffs, not vibes. Every handoff survives restarts.</text>
+
+        <!-- ============================================ -->
+        <!-- LAYER 4: SYSTEMD & WATCH (Bottom-Left)          -->
+        <!-- ============================================ -->
+        <rect x="50" y="580" width="520" height="120" rx="16" fill="rgba(136, 19, 55, 0.06)" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="8,4"/>
+        <text x="70" y="605" fill="#fb7185" font-size="12" font-weight="700" letter-spacing="1">SUPERVISION & OBSERVABILITY</text>
+
+        <!-- systemd -->
+        <rect x="80" y="620" width="160" height="55" rx="8" fill="rgba(136, 19, 55, 0.3)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="160" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">systemd Service</text>
+        <text x="160" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">daedalus-active@.service</text>
+
+        <!-- Watch TUI -->
+        <rect x="280" y="620" width="140" height="55" rx="8" fill="rgba(8, 51, 68, 0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="350" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">/daedalus watch</text>
+        <text x="350" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">Live TUI · 1s refresh</text>
+
+        <!-- HTTP Server -->
+        <rect x="460" y="620" width="90" height="55" rx="8" fill="rgba(8, 51, 68, 0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="505" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">HTTP</text>
+        <text x="505" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">localhost:8765</text>
+
+        <!-- ============================================ -->
+        <!-- LAYER 5: GITHUB & WEBHOOKS (Bottom-Right)     -->
+        <!-- ============================================ -->
+        <rect x="620" y="580" width="530" height="120" rx="16" fill="rgba(120, 53, 15, 0.06)" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="8,4"/>
+        <text x="640" y="605" fill="#fbbf24" font-size="12" font-weight="700" letter-spacing="1">EXTERNAL INTEGRATIONS</text>
+
+        <!-- GitHub -->
+        <rect x="650" y="620" width="180" height="55" rx="8" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="740" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">GitHub API</text>
+        <text x="740" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">Issues · PRs · Reviews · Comments</text>
+
+        <!-- Webhooks -->
+        <rect x="870" y="620" width="140" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="940" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">Webhooks</text>
+        <text x="940" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">Slack · HTTP JSON</text>
+
+        <!-- Comments -->
+        <rect x="1050" y="620" width="80" height="55" rx="8" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="1090" y="642" fill="white" font-size="11" font-weight="600" text-anchor="middle">Comments</text>
+        <text x="1090" y="660" fill="#94a3b8" font-size="9" text-anchor="middle">PR audit</text>
+
+        <!-- ============================================ -->
+        <!-- CONNECTIONS / ARROWS                          -->
+        <!-- ============================================ -->
+
+        <!-- Issue → Daedalus -->
+        <line x1="340" y1="72" x2="340" y2="130" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <text x="350" y="108" fill="#94a3b8" font-size="8">labeled</text>
+
+        <!-- Operator → Daedalus -->
+        <line x1="600" y1="100" x2="600" y2="130" stroke="#fb7185" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Config → Daedalus -->
+        <line x1="930" y1="100" x2="570" y2="130" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Daedalus ↔ Wrapper (thick bidirectional) -->
+        <line x1="570" y1="250" x2="620" y2="250" stroke="#22d3ee" stroke-width="2" marker-end="url(#arrowhead-cyan)"/>
+        <line x1="620" y1="260" x2="570" y2="260" stroke="#34d399" stroke-width="2" marker-end="url(#arrowhead-emerald)"/>
+        <text x="595" y="245" fill="#22d3ee" font-size="8" text-anchor="middle">ingest</text>
+        <text x="595" y="275" fill="#34d399" font-size="8" text-anchor="middle">dispatch</text>
+
+        <!-- Runtime → SQLite -->
+        <line x1="180" y1="270" x2="180" y2="300" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Runtime → JSONL -->
+        <line x1="280" y1="230" x2="390" y2="300" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Shadow → Active gate -->
+        <line x1="280" y1="455" x2="340" y2="455" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="4,4" marker-end="url(#arrowhead)"/>
+        <text x="310" y="450" fill="#fbbf24" font-size="8" text-anchor="middle">promote</text>
+
+        <!-- Wrapper → Actors -->
+        <line x1="760" y1="250" x2="720" y2="280" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="890" y1="250" x2="890" y2="280" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="1020" y1="250" x2="1060" y2="280" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Wrapper → GitHub -->
+        <line x1="890" y1="500" x2="740" y2="580" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Daedalus → systemd -->
+        <line x1="310" y1="550" x2="160" y2="580" stroke="#fb7185" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Daedalus → Watch/HTTP -->
+        <line x1="350" y1="550" x2="350" y2="620" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <line x1="430" y1="530" x2="505" y2="620" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- Wrapper → Webhooks -->
+        <line x1="1020" y1="500" x2="940" y2="580" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+        <!-- ============================================ -->
+        <!-- LEGEND                                        -->
+        <!-- ============================================ -->
+        <text x="1050" y="740" fill="white" font-size="10" font-weight="600">Legend</text>
+        
+        <rect x="1050" y="752" width="16" height="10" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="1072" y="760" fill="#94a3b8" font-size="8">Daedalus Engine</text>
+        
+        <rect x="1050" y="768" width="16" height="10" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="1072" y="776" fill="#94a3b8" font-size="8">Workflow Wrapper</text>
+        
+        <rect x="1050" y="784" width="16" height="10" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="1072" y="792" fill="#94a3b8" font-size="8">State / Storage</text>
+        
+        <rect x="1050" y="800" width="16" height="10" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="1072" y="808" fill="#94a3b8" font-size="8">Runtime / Actor</text>
+        
+        <rect x="1050" y="816" width="16" height="10" rx="2" fill="rgba(136, 19, 55, 0.3)" stroke="#fb7185" stroke-width="1"/>
+        <text x="1072" y="824" fill="#94a3b8" font-size="8">Operator / Alert</text>
+        
+        <rect x="1050" y="832" width="16" height="10" rx="2" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1"/>
+        <text x="1072" y="840" fill="#94a3b8" font-size="8">External</text>
+
+        <!-- Data flow label -->
+        <text x="600" y="730" fill="#64748b" font-size="10" font-weight="600" text-anchor="middle" letter-spacing="2">DATA FLOW</text>
+        <line x1="200" y1="740" x2="1000" y2="740" stroke="#1e293b" stroke-width="1"/>
+
+        <!-- Bottom tagline -->
+        <text x="600" y="870" fill="#475569" font-size="10" text-anchor="middle" font-style="italic">
+          "Turn fragile cron-loop automation into explicit, durable, role-based 24/7 workflow orchestration."
+        </text>
+      </svg>
+    </div>
+
+    <!-- Info Cards -->
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot cyan"></div>
+          <h3>Daedalus Engine</h3>
+        </div>
+        <ul>
+          <li>• <strong>Runtime Loop:</strong> Tick → Ingest → Derive → Dispatch → Record</li>
+          <li>• <strong>Leases:</strong> Heartbeat-based ownership with automatic recovery</li>
+          <li>• <strong>Shadow Mode:</strong> Safe observation without side effects</li>
+          <li>• <strong>Active Mode:</strong> Real execution with failure tracking & retries</li>
+          <li>• <strong>Operator Surfaces:</strong> status, doctor, watch, shadow-report, active-gate</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Workflow Wrapper</h3>
+        </div>
+        <ul>
+          <li>• <strong>Policy Brain:</strong> Decides nextAction, health, review state</li>
+          <li>• <strong>Actors:</strong> Internal Coder (Codex), Internal Reviewer (Claude), External Reviewer (Codex Cloud)</li>
+          <li>• <strong>State Machine:</strong> implementing → review → publish → merge</li>
+          <li>• <strong>Handoffs:</strong> Explicit, durable, survive restarts</li>
+          <li>• <strong>Semantic → Execution:</strong> Translates policy into dispatchable actions</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>State & Storage</h3>
+        </div>
+        <ul>
+          <li>• <strong>SQLite:</strong> Canonical runtime state — lanes, actions, reviews, failures, leases</li>
+          <li>• <strong>JSONL:</strong> Append-only event history for audit & replay</li>
+          <li>• <strong>Lane State:</strong> .lane-state.json + .lane-memo.md per workspace</li>
+          <li>• <strong>Hot-reload:</strong> workflow.yaml edits take effect on next tick</li>
+          <li>• <strong>Idempotency:</strong> Composite keys prevent duplicate actions</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>External Integrations</h3>
+        </div>
+        <ul>
+          <li>• <strong>GitHub:</strong> Issues, PRs, review threads, comment publishing</li>
+          <li>• <strong>Webhooks:</strong> Slack, HTTP JSON with SSRF guard</li>
+          <li>• <strong>Runtimes:</strong> claude-cli, acpx-codex, hermes-agent</li>
+          <li>• <strong>Models:</strong> gpt-5, claude-sonnet-4-6, gpt-5.4</li>
+          <li>• <strong>Config:</strong> workflow.yaml drives all behavior</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Supervision & Ops</h3>
+        </div>
+        <ul>
+          <li>• <strong>systemd:</strong> daedalus-active@.service for 24/7 supervision</li>
+          <li>• <strong>Watch TUI:</strong> /daedalus watch — live lanes + alerts + events</li>
+          <li>• <strong>HTTP Status:</strong> localhost:8765 for dashboards & health checks</li>
+          <li>• <strong>Stall Detection:</strong> Automatic termination of wedged workers</li>
+          <li>• <strong>Alerts:</strong> Outage detection with deduplication</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot cyan"></div>
+          <h3>Design Principles</h3>
+        </div>
+        <ul>
+          <li>• <strong>Wrapper decides what.</strong> Daedalus decides how to orchestrate it durably.</li>
+          <li>• <strong>State is tracked, not guessed.</strong> SQLite is current truth.</li>
+          <li>• <strong>Bad edits don't crash.</strong> workflow.yaml errors are ignored until fixed.</li>
+          <li>• <strong>Recovery is automatic.</strong> Dead workers never block forward motion.</li>
+          <li>• <strong>Humans observe, don't schedule.</strong> Passive by default, intervene only when needed.</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <p class="footer">
+      Daedalus Architecture v1.0 • Hermes Agent Plugin • MIT License
+    </p>
+  </div>
+</body>
+</html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,435 +1,406 @@
 # Daedalus Architecture
 
-## Executive summary
+<div align="center">
 
-Daedalus is a **workflow-oriented orchestration layer** for agentic software delivery. It does **not** replace the workflow brain. It wraps that brain in durable runtime mechanics: leases, canonical state, action queues, retries, failures, service supervision, and operator tooling.
+![Daedalus Architecture Diagram](assets/daedalus-architecture-diagram.html)
 
-In the current YoYoPod deployment:
-- the **workflow wrapper** is still the semantic policy engine
-- the **Daedalus runtime** is the durable orchestrator
-- the **active systemd service** keeps Daedalus running continuously
-- the **coder / reviewer actors** are explicit roles, not ad-hoc prompt invocations
+> **Daedalus is a durable orchestration runtime that wraps an SDLC workflow brain with leases, canonical state, action queues, role handoffs, retries, and operator tooling so agentic lanes can run continuously without turning into invisible cron-driven chaos.**
 
-The design goal is simple:
-
-> Turn fragile cron-loop automation into explicit, durable, role-based 24/7 workflow orchestration.
+</div>
 
 ---
 
-## 1. Problem statement
+## The 30-Second Read
 
-Classic agent automation breaks down for the same reasons every time:
-- policy is buried in prompts or cron jobs
-- state is spread across files, GitHub, and half-finished sessions
-- actions are inferred, not queued
-- failures are logged but not modeled
-- retries are accidental instead of explicit
-- handoffs between coder, reviewer, and merge logic are implicit and brittle
-
-That works for toy demos. It fails for long-running SDLC lanes.
-
-Daedalus exists to solve that by introducing:
-- a durable runtime
-- explicit actions and actors
-- canonical current state
-- append-only event history
-- active/shadow execution modes
-- supervised long-running process ownership
+| Question | Answer |
+|---|---|
+| **What is it?** | A plugin that turns fragile cron-loop automation into explicit, durable, role-based 24/7 workflow orchestration. |
+| **What problem does it solve?** | Agentic SDLC breaks because policy is buried in prompts, state is scattered, failures are logged but not modeled, and handoffs are implicit. |
+| **How?** | Leases. SQLite canonical state. JSONL event history. Shadow/active execution. Explicit actor roles. |
+| **Who owns what?** | The **wrapper** decides *what* should happen. **Daedalus** decides *how* to orchestrate it durably. |
 
 ---
 
-## 2. Architecture principles
+## The Architecture at a Glance
 
-### 2.1 Wrapper is the semantic policy brain
-The workflow wrapper decides:
-- current read model
-- semantic workflow state
-- next action
-- review/publish/merge policy
-
-### 2.2 Daedalus is the orchestration runtime
-Daedalus owns:
-- lease / heartbeat
-- durable runtime tables
-- shadow vs active action rows
-- failure tracking
-- retry bookkeeping
-- operator surfaces
-
-### 2.3 SQLite is current truth, JSONL is history
-- **SQLite** stores canonical runtime state now
-- **JSONL** stores append-only event and audit history
-
-### 2.4 Actors are explicit
-The system is modeled around named roles:
-- `Workflow_Orchestrator`
-- `Internal_Coder_Agent`
-- `Internal_Reviewer_Agent`
-- `External_Reviewer_Agent`
-- `Advisory_Reviewer_Agent`
-
-### 2.5 Handoffs must be durable
-Every meaningful handoff should survive:
-- service restarts
-- session staleness
-- transient CLI failures
-- GitHub drift
-
----
-
-## 3. Repository anatomy
-
-## 3.1 Core files
-- `__init__.py` — plugin registration
-- `plugin.yaml` — plugin manifest
-- `daedalus/schemas.py` — CLI/slash parser schema
-- `daedalus/tools.py` — operator surface and service helpers
-- `daedalus/runtime.py` — durable Daedalus engine
-- `daedalus/alerts.py` — outage alert logic
-- `daedalus/watch.py` — TUI frame renderer for `/daedalus watch`
-- `daedalus/watch_sources.py` — watch source aggregation (lanes + alerts + events)
-- `daedalus/formatters.py` — inspection output formatting (status, doctor, shadow-report)
-- `daedalus/migration.py` — relay→daedalus filesystem migration
-- `daedalus/observability_overrides.py` — operator observability config overrides
-- `scripts/install.py` / `scripts/install.sh` — plugin installation
-- `scripts/migrate_config.py` — config path migration helper
-
-## 3.2 Responsibility split
-
-### `__init__.py`
-Registers the plugin surfaces:
-- slash/session command
-- CLI command
-- optional operator skill
-
-### `daedalus/tools.py`
-Provides the human/operator interface:
-- status surfaces
-- doctoring
-- shadow reports
-- active gate checks
-- systemd install/start/restart helpers
-
-### `daedalus/runtime.py`
-Implements the real orchestration model:
-- database schema
-- leases
-- ingestion
-- action derivation
-- active action execution
-- retries
-- failure analysis state
-- runtime loops
-
-### `daedalus/alerts.py`
-Isolates outage alert decision logic from orchestration logic.
-
-### `daedalus/watch.py` + `watch_sources.py`
-Implements the `/daedalus watch` TUI. `watch_sources.py` aggregates three sources into a snapshot dict:
-- `active_lanes` — from SQLite
-- `alert_state` — from `alerts.py` output
-- `recent_events` — from JSONL tail
-
-`watch.py` renders the snapshot into a Rich panel layout. Supports both live mode (1s refresh) and one-shot mode (`--once`).
-
-### `daedalus/formatters.py`
-Human-readable panel renderer for all `/daedalus` inspection commands. Each command (`status`, `doctor`, `shadow-report`, `active-gate-status`, `service-status`, `get-observability`) has a dedicated formatter that builds `Section` + `Row` objects and calls `format_panel`. ANSI color is auto-detected; `--format json` bypasses formatting entirely.
-
-### `daedalus/migration.py` + `observability_overrides.py`
-`migration.py` handles relay→daedalus filesystem renames (idempotent). `observability_overrides.py` reads/writes the `observability-overrides.json` file that lets operators change GitHub-comments behavior without editing `workflow.yaml`.
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         EXTERNAL TRIGGERS                                    │
+│   GitHub Issue (#42)    Operator (/daedalus)    workflow.yaml (hot-reload)   │
+└─────────────────────────────────────────────────────────────────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌──────────────────────────────────────┐  ┌──────────────────────────────────────┐
+│     DAEDALUS ENGINE (Cyan)          │  │    WORKFLOW WRAPPER (Emerald)       │
+│  ─────────────────────────────────   │  │  ─────────────────────────────────   │
+│  Runtime Loop                        │  │  Status / Read Model                │
+│    Tick → Ingest → Derive → Dispatch │◄─┤  Policy Engine                       │
+│    → Record                          │  │  Actors (Coder / Reviewer / Merge)   │
+│                                      │  │  Lane State Machine                  │
+│  Leases (heartbeat · TTL · recovery) │  │  Handoffs (explicit, durable)       │
+│                                      │  │                                      │
+│  SQLite ──► lanes · actions ·      │  │  Semantic Actions                    │
+│             reviews · failures       │  │    run_claude_review                 │
+│                                      │  │    publish_ready_pr                  │
+│  JSONL ───► turn_started ·           │  │    merge_and_promote                 │
+│             turn_completed · stall     │  │                                      │
+│                                      │  │  ▼                                   │
+│  Shadow Mode ──► observe · plan     │  │  Execution Actions                   │
+│  Active Mode ──► execute · dispatch │◄─┤    request_internal_review           │
+│                                      │  │    publish_pr                        │
+│  Operator Surfaces                   │  │    merge_pr                          │
+│    /daedalus status · doctor · watch │  │    dispatch_implementation_turn      │
+│    shadow-report · active-gate        │  │                                      │
+└──────────────────────────────────────┘  └──────────────────────────────────────┘
+         │                                           │
+         ▼                                           ▼
+┌────────────────────────────┐              ┌────────────────────────────┐
+│  SUPERVISION (Rose)        │              │  EXTERNAL (Amber/Grey)     │
+│  systemd service           │              │  GitHub API                │
+│  /daedalus watch (TUI)     │              │  Webhooks (Slack / HTTP)   │
+│  HTTP status :8765         │              │  Comments (PR audit trail) │
+└────────────────────────────┘              └────────────────────────────┘
+```
 
 ---
 
-## 4. Runtime model
+## The Two Brains
 
-## 4.1 Canonical runtime state
-Daedalus persists canonical state in SQLite under a workflow-local state path.
+Daedalus has **two brains** that speak different languages. The boundary between them is the most important design decision in the system.
 
-Important runtime entities include:
-- `lanes`
-- `lane_actors`
-- `lane_reviews`
-- `lane_actions`
-- `failures`
-- `leases`
-- `daedalus_runtime`
+### Brain 1: The Workflow Wrapper (Semantic)
 
-This lets Daedalus answer questions like:
-- what lane is active?
-- who owns the lane actor session?
-- which review is pending or complete?
-- what action has been requested, failed, or retried?
-- is this runtime still the lease holder?
+> *"What should happen next?"*
 
-## 4.2 Event log
-Daedalus appends semantic events into JSONL for replay/postmortem/operator archaeology.
+The wrapper is the **policy engine**. It knows about:
+- GitHub issues, labels, PRs, review threads
+- Semantic workflow states (`implementing`, `under_review`, `approved`)
+- Review policy (Claude must pass before publish, Codex Cloud must pass before merge)
+- Actor configuration (which model runs which role)
 
-Typical events:
-- shadow action requested
-- active action requested
-- action failed
-- failure detected
-- operator attention required
-- implementation requested
-- internal review requested
-- merge requested
+It speaks **workflow semantics**:
+```
+run_claude_review
+publish_ready_pr
+merge_and_promote
+dispatch_codex_turn
+```
 
-## 4.3 Lease model
-The runtime loop refreshes a lease/heartbeat on every iteration.
+### Brain 2: Daedalus Runtime (Execution)
 
-This protects against:
-- split-brain active ownership
-- fake liveness after a dead process
-- orphaned background instances
+> *"How do I orchestrate this durably?"*
 
----
+Daedalus is the **execution engine**. It knows about:
+- Leases and heartbeats
+- SQLite canonical state
+- Action queues and idempotency keys
+- Retry bookkeeping and failure tracking
+- Shadow vs active execution modes
 
-## 5. Execution modes
+It speaks **execution semantics**:
+```
+request_internal_review
+publish_pr
+merge_pr
+dispatch_implementation_turn
+dispatch_repair_handoff
+```
 
-## 5.1 Shadow mode
-Daedalus:
-- ingests workflow truth
-- derives what it would do
-- persists shadow actions
-- emits comparison/operator reports
-- does **not** own primary side effects
+### Why two vocabularies?
 
-Use shadow mode to validate parity safely.
-
-## 5.2 Active mode
-Daedalus:
-- ingests workflow truth
-- derives active actions
-- executes allowed side effects
-- records success/failure/retry state
-
-Use active mode for real orchestration.
+Because **policy changes faster than orchestration**. The wrapper can change its mind about when to publish. Daedalus must still guarantee that the publish action happens exactly once, survives crashes, and retries correctly.
 
 ---
 
-## 6. Background service model
+## The Five Guarantees
 
-In YoYoPod, Daedalus is supervised as a user-scoped systemd service.
+Daedalus exists to provide five guarantees that fragile cron-loop automation cannot:
 
-Current active unit points directly at the plugin runtime:
-- `python3 .hermes/plugins/daedalus/runtime.py run-active ...`
+### 1. Exactly-One Ownership (Leases)
 
-This gives:
-- restart on failure
-- explicit runtime profile
-- stable working directory and PATH
-- durable 24/7 process ownership
+```
+┌─────────┐    acquire lease    ┌─────────┐
+│ Runtime │ ───────────────────► │  Lane   │
+│    A    │ ◄─────────────────── │  #42    │
+└─────────┘    heartbeat (TTL)   └─────────┘
+      │
+      │  process dies
+      ▼
+┌─────────┐    lease expires    ┌─────────┐
+│ Runtime │ ◄─────────────────── │  Lane   │
+│    B    │ ───────────────────► │  #42    │
+└─────────┘    claim on next tick └─────────┘
+```
 
-That matters because an orchestrator pretending to be a chat session is bullshit. A real orchestrator must have real supervision.
+- **Exclusivity:** One runtime owns a lane at a time.
+- **Liveness:** Heartbeats prove the owner is alive.
+- **Recovery:** Any instance can claim an expired lease. No coordinator needed.
 
----
+### 2. Exactly-Once Actions (Idempotency)
 
-## 7. Workflow integration model
+Every active action has a composite key:
+```
+lane:<id>:<action_type>:<head_sha>
+```
 
-Daedalus is intentionally **workflow-aware**, not generic magic.
+This prevents:
+- Double-dispatching the same review on the same head
+- Re-running `merge_pr` after the PR is already merged
+- Spawning infinite coder sessions for a single issue
 
-It consumes workflow truth from the wrapper and then maps it into a durable execution model.
+### 3. State Is Tracked, Not Guessed
 
-### Wrapper semantic actions
-Examples:
-- `run_claude_review`
-- `publish_ready_pr`
-- `merge_and_promote`
-- `dispatch_codex_turn`
+| Layer | Storage | Purpose |
+|---|---|---|
+| **SQLite** | `daedalus.db` | Canonical runtime state now |
+| **JSONL** | `daedalus-events.jsonl` | Append-only history |
+| **Lane files** | `.lane-state.json` | Lane-local handoff artifacts |
+| **Lane memos** | `.lane-memo.md` | Human-readable handoff notes |
 
-### Daedalus execution actions
-Examples:
-- `request_internal_review`
-- `publish_pr`
-- `merge_pr`
-- `dispatch_implementation_turn`
-- `dispatch_repair_handoff`
+Never reconstruct current state by replaying events. That's what the `lanes` table is for.
 
-That translation boundary is deliberate.
-The wrapper speaks **workflow semantics**.
-Daedalus speaks **execution semantics**.
+### 4. Bad Edits Don't Crash the Loop
 
----
+```mermaid
+flowchart TD
+    A[tick begins] --> B{workflow.yaml changed?}
+    B -- no --> C[reuse last ConfigSnapshot]
+    B -- yes --> D[parse + validate]
+    D -- ok --> E[swap AtomicRef]
+    D -- fail --> F[keep last good config]
+    F --> G[emit config_reload_failed]
+    C --> H[continue tick]
+    E --> H
+    G --> H
+```
 
-## 8. Actor and review model
+A bad `workflow.yaml` edit is **ignored**, not fatal. The next valid save picks up automatically.
 
-## 8.1 Internal coder
-Usually Codex-backed persistent lane session.
+### 5. Recovery Is Automatic
 
-Responsibilities:
-- implement changes
-- repair findings
-- update local branch or PR branch
+When an action fails:
+1. Failed row is persisted with `retry_count`
+2. Next tick checks if retry budget remains
+3. If yes: requeue with incremented `retry_count`
+4. If no: transition to `operator_attention_required`
+5. Human intervenes, or the lane is archived
 
-## 8.2 Internal reviewer
-Usually Claude-backed local unpublished-branch gate.
-
-Responsibilities:
-- evaluate local unpublished head before publish
-- emit local review verdict and findings
-
-## 8.3 External reviewer
-Usually Codex Cloud on published PRs.
-
-Responsibilities:
-- review ready-for-review PR head
-- generate actionable external findings
-- gate merge
-
-## 8.4 Advisory reviewer
-Optional additional reviewer role, for example Rock Claw.
-
----
-
-## 9. Policy and phase model
-
-## 9.1 Local phase
-No PR yet.
-Primary actor: internal coder.
-Primary gate: internal reviewer.
-
-Typical states:
-- `implementing`
-- `implementing_local`
-- `awaiting_claude_prepublish`
-- `claude_prepublish_findings`
-- `ready_to_publish`
-
-## 9.2 Published phase
-PR exists and is ready for review.
-Primary external gate: Codex Cloud.
-
-Typical states:
-- `under_review`
-- `findings_open`
-- `approved`
-
-## 9.3 Merge phase
-If the published PR is clean and mergeable:
-- merge
-- close issue
-- promote next lane
+Lost workers never block forward motion.
 
 ---
 
-## 10. Handoff design
+## The Lane Lifecycle
 
-### Handoff A: Orchestrator -> coder
-Wrapper or Daedalus dispatches implementation work.
+A lane is the unit of work. One GitHub issue becomes one lane. The lane carries the issue from discovery to merge.
 
-Artifacts:
-- worktree
-- lane memo
-- lane state
-- actor session strategy
-- target head / PR context
+```mermaid
+stateDiagram-v2
+    [*] --> discovered: issue labeled
+    discovered --> implementing: lane selected
+    implementing --> awaiting_review: coder commits
+    awaiting_review --> changes_requested: reviewer rejects
+    changes_requested --> implementing: repair handoff
+    awaiting_review --> ready_to_publish: internal gate passed
+    ready_to_publish --> under_review: PR published
+    under_review --> findings_open: external reviewer rejects
+    findings_open --> implementing: repair handoff
+    under_review --> approved: external gate passed
+    approved --> merged: merge tick
+    merged --> [*]
 
-### Handoff B: coder -> internal reviewer
-Once a local candidate head exists, Claude reviews the unpublished head.
+    implementing --> stall_terminated: stall timeout
+    stall_terminated --> implementing: retry queued
+    awaiting_review --> stall_terminated: stall timeout
+    under_review --> stall_terminated: stall timeout
+```
 
-### Handoff C: internal reviewer -> coder
-If local findings exist, repair handoff goes back to the coder lane.
-
-### Handoff D: internal reviewer -> publish path
-If local gate is clean, wrapper derives publish.
-
-### Handoff E: publish -> external reviewer
-Once PR is ready, Codex Cloud becomes the required reviewer.
-
-### Handoff F: external reviewer -> coder
-If external findings exist, repair handoff goes back to the coder lane.
-
-### Handoff G: clean PR -> merge/promote
-If no blockers remain, merge and advance the workflow.
-
-This is the heart of the design: **explicit role handoffs, not vibes.**
+States with no outgoing arrows (other than terminal `merged` / `closed` / `archived`) keep retrying — **the lane never crashes the loop, only the current attempt.**
 
 ---
 
-## 11. Failure model
+## The Actor Model
 
-Daedalus models failures as first-class runtime state.
+Coding and reviewing are **explicit roles**, not ad-hoc prompt invocations.
 
-When an active action fails, Daedalus can persist:
-- failed action row
-- failure summary
-- recovery state
-- retry count
-- optional superseding recovery action
+| Role | Runtime | Model | When Active | Gate |
+|---|---|---|---|---|
+| **Internal Coder** | `acpx-codex` | `gpt-5.3-codex-spark/high` | Before PR exists | — |
+| **Internal Reviewer** | `claude-cli` | `claude-sonnet-4-6` | Local branch exists | Must pass before publish |
+| **External Reviewer** | `acpx-codex` | `gpt-5` | PR published | Must pass before merge |
+| **Advisory Reviewer** | varies | varies | Any time | Informative only |
 
-### Why this matters
-Without explicit failure state, every retry decision becomes guesswork.
-With explicit failure state, the system can answer:
-- did this fail before?
-- should we retry?
-- did retry already happen?
-- has this been superseded?
-- are we stuck badly enough to require operator attention?
+### Handoff Map
 
-### Recent hardening that matters
-Two failure modes were fixed during lane 220 work:
-1. failed internal review no longer leaves wrapper review state falsely stuck at `running`
-2. failed active `request_internal_review` actions no longer permanently consume the active idempotency slot for that head
+```
+Orchestrator ──► Coder ──► Internal Reviewer ──► Publish ──► External Reviewer ──► Merge
+     │              │              │                    │              │
+     │              │              └─► repair ──────────┘              │
+     │              │                                                   │
+     │              └─► repair ◄────────────────────────────────────────┘
+     │
+     └─► restart session (if stale)
+```
 
-That second fix is the difference between a durable orchestrator and a deadlocked queue with nice branding.
+Every handoff survives service restarts, session staleness, and GitHub drift.
 
 ---
 
-## 12. Operator surfaces
+## Execution Modes
 
-Daedalus intentionally exposes operator tooling instead of forcing direct DB archaeology.
+### Shadow Mode: "What would I do?"
 
-Typical surfaces:
-- `status`
-- `shadow-report`
-- `doctor`
-- `active-gate-status`
-- service install/start/restart helpers
+- Reads workflow state
+- Derives next action
+- Writes **shadow** action rows (no idempotency check)
+- Emits comparison reports
+- **No side effects**
 
-These should answer:
-- who owns orchestration?
-- is the runtime healthy?
-- is it fresh or stale?
-- does Daedalus agree with wrapper semantics?
-- are there unresolved failures?
-- is a service crash or lease problem hiding under the hood?
+Use shadow mode to validate parity safely before promoting to active.
+
+### Active Mode: "What actually happens."
+
+- Reads workflow state
+- Derives next action
+- Writes **active** action rows (idempotency enforced)
+- Dispatches to real runtimes
+- Records success / failure / retry state
+
+Promotion from shadow to active is gated by `active-gate-status` — an explicit operator step, not a config edit.
 
 ---
 
-## 13. Current YoYoPod deployment interpretation
+## The Data Flow (One Tick)
 
-The current deployment uses a layered model:
-- wrapper remains semantic owner
-- Daedalus active service is recurring dispatcher
-- wrapper `tick` remains manual fallback
-- milestone notifier remains as a Hermes cron support job
-- outage alerts remain a support surface, not the orchestrator
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   TICK      │────►│   INGEST    │────►│   DERIVE    │────►│   DISPATCH  │
+│  (cron/     │     │  wrapper    │     │  nextAction │     │  to runtime │
+│   manual)   │     │  status     │     │  from state │     │  (active)   │
+└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘
+                                                                  │
+                                                                  ▼
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   NEXT      │◄────│   RECORD    │◄────│   RESULT    │◄────│   RUNTIME   │
+│   TICK      │     │  success/   │     │  success/   │     │  executes   │
+│             │     │  failure    │     │  failure    │     │  turn       │
+└─────────────┘     └─────────────┘     └─────────────┘     └─────────────┘
+```
 
-That is a sensible transitional architecture.
+Each tick:
+1. **Ingest** — Pull wrapper status into SQLite
+2. **Derive** — Compare wrapper `nextAction` with runtime state
+3. **Dispatch** — If action is new and idempotency key is free, dispatch to runtime
+4. **Record** — Write result (success/failure/retry) to SQLite + JSONL
+5. **Heartbeat** — Refresh lease to prove liveness
+
+---
+
+## Operator Surfaces
+
+Daedalus exposes tooling instead of forcing DB archaeology.
+
+| Surface | Command | What It Answers |
+|---|---|---|
+| **Status** | `/daedalus status` | Runtime row, lane count, paths, freshness |
+| **Doctor** | `/daedalus doctor` | Full health check across all subsystems |
+| **Watch** | `/daedalus watch` | Live TUI: lanes + alerts + events |
+| **Shadow Report** | `/daedalus shadow-report` | Diff shadow plan vs active reality |
+| **Active Gate** | `/daedalus active-gate-status` | What's blocking promotion to active |
+| **Service** | `/daedalus service-status` | systemd health snapshot |
+| **HTTP** | `GET localhost:8765/api/v1/state` | JSON snapshot for dashboards |
+
+---
+
+## Repository Anatomy
+
+```
+daedalus/
+├── __init__.py              # Plugin registration
+├── plugin.yaml              # Plugin manifest
+├── schemas.py               # CLI/slash parser schema
+├── tools.py                 # Operator surface + systemd helpers
+├── runtime.py               # Durable engine (the heart)
+│   ├── database schema
+│   ├── leases + heartbeats
+│   ├── ingestion
+│   ├── action derivation
+│   ├── active execution
+│   ├── retries + failure tracking
+│   └── runtime loops
+├── alerts.py                # Outage alert logic
+├── watch.py                 # TUI frame renderer
+├── watch_sources.py         # Lane + alert + event aggregation
+├── formatters.py            # Human-readable inspection output
+├── migration.py             # relay→daedalus filesystem migration
+├── observability_overrides.py  # Operator config overrides
+└── workflows/
+    ├── __init__.py          # Workflow CLI entrypoint
+    └── code_review/
+        ├── workflow.py      # Semantic policy engine
+        ├── dispatch.py      # Action dispatch
+        ├── actions.py       # Action primitives
+        ├── reviews.py       # Review policy + findings
+        ├── sessions.py      # Session protocol
+        ├── runtimes/        # Runtime adapters
+        │   ├── claude_cli.py
+        │   ├── acpx_codex.py
+        │   └── hermes_agent.py
+        ├── reviewers/       # Reviewer implementations
+        ├── webhooks/        # Outbound webhook subscribers
+        ├── server/          # HTTP status surface
+        ├── comments.py      # GitHub comment formatting
+        └── observability.py # Config resolution
+```
+
+---
+
+## Current Deployment (YoYoPod)
+
+The current YoYoPod deployment is a **sensible transitional architecture**:
+
+| Layer | Owner | Role |
+|---|---|---|
+| **Wrapper** | YoYoPod workflow | Semantic policy engine |
+| **Daedalus active service** | systemd | Recurring dispatcher |
+| **Wrapper `tick`** | Manual fallback | Operator override |
+| **Milestone notifier** | Hermes cron | Support job (not orchestrator) |
+| **Outage alerts** | Daedalus alerts | Support surface (not scheduler) |
+
 It is not fully pure yet, but it is sane.
 
 ---
 
-## 14. Long-term vision
+## Long-Term Vision
 
-The long-term target is bigger than “a plugin that runs a bot.”
-
-The real target is:
-
-> full agentic SDLC lanes that run continuously, respect policy and review gates, survive failures, and let humans stay passive by default while stepping in only when judgment or escalation is truly needed.
+> Full agentic SDLC lanes that run continuously, respect policy and review gates, survive failures, and let humans stay passive by default while stepping in only when judgment or escalation is truly needed.
 
 That means:
-- each lane is durable
-- coding and reviewing are explicit roles
-- state transitions are auditable
-- failures are recoverable
-- humans can observe or intervene without becoming the scheduler
-- the system can run 24/7 without degrading into prompt spaghetti
+- Each lane is durable
+- Coding and reviewing are explicit roles
+- State transitions are auditable
+- Failures are recoverable
+- Humans observe or intervene without becoming the scheduler
+- The system runs 24/7 without degrading into prompt spaghetti
 
-Daedalus is the control-plane skeleton for that future.
+**Daedalus is the control-plane skeleton for that future.**
 
 ---
 
-## 15. Architecture in one sentence
+## See Also
+
+| Doc | What It Covers |
+|---|---|
+| [`concepts/lanes.md`](concepts/lanes.md) | Lane state machine, selection, workspace binding |
+| [`concepts/actions.md`](concepts/actions.md) | Action types, idempotency, shadow vs active |
+| [`concepts/failures.md`](concepts/failures.md) | Failure lifecycle, retry policy, lane-220 fixes |
+| [`concepts/leases.md`](concepts/leases.md) | Lease acquisition, heartbeat, recovery, split-brain |
+| [`concepts/reviewers.md`](concepts/reviewers.md) | Internal/external/advisory review pipeline |
+| [`concepts/observability.md`](concepts/observability.md) | Watch TUI, HTTP server, GitHub comments |
+| [`concepts/operator-attention.md`](concepts/operator-attention.md) | When attention triggers, thresholds, recovery |
+| [`operator/cheat-sheet.md`](operator/cheat-sheet.md) | Day-to-day commands, debugging, SQL cheats |
+
+---
+
+## Architecture in One Sentence
 
 **Daedalus is a durable orchestration runtime that wraps an SDLC workflow brain with leases, canonical state, action queues, role handoffs, retries, and operator tooling so agentic lanes can run continuously without turning into invisible cron-driven chaos.**


### PR DESCRIPTION
## Summary

Complete overhaul of the flagship architecture document. The old version was a dense wall of text — this one is designed to be read from top to bottom.

## What's New

### Visual
- **Interactive SVG architecture diagram** ()
  - Dark-themed, 5-layer system view
  - Semantic color coding (cyan=engine, emerald=wrapper, violet=storage, amber=external, rose=operator)
  - Bidirectional data flow arrows
  - Six info cards summarizing subsystems

### Rewritten Content
- **30-Second Read** — quick-reference table at the top
- **ASCII System Diagram** — full architecture at a glance
- **The Two Brains** — explains the wrapper (semantic) vs Daedalus (execution) boundary with their different vocabularies
- **The Five Guarantees** — exactly-one ownership, exactly-once actions, tracked state, crash-resistant config, automatic recovery
- **Lane Lifecycle** — Mermaid state diagram including stall termination
- **Actor Model** — table of roles with runtimes, models, gates
- **Handoff Map** — visual ASCII showing full flow with repair loops
- **Data Flow (One Tick)** — step-by-step ASCII diagram
- **Operator Surfaces** — table of every command and what it answers
- **Repository Anatomy** — tree view of the codebase
- **See Also** — cross-references to all concept docs

## Stats
- : 328 insertions, 357 deletions (net -29 lines but vastly more information density)
- New file:  (26KB standalone HTML)

Closes #30
