### PR TITLE
fix(architecture): replace HTML diagram with SVG for GitHub native rendering

### DIFF
--- a/assets/daedalus-architecture-diagram.svg
+++ b/assets/daedalus-architecture-diagram.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" width="100%" style="background-color:#020617;">
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+    </pattern>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
+    </marker>
+    <marker id="arrowhead-cyan" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#22d3ee"/>
+    </marker>
+    <marker id="arrowhead-emerald" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#34d399"/>
+    </marker>
+    <marker id="arrowhead-rose" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#fb7185"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="900" fill="#020617"/>
+  <rect width="1200" height="900" fill="url(#grid)"/>
+
+  <text x="600" y="40" fill="white" font-family="monospace" font-size="20" font-weight="700" text-anchor="middle">Daedalus Architecture</text>
+  <text x="600" y="65" fill="#94a3b8" font-family="monospace" font-size="12" text-anchor="middle">Durable orchestration for agentic SDLC lanes</text>
+
+  <text x="600" y="100" fill="#64748b" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="2">EXTERNAL TRIGGERS</text>
+  
+  <rect x="200" y="115" width="140" height="55" rx="8" fill="rgba(30,41,59,0.6)" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="270" y="138" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">GitHub Issue</text>
+  <text x="270" y="155" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">#42 · active-lane</text>
+
+  <rect x="530" y="115" width="140" height="55" rx="8" fill="rgba(136,19,55,0.3)" stroke="#fb7185" stroke-width="1.5"/>
+  <text x="600" y="138" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Operator</text>
+  <text x="600" y="155" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">/daedalus commands</text>
+
+  <rect x="860" y="115" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="930" y="138" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">workflow.yaml</text>
+  <text x="930" y="155" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Hot-reload config</text>
+
+  <rect x="50" y="200" width="520" height="420" rx="16" fill="rgba(8,51,68,0.08)" stroke="#22d3ee" stroke-width="2" stroke-dasharray="12,6"/>
+  <text x="70" y="225" fill="#22d3ee" font-family="monospace" font-size="13" font-weight="700" letter-spacing="1">DAEDALUS ENGINE</text>
+  <text x="70" y="240" fill="#22d3ee" font-family="monospace" font-size="9" opacity="0.7">Orchestration Runtime</text>
+
+  <rect x="80" y="260" width="200" height="80" rx="10" fill="rgba(8,51,68,0.4)" stroke="#22d3ee" stroke-width="2"/>
+  <text x="180" y="285" fill="white" font-family="monospace" font-size="13" font-weight="700" text-anchor="middle">Runtime Loop</text>
+  <text x="180" y="305" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Tick → Ingest → Derive</text>
+  <text x="180" y="320" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">→ Dispatch → Record</text>
+
+  <rect x="340" y="260" width="200" height="55" rx="8" fill="rgba(8,51,68,0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+  <text x="440" y="285" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Leases</text>
+  <text x="440" y="302" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Heartbeat · TTL · Recovery</text>
+
+  <rect x="80" y="370" width="200" height="70" rx="8" fill="rgba(76,29,149,0.4)" stroke="#a78bfa" stroke-width="2"/>
+  <text x="180" y="395" fill="white" font-family="monospace" font-size="13" font-weight="700" text-anchor="middle">SQLite</text>
+  <text x="180" y="412" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Canonical State</text>
+  <text x="180" y="427" fill="#a78bfa" font-family="monospace" font-size="8" text-anchor="middle">lanes · actions · reviews · failures</text>
+
+  <rect x="340" y="370" width="200" height="70" rx="8" fill="rgba(76,29,149,0.3)" stroke="#a78bfa" stroke-width="1.5"/>
+  <text x="440" y="395" fill="white" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle">JSONL Event Log</text>
+  <text x="440" y="412" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Append-Only History</text>
+  <text x="440" y="427" fill="#a78bfa" font-family="monospace" font-size="8" text-anchor="middle">turn_started · turn_completed · stall</text>
+
+  <rect x="80" y="470" width="200" height="55" rx="8" fill="rgba(120,53,15,0.2)" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="180" y="492" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Shadow Mode</text>
+  <text x="180" y="510" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Observe · Plan · No Side Effects</text>
+
+  <rect x="340" y="470" width="200" height="55" rx="8" fill="rgba(6,78,59,0.4)" stroke="#34d399" stroke-width="2"/>
+  <text x="440" y="492" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Active Mode</text>
+  <text x="440" y="510" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Execute · Dispatch · Real Side Effects</text>
+
+  <rect x="80" y="550" width="460" height="50" rx="8" fill="rgba(136,19,55,0.2)" stroke="#fb7185" stroke-width="1.5"/>
+  <text x="310" y="570" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Operator Surfaces</text>
+  <text x="310" y="588" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">/daedalus status · doctor · watch · shadow-report · active-gate</text>
+
+  <rect x="620" y="200" width="530" height="420" rx="16" fill="rgba(6,78,59,0.08)" stroke="#34d399" stroke-width="2" stroke-dasharray="12,6"/>
+  <text x="640" y="225" fill="#34d399" font-family="monospace" font-size="13" font-weight="700" letter-spacing="1">WORKFLOW WRAPPER</text>
+  <text x="640" y="240" fill="#34d399" font-family="monospace" font-size="9" opacity="0.7">Semantic Policy Brain</text>
+
+  <rect x="650" y="260" width="220" height="60" rx="8" fill="rgba(6,78,59,0.4)" stroke="#34d399" stroke-width="2"/>
+  <text x="760" y="285" fill="white" font-family="monospace" font-size="13" font-weight="700" text-anchor="middle">Status / Read Model</text>
+  <text x="760" y="305" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">nextAction · health · reviewLoopState</text>
+
+  <rect x="910" y="260" width="220" height="60" rx="8" fill="rgba(6,78,59,0.3)" stroke="#34d399" stroke-width="1.5"/>
+  <text x="1020" y="285" fill="white" font-family="monospace" font-size="13" font-weight="600" text-anchor="middle">Policy Engine</text>
+  <text x="1020" y="305" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">publish · merge · promote rules</text>
+
+  <rect x="650" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="720" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Internal Coder</text>
+  <text x="720" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Codex · acpx</text>
+
+  <rect x="820" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="890" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Internal Reviewer</text>
+  <text x="890" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Claude · claude-cli</text>
+
+  <rect x="990" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="1060" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">External Reviewer</text>
+  <text x="1060" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Codex Cloud</text>
+
+  <rect x="650" y="430" width="480" height="80" rx="10" fill="rgba(6,78,59,0.2)" stroke="#34d399" stroke-width="1.5"/>
+  <text x="890" y="452" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Lane State Machine</text>
+  <text x="890" y="475" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">implementing → awaiting_claude_prepublish → ready_to_publish</text>
+  <text x="890" y="492" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">→ under_review → findings_open → approved → merged</text>
+
+  <rect x="650" y="535" width="480" height="55" rx="8" fill="rgba(6,78,59,0.15)" stroke="#34d399" stroke-width="1" stroke-dasharray="4,4"/>
+  <text x="890" y="555" fill="#34d399" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Handoffs: Orchestrator → Coder → Reviewer → Publish → Merge</text>
+  <text x="890" y="575" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Explicit role handoffs, not vibes. Every handoff survives restarts.</text>
+
+  <rect x="50" y="650" width="520" height="120" rx="16" fill="rgba(136,19,55,0.06)" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="70" y="675" fill="#fb7185" font-family="monospace" font-size="12" font-weight="700" letter-spacing="1">SUPERVISION &amp; OBSERVABILITY</text>
+
+  <rect x="80" y="690" width="160" height="55" rx="8" fill="rgba(136,19,55,0.3)" stroke="#fb7185" stroke-width="1.5"/>
+  <text x="160" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">systemd Service</text>
+  <text x="160" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">daedalus-active@.service</text>
+
+  <rect x="280" y="690" width="140" height="55" rx="8" fill="rgba(8,51,68,0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+  <text x="350" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">/daedalus watch</text>
+  <text x="350" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Live TUI · 1s refresh</text>
+
+  <rect x="460" y="690" width="90" height="55" rx="8" fill="rgba(8,51,68,0.3)" stroke="#22d3ee" stroke-width="1.5"/>
+  <text x="505" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">HTTP</text>
+  <text x="505" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">localhost:8765</text>
+
+  <rect x="620" y="650" width="530" height="120" rx="16" fill="rgba(120,53,15,0.06)" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="640" y="675" fill="#fbbf24" font-family="monospace" font-size="12" font-weight="700" letter-spacing="1">EXTERNAL INTEGRATIONS</text>
+
+  <rect x="650" y="690" width="180" height="55" rx="8" fill="rgba(30,41,59,0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="740" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">GitHub API</text>
+  <text x="740" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Issues · PRs · Reviews · Comments</text>
+
+  <rect x="870" y="690" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="940" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Webhooks</text>
+  <text x="940" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Slack · HTTP JSON</text>
+
+  <rect x="1050" y="690" width="80" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="1090" y="712" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Comments</text>
+  <text x="1090" y="730" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">PR audit</text>
+
+  <line x1="340" y1="170" x2="340" y2="200" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <text x="350" y="190" fill="#94a3b8" font-family="monospace" font-size="8">labeled</text>
+
+  <line x1="600" y1="170" x2="600" y2="200" stroke="#fb7185" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="930" y1="170" x2="570" y2="200" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="570" y1="320" x2="620" y2="320" stroke="#22d3ee" stroke-width="2" marker-end="url(#arrowhead-cyan)"/>
+  <line x1="620" y1="330" x2="570" y2="330" stroke="#34d399" stroke-width="2" marker-end="url(#arrowhead-emerald)"/>
+  <text x="595" y="315" fill="#22d3ee" font-family="monospace" font-size="8" text-anchor="middle">ingest</text>
+  <text x="595" y="345" fill="#34d399" font-family="monospace" font-size="8" text-anchor="middle">dispatch</text>
+
+  <line x1="180" y1="340" x2="180" y2="370" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="280" y1="300" x2="390" y2="370" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="280" y1="525" x2="340" y2="525" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="4,4" marker-end="url(#arrowhead)"/>
+  <text x="310" y="520" fill="#fbbf24" font-family="monospace" font-size="8" text-anchor="middle">promote</text>
+
+  <line x1="760" y1="320" x2="720" y2="350" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="890" y1="320" x2="890" y2="350" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="1020" y1="320" x2="1060" y2="350" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="890" y1="590" x2="740" y2="650" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="310" y1="620" x2="160" y2="650" stroke="#fb7185" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="350" y1="620" x2="350" y2="690" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="430" y1="600" x2="505" y2="690" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <line x1="1020" y1="590" x2="940" y2="650" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+
+  <text x="1050" y="810" fill="white" font-family="monospace" font-size="10" font-weight="600">Legend</text>
+  
+  <rect x="1050" y="822" width="16" height="10" rx="2" fill="rgba(8,51,68,0.4)" stroke="#22d3ee" stroke-width="1"/>
+  <text x="1072" y="830" fill="#94a3b8" font-family="monospace" font-size="8">Daedalus Engine</text>
+  
+  <rect x="1050" y="838" width="16" height="10" rx="2" fill="rgba(6,78,59,0.4)" stroke="#34d399" stroke-width="1"/>
+  <text x="1072" y="846" fill="#94a3b8" font-family="monospace" font-size="8">Workflow Wrapper</text>
+  
+  <rect x="1050" y="854" width="16" height="10" rx="2" fill="rgba(76,29,149,0.4)" stroke="#a78bfa" stroke-width="1"/>
+  <text x="1072" y="862" fill="#94a3b8" font-family="monospace" font-size="8">State / Storage</text>
+  
+  <rect x="1050" y="870" width="16" height="10" rx="2" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1"/>
+  <text x="1072" y="878" fill="#94a3b8" font-family="monospace" font-size="8">Runtime / Actor</text>
+  
+  <rect x="1050" y="886" width="16" height="10" rx="2" fill="rgba(136,19,55,0.3)" stroke="#fb7185" stroke-width="1"/>
+  <text x="1072" y="894" fill="#94a3b8" font-family="monospace" font-size="8">Operator / Alert</text>
+
+  <rect x="1050" y="902" width="16" height="10" rx="2" fill="rgba(30,41,59,0.5)" stroke="#94a3b8" stroke-width="1"/>
+  <text x="1072" y="910" fill="#94a3b8" font-family="monospace" font-size="8">External</text>
+
+  <text x="600" y="940" fill="#475569" font-family="monospace" font-size="10" text-anchor="middle" font-style="italic">
+    "Turn fragile cron-loop automation into explicit, durable, role-based 24/7 workflow orchestration."
+  </text>
+</svg>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Daedalus Architecture Diagram](assets/daedalus-architecture-diagram.html)
+![Daedalus Architecture Diagram](assets/daedalus-architecture-diagram.svg)
 
 > **Daedalus is a durable orchestration runtime that wraps an SDLC workflow brain with leases, canonical state, action queues, role handoffs, retries, and operator tooling so agentic lanes can run continuously without turning into invisible cron-driven chaos.**
 


### PR DESCRIPTION
## Problem

The interactive HTML architecture diagram added in #31 does not render inline on GitHub because GitHub strips raw HTML in Markdown for security.

## Solution

- Add a standalone SVG version of the architecture diagram ()
- Update  to reference  instead of 
- The SVG is pure vector graphics — no external dependencies, no JavaScript

## What renders now

The diagram appears inline in the architecture doc with:
- Dark theme with grid background
- 5 semantic layers (External Triggers → Daedalus Engine → Workflow Wrapper → Supervision → External Integrations)
- Color-coded components: cyan (engine), emerald (wrapper), violet (storage), amber (actors/external), rose (operator)
- Bidirectional data flow arrows with labels
- Legend and tagline

## Keep the HTML too?

The HTML version () is preserved for:
- Local interactive viewing (open in browser)
- Future GitHub Pages hosting

Fixes #30