### PR TITLE
[codex] align Daedalus with official Hermes plugin distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+
+      - name: Run test suite
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 .pytest_cache/
 .DS_Store
 .claude/
+build/
+dist/
+*.egg-info/
 content/*
 daedalus/projects/*/runtime/*
 !daedalus/projects/*/runtime/README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+recursive-include daedalus *.yaml *.md *.json

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Daedalus warned Icarus, then flew home. Edits take effect on the next tick. A ba
 - **Operator commands** — `/daedalus status`, `/daedalus doctor`, `/workflow code-review status`, `/workflow code-review tick`.
 - **Live status dashboard** — ships separately as a Hermes-Agent watch plugin.
 
+## Supported path
+
+Daedalus is ready to publish on one explicit path:
+
+- **Platform:** Linux
+- **Plugin home:** `~/.hermes/plugins/daedalus`
+- **Workflow root:** `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
+- **Host Python:** `python3` with `yaml` and `jsonschema` available
+- **24/7 supervision:** `systemd --user`
+- **Runtime adapters:** whatever `workflow.yaml` names must exist on the host (`acpx-codex`, `claude-cli`, `hermes-agent`, ...).
+
+If you want the exact operator contract we support, read [docs/public-contract.md](docs/public-contract.md).
+
 ## Install & quick start
 
 ```bash
@@ -68,24 +81,69 @@ Daedalus warned Icarus, then flew home. Edits take effect on the next tick. A ba
 git clone https://github.com/attmous/daedalus.git
 cd daedalus
 
-# 2. Install into your Hermes home
+# 2. Make sure host python has the runtime deps
+# Debian/Ubuntu example:
+sudo apt install python3-yaml python3-jsonschema
+
+# 3. Install the plugin into your Hermes home
 ./scripts/install.sh
 
-# 3. Launch Hermes with project plugins enabled
+# 4. Scaffold one workflow instance
+python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --github-slug your-org/your-repo
+```
+
+Edit `~/.hermes/workflows/your-org-your-repo-code-review/config/workflow.yaml` before starting the engine:
+
+- set `repository.local-path`
+- confirm the runtime kinds you actually have installed
+- tune agents/models/gates for your repo
+
+Then initialize, verify, and supervise it:
+
+```bash
+python3 ~/.hermes/plugins/daedalus/tools.py init \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
+
+python3 ~/.hermes/plugins/daedalus/tools.py doctor \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --format json
+
+python3 ~/.hermes/plugins/daedalus/tools.py service-install \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+
+python3 ~/.hermes/plugins/daedalus/tools.py service-enable \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+
+python3 ~/.hermes/plugins/daedalus/tools.py service-start \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+```
+
+Start Hermes in your repo:
+
+```bash
 export HERMES_ENABLE_PROJECT_PLUGINS=true
-cd <project-root>
+export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
+cd /path/to/your/repo
 hermes
 ```
 
 Inside Hermes:
 
 ```text
+
 /daedalus status
 /daedalus doctor
 /workflow code-review status
 ```
 
-**Need a non-default install location?**
+The full supported install path is documented in [docs/operator/installation.md](docs/operator/installation.md).
+
+Need a non-default plugin install location?
 
 ```bash
 ./scripts/install.sh --hermes-home /path/to/hermes-home    # custom Hermes home
@@ -134,6 +192,8 @@ A **labeled issue** is the trigger. The **engine** ticks; for every active issue
 ## Documentation
 
 - **[docs/architecture.md](docs/architecture.md)** — the big picture, end to end.
+- **[docs/operator/installation.md](docs/operator/installation.md)** — the supported install, scaffold, verify, and supervise path.
+- **[docs/public-contract.md](docs/public-contract.md)** — the stability boundary for the first public release.
 - **[docs/concepts/](docs/concepts/)** — short explainers for each moving part: lanes, leases, runtimes, events, hot-reload, stalls.
 - **[docs/operator/](docs/operator/)** — day-to-day commands, the operator cheat sheet, the full slash-command catalogue.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Daedalus warned Icarus, then flew home. Edits take effect on the next tick. A ba
 Daedalus is ready to publish on one explicit path:
 
 - **Platform:** Linux
-- **Plugin home:** `~/.hermes/plugins/daedalus`
+- **Install path:** `hermes plugins install attmous/daedalus --enable`
+- **Plugin home after install:** `~/.hermes/plugins/daedalus`
 - **Workflow root:** `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
 - **Host Python:** `python3` with `yaml` and `jsonschema` available
 - **24/7 supervision:** `systemd --user`
@@ -77,19 +78,15 @@ If you want the exact operator contract we support, read [docs/public-contract.m
 ## Install & quick start
 
 ```bash
-# 1. Get the code
-git clone https://github.com/attmous/daedalus.git
-cd daedalus
-
-# 2. Make sure host python has the runtime deps
+# 1. Make sure host python has the runtime deps
 # Debian/Ubuntu example:
 sudo apt install python3-yaml python3-jsonschema
 
-# 3. Install the plugin into your Hermes home
-./scripts/install.sh
+# 2. Install and enable the plugin
+hermes plugins install attmous/daedalus --enable
 
-# 4. Scaffold one workflow instance
-python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow \
+# 3. Scaffold one workflow instance
+hermes daedalus scaffold-workflow \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --github-slug your-org/your-repo
 ```
@@ -103,22 +100,22 @@ Edit `~/.hermes/workflows/your-org-your-repo-code-review/config/workflow.yaml` b
 Then initialize, verify, and supervise it:
 
 ```bash
-python3 ~/.hermes/plugins/daedalus/tools.py init \
+hermes daedalus init \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
 
-python3 ~/.hermes/plugins/daedalus/tools.py doctor \
+hermes daedalus doctor \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --format json
 
-python3 ~/.hermes/plugins/daedalus/tools.py service-install \
+hermes daedalus service-install \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 
-python3 ~/.hermes/plugins/daedalus/tools.py service-enable \
+hermes daedalus service-enable \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 
-python3 ~/.hermes/plugins/daedalus/tools.py service-start \
+hermes daedalus service-start \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 ```
@@ -126,7 +123,6 @@ python3 ~/.hermes/plugins/daedalus/tools.py service-start \
 Start Hermes in your repo:
 
 ```bash
-export HERMES_ENABLE_PROJECT_PLUGINS=true
 export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
 cd /path/to/your/repo
 hermes
@@ -143,12 +139,28 @@ Inside Hermes:
 
 The full supported install path is documented in [docs/operator/installation.md](docs/operator/installation.md).
 
-Need a non-default plugin install location?
+Daedalus also ships a standard Hermes pip entry point. From a local checkout or
+published package, Hermes can discover it through `hermes_agent.plugins`:
 
 ```bash
+python3 -m pip install .
+hermes plugins enable daedalus
+```
+
+The Git install path above remains the primary community path because it is the
+most direct operator story and handles install + enable in one command.
+
+Need a local-dev fallback instead of `hermes plugins install`?
+
+```bash
+git clone https://github.com/attmous/daedalus.git
+cd daedalus
 ./scripts/install.sh --hermes-home /path/to/hermes-home    # custom Hermes home
 ./scripts/install.sh --destination /tmp/daedalus           # arbitrary destination
+hermes plugins enable daedalus
 ```
+
+`HERMES_ENABLE_PROJECT_PLUGINS=true` is only for project-local plugins under `./.hermes/plugins/`. It is not required for the supported global install path above.
 
 The full operator surface is in the [cheat sheet](docs/operator/cheat-sheet.md); every slash command is catalogued in [slash-commands.md](docs/operator/slash-commands.md).
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,16 @@
+"""Repo-root Hermes plugin entrypoint.
+
+Hermes' official Git install path expects ``plugin.yaml`` and ``__init__.py``
+at the repository root. The real implementation lives under ``./daedalus/``.
+This wrapper keeps the repo installable via ``hermes plugins install`` without
+moving the engine package again.
+"""
+
+try:
+    from .daedalus import register as _register
+except ImportError:
+    from daedalus import register as _register
+
+
+def register(ctx):
+    return _register(ctx)

--- a/daedalus/workflows/code_review/workflow.template.yaml
+++ b/daedalus/workflows/code_review/workflow.template.yaml
@@ -18,6 +18,8 @@ repository:
   active-lane-label: active-lane
 
 runtimes:
+  # These runtime kinds are host prerequisites. Change them if your
+  # environment uses a different adapter mix.
   coder-runtime:
     kind: acpx-codex
     session-idle-freshness-seconds: 900

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,9 @@ Entry point for everything that won't fit on the [project landing page](../READM
 ## Start here
 
 - **[architecture.md](architecture.md)** — the big picture. What Daedalus is, what it isn't, how the pieces fit together.
+- **[operator/installation.md](operator/installation.md)** — the supported install, scaffold, verify, and supervise flow.
 - **[examples/code-review.workflow.yaml](examples/code-review.workflow.yaml)** — copyable public baseline for `config/workflow.yaml`.
+- **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
 
 ## Concepts
 
@@ -41,10 +43,11 @@ Day-2 commands and observability.
 docs/
 ├── README.md                this file
 ├── architecture.md          big picture
+├── public-contract.md       stable public surfaces for the first release
 │
 ├── concepts/                "what does X mean" — one file per abstraction
 ├── examples/                copyable config baselines
-├── operator/                day-2 surface — cheat sheets, commands, endpoints
+├── operator/                install + day-2 surface — cheat sheets, commands, endpoints
 │
 ├── adr/                     architectural decisions (immutable record)
 ├── design/                  implementation specs that shipped

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,0 +1,179 @@
+# Daedalus Concepts
+
+> **The mental model of Daedalus, broken into bite-sized, interconnected ideas.**
+>
+> Each concept below is a self-contained document. Read them in any order — they cross-reference each other where it matters.
+
+---
+
+## Concept Map
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         DAEDALUS CONCEPT MAP                                   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌──────────────────┐      ┌──────────────────┐      ┌──────────────────┐  │
+│  │  CORE RUNTIME    │◄────►│  FAILURE &       │◄────►│  EXECUTION       │  │
+│  │                  │      │  RECOVERY        │      │  MODEL           │  │
+│  │  • Leases        │      │                  │      │                  │  │
+│  │  • Lanes         │      │  • Failures      │      │  • Runtimes      │  │
+│  │  • Actions       │      │  • Stalls        │      │  • Sessions      │  │
+│  │  • Shadow/Active │      │  • Operator      │      │  • Reviewers     │  │
+│  │  • Hot-reload    │      │    Attention     │      │                  │  │
+│  └────────┬─────────┘      └────────┬─────────┘      └────────┬─────────┘  │
+│           │                         │                         │             │
+│           └─────────────────────────┼─────────────────────────┘             │
+│                                     │                                       │
+│                                     ▼                                       │
+│  ┌──────────────────┐      ┌──────────────────┐      ┌──────────────────┐  │
+│  │  OBSERVABILITY   │◄────►│  OPERATIONS      │      │  (You are here)  │  │
+│  │  & INTEGRATION   │      │                  │      │                  │  │
+│  │                  │      │  • Migration     │      │                  │  │
+│  │  • Events        │      │                  │      │                  │  │
+│  │  • Observability │      │                  │      │                  │  │
+│  │  • Webhooks      │      │                  │      │                  │  │
+│  │  • Comments      │      │                  │      │                  │  │
+│  └──────────────────┘      └──────────────────┘      └──────────────────┘  │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Runtime
+
+The beating heart of Daedalus. These five concepts explain how the engine keeps lanes alive, decides what to do, and survives restarts.
+
+| Concept | One-Liner | Read This If... |
+|:---|:---|:---|
+| [**Leases**](./leases.md) | The thread Theseus carried into the labyrinth. Heartbeat-based ownership with automatic recovery. | ...you want to understand how Daedalus prevents split-brain and claims dead lanes. |
+| [**Lanes**](./lanes.md) | The unit of work. One GitHub issue becomes one lane, carried from discovery to merge. | ...you want to see the full lifecycle of an automated issue. |
+| [**Actions**](./actions.md) | The atomic unit of work. Queued, idempotent, tracked with composite keys. | ...you want to know how Daedalus guarantees exactly-once execution. |
+| [**Shadow → Active**](./shadow-active.md) | Two execution modes: observe safely, then promote to real side effects. | ...you want to validate Daedalus parity before letting it touch real PRs. |
+| [**Hot-reload**](./hot-reload.md) | Edit `workflow.yaml`, save, next tick picks it up. Bad edits are ignored, not fatal. | ...you want to change policy without restarting the service. |
+
+**The narrative arc:** *Leases* give you ownership → *Lanes* give you work → *Actions* give you execution → *Shadow/Active* gives you safety → *Hot-reload* gives you agility.
+
+---
+
+## Failure & Recovery
+
+Daedalus does not pretend failures don't happen. It models them as first-class state and recovers automatically.
+
+| Concept | One-Liner | Read This If... |
+|:---|:---|:---|
+| [**Failures**](./failures.md) | First-class runtime state with retry budgets, recovery actions, and superseding logic. | ...you want to know what happens when a review or merge fails. |
+| [**Stalls**](./stalls.md) | A wedged worker holding a lease but making no progress. Detected and terminated automatically. | ...you want to understand how Daedalus kills zombies. |
+| [**Operator Attention**](./operator-attention.md) | The state a lane enters when the wrapper decides human judgment is required. | ...you want to know when and why Daedalus asks for help. |
+
+**The narrative arc:** *Failures* are tracked → *Stalls* are detected → *Operator Attention* is the graceful off-ramp when automation hits its limit.
+
+---
+
+## Execution Model
+
+How code gets written, reviewed, and shipped by explicit actors with defined roles.
+
+| Concept | One-Liner | Read This If... |
+|:---|:---|:---|
+| [**Runtimes**](./runtimes.md) | The thing Daedalus shells out to. Claude CLI, Codex, or any subprocess that speaks the session protocol. | ...you want to add a new AI backend or local tool. |
+| [**Sessions**](./sessions.md) | The runtime's handle to a persistent or one-shot execution context. | ...you want to understand how Daedalus manages long-lived coder sessions. |
+| [**Reviewers**](./reviewers.md) | Multi-stage review pipeline: internal (Claude), external (Codex Cloud), advisory (optional). | ...you want to see how review gates are structured and enforced. |
+
+**The narrative arc:** *Runtimes* execute → *Sessions* persist state → *Reviewers* gate quality.
+
+---
+
+## Observability & Integration
+
+How Daedalus talks to the outside world and lets operators see what's happening.
+
+| Concept | One-Liner | Read This If... |
+|:---|:---|:---|
+| [**Events**](./events.md) | Append-only JSONL history of everything that happened. Replayable, auditable, immutable. | ...you want to debug what the system did last Tuesday. |
+| [**Observability**](./observability.md) | Three surfaces: watch TUI, HTTP status server, and GitHub comment audit trails. | ...you want to monitor health without SSHing into the box. |
+| [**Webhooks**](./webhooks.md) | Pluggable outbound subscribers for audit events. Slack, HTTP JSON, with SSRF guard. | ...you want notifications in your team's chat. |
+| [**Comments**](./comments.md) | Publish audit events as comments on the active GitHub issue or PR. | ...you want a public, timestamped record of what Daedalus did. |
+
+**The narrative arc:** *Events* record → *Observability* surfaces → *Webhooks* notify → *Comments* document.
+
+---
+
+## Operations
+
+The boring-but-critical stuff that keeps the lights on during transitions.
+
+| Concept | One-Liner | Read This If... |
+|:---|:---|:---|
+| [**Migration & Cutover**](./migration.md) | Moving from hermes-relay to Daedalus. Filesystem renames, config paths, and the cutover dance. | ...you are upgrading an existing installation. |
+
+---
+
+## How These Connect
+
+```
+GitHub Issue ──► [Lanes] ──► [Leases] claim ownership
+                    │
+                    ▼
+              [Actions] queued (shadow first)
+                    │
+                    ▼
+              [Runtimes] execute via [Sessions]
+                    │
+                    ▼
+              [Reviewers] gate (internal → external)
+                    │
+                    ▼
+              [Events] record ──► [Observability] surface
+                    │                    │
+                    ▼                    ▼
+              [Comments] publish    [Webhooks] notify
+                    │
+                    ▼
+              [Failures] tracked ──► [Stalls] detected
+                    │                    │
+                    ▼                    ▼
+              [Operator Attention] ◄── recovery
+                    │
+                    ▼
+              [Hot-reload] policy updated
+                    │
+                    ▼
+              [Migration] when upgrading
+```
+
+---
+
+## Start Here
+
+**New to Daedalus?** Read in this order:
+
+1. [**Lanes**](./lanes.md) — understand the unit of work
+2. [**Actions**](./actions.md) — understand what Daedalus actually does
+3. [**Leases**](./leases.md) — understand how it stays alive
+4. [**Shadow → Active**](./shadow-active.md) — understand how to deploy safely
+5. [**Failures**](./failures.md) — understand how it handles bad days
+
+**Operating Daedalus day-to-day?** Keep these open:
+
+- [**Observability**](./observability.md) — for monitoring
+- [**Operator Attention**](./operator-attention.md) — for knowing when to intervene
+- [**Events**](./events.md) — for archaeology
+
+**Extending Daedalus?** Read these:
+
+- [**Runtimes**](./runtimes.md) — adding new backends
+- [**Reviewers**](./reviewers.md) — changing review policy
+- [**Webhooks**](./webhooks.md) — adding new integrations
+
+---
+
+## See Also
+
+| Doc | What It Covers |
+|---|---|
+| [Architecture Overview](../architecture.md) | The big picture — how all concepts fit together |
+| [Operator Cheat Sheet](../operator/cheat-sheet.md) | Day-to-day commands, SQL, debugging |
+| [Slash Commands](../operator/slash-commands.md) | Every `/daedalus` command explained |
+| [Contributing](../contributing.md) | How to contribute to Daedalus |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,7 +31,13 @@ The public onboarding path should stay green too:
 
 ```bash
 pytest tests/test_public_onboarding_smoke.py -v
+pytest tests/test_official_plugin_layout.py -v
+pytest tests/test_pip_plugin_packaging.py -v
 ```
+
+If you touch files loaded at runtime via `Path(__file__).parent` — prompts,
+skills, workflow templates, project packs, or `plugin.yaml` — keep the package
+metadata in `pyproject.toml` / `MANIFEST.in` and the packaging test green.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,6 +11,9 @@ So you want to hack on Daedalus? Welcome. This doc covers how to run tests, add 
 git clone https://github.com/attmous/daedalus.git
 cd daedalus
 
+# Install contributor/test deps
+python3 -m pip install -r requirements-dev.txt
+
 # Install (into your Hermes home)
 ./scripts/install.sh
 
@@ -22,6 +25,12 @@ pytest tests/test_stall_detection.py -v
 
 # Run with coverage
 pytest --cov=daedalus --cov-report=term-missing
+```
+
+The public onboarding path should stay green too:
+
+```bash
+pytest tests/test_public_onboarding_smoke.py -v
 ```
 
 ---

--- a/docs/examples/code-review.workflow.yaml
+++ b/docs/examples/code-review.workflow.yaml
@@ -22,6 +22,8 @@ repository:
   active-lane-label: active-lane
 
 runtimes:
+  # These runtime kinds are host prerequisites. Change them if your
+  # environment uses a different adapter mix.
   coder-runtime:
     kind: acpx-codex
     session-idle-freshness-seconds: 900

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -1,0 +1,111 @@
+# Daedalus installation
+
+This is the supported community install path for the first public release.
+
+## Requirements
+
+- Linux
+- Hermes with plugin loading enabled
+- `python3` with `yaml` and `jsonschema` available
+- `systemd --user` for supervised active/shadow mode
+- the host CLIs required by the runtimes named in `workflow.yaml`
+
+The bundled `code-review` template defaults to:
+
+- `acpx-codex` for the coder runtime
+- `claude-cli` for the internal reviewer runtime
+
+If your host does not have those runtimes, edit `workflow.yaml` before starting the service.
+
+## Install the plugin
+
+```bash
+git clone https://github.com/attmous/daedalus.git
+cd daedalus
+sudo apt install python3-yaml python3-jsonschema
+./scripts/install.sh
+```
+
+The plugin source of truth is:
+
+```text
+~/.hermes/plugins/daedalus
+```
+
+## Scaffold a workflow root
+
+```bash
+python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --github-slug your-org/your-repo
+```
+
+This creates the supported instance layout:
+
+```text
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>/
+```
+
+## Configure the workflow
+
+Edit:
+
+```text
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>/config/workflow.yaml
+```
+
+At minimum, set:
+
+- `repository.local-path`
+- runtime kinds/models that exist on your host
+- any gates, webhooks, or observability settings your repo needs
+
+## Initialize and verify
+
+```bash
+python3 ~/.hermes/plugins/daedalus/tools.py init \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
+
+python3 ~/.hermes/plugins/daedalus/tools.py doctor \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --format json
+```
+
+## Supervise it
+
+```bash
+python3 ~/.hermes/plugins/daedalus/tools.py service-install \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+
+python3 ~/.hermes/plugins/daedalus/tools.py service-enable \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+
+python3 ~/.hermes/plugins/daedalus/tools.py service-start \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
+  --service-mode active
+```
+
+Use `--service-mode shadow` if you want read-only parity validation first.
+
+## Operate it from Hermes
+
+```bash
+export HERMES_ENABLE_PROJECT_PLUGINS=true
+export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
+cd /path/to/your/repo
+hermes
+```
+
+Then use:
+
+```text
+/daedalus status
+/daedalus doctor
+/workflow code-review status
+```
+
+## Legacy migration
+
+`scripts/migrate_config.py` is only for migrating older JSON configs into the new `workflow.yaml` shape. It is not the primary onboarding path for new installs.

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -20,10 +20,8 @@ If your host does not have those runtimes, edit `workflow.yaml` before starting 
 ## Install the plugin
 
 ```bash
-git clone https://github.com/attmous/daedalus.git
-cd daedalus
 sudo apt install python3-yaml python3-jsonschema
-./scripts/install.sh
+hermes plugins install attmous/daedalus --enable
 ```
 
 The plugin source of truth is:
@@ -32,10 +30,19 @@ The plugin source of truth is:
 ~/.hermes/plugins/daedalus
 ```
 
+Daedalus also ships a standard Hermes pip plugin entry point. If you install it
+as a Python package instead of through `hermes plugins install`, Hermes will
+discover it on the next startup and you must enable it explicitly:
+
+```bash
+python3 -m pip install .
+hermes plugins enable daedalus
+```
+
 ## Scaffold a workflow root
 
 ```bash
-python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow \
+hermes daedalus scaffold-workflow \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --github-slug your-org/your-repo
 ```
@@ -63,10 +70,10 @@ At minimum, set:
 ## Initialize and verify
 
 ```bash
-python3 ~/.hermes/plugins/daedalus/tools.py init \
+hermes daedalus init \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
 
-python3 ~/.hermes/plugins/daedalus/tools.py doctor \
+hermes daedalus doctor \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --format json
 ```
@@ -74,15 +81,15 @@ python3 ~/.hermes/plugins/daedalus/tools.py doctor \
 ## Supervise it
 
 ```bash
-python3 ~/.hermes/plugins/daedalus/tools.py service-install \
+hermes daedalus service-install \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 
-python3 ~/.hermes/plugins/daedalus/tools.py service-enable \
+hermes daedalus service-enable \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 
-python3 ~/.hermes/plugins/daedalus/tools.py service-start \
+hermes daedalus service-start \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
 ```
@@ -92,7 +99,6 @@ Use `--service-mode shadow` if you want read-only parity validation first.
 ## Operate it from Hermes
 
 ```bash
-export HERMES_ENABLE_PROJECT_PLUGINS=true
 export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
 cd /path/to/your/repo
 hermes
@@ -104,6 +110,41 @@ Then use:
 /daedalus status
 /daedalus doctor
 /workflow code-review status
+```
+
+## Plugin state
+
+Hermes plugins are opt-in. `hermes plugins install ... --enable` is the
+supported path because it installs the repo and enables the plugin in one step.
+
+If you install Daedalus by some other method, enable it explicitly:
+
+```bash
+hermes plugins enable daedalus
+```
+
+`HERMES_ENABLE_PROJECT_PLUGINS=true` is only for project-local plugins under
+`./.hermes/plugins/`. It is not required for a global `~/.hermes/plugins/daedalus`
+install.
+
+## Manage the plugin
+
+```bash
+hermes plugins list
+hermes plugins update daedalus
+hermes plugins disable daedalus
+```
+
+## Local-dev fallback
+
+If you want to install straight from a local checkout instead of the Hermes
+plugin manager:
+
+```bash
+git clone https://github.com/attmous/daedalus.git
+cd daedalus
+./scripts/install.sh
+hermes plugins enable daedalus
 ```
 
 ## Legacy migration

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -4,7 +4,7 @@ Quick reference for the two slash commands the plugin registers in Hermes:
 `/daedalus` (engine + service control) and `/workflow` (per-workflow operations).
 
 For the operator playbook ("when something looks wrong, do X"), see
-`docs/operator-cheat-sheet.md`. This file is a flat catalog: every command,
+`docs/operator/cheat-sheet.md`. This file is a flat catalog: every command,
 grouped by purpose, with a one-line description.
 
 ## `/daedalus` — engine + service control

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -7,9 +7,11 @@ This document defines the stability boundary for the first public Daedalus relea
 These are the surfaces we should treat as `v1` public contract:
 
 - `config/workflow.yaml` for workflow instance configuration
-- `python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow`
-- `python3 ~/.hermes/plugins/daedalus/tools.py init`
-- `python3 ~/.hermes/plugins/daedalus/tools.py service-*`
+- `hermes plugins install attmous/daedalus --enable`
+- the `hermes_agent.plugins` entry point name `daedalus`
+- `hermes daedalus scaffold-workflow`
+- `hermes daedalus init`
+- `hermes daedalus service-*`
 - `/daedalus ...` operator commands
 - `/workflow <name> ...` workflow commands
 - the workflow root naming convention: `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -1,0 +1,37 @@
+# Public contract
+
+This document defines the stability boundary for the first public Daedalus release.
+
+## Stable surfaces
+
+These are the surfaces we should treat as `v1` public contract:
+
+- `config/workflow.yaml` for workflow instance configuration
+- `python3 ~/.hermes/plugins/daedalus/tools.py scaffold-workflow`
+- `python3 ~/.hermes/plugins/daedalus/tools.py init`
+- `python3 ~/.hermes/plugins/daedalus/tools.py service-*`
+- `/daedalus ...` operator commands
+- `/workflow <name> ...` workflow commands
+- the workflow root naming convention: `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
+
+Changes to those surfaces should be documented, tested, and treated as compatibility-sensitive.
+
+## Internal implementation
+
+These are not public compatibility promises yet:
+
+- SQLite schema details in `runtime/state/daedalus/daedalus.db`
+- event payload internals beyond documented operator output
+- archived design/spec material under `docs/superpowers/`
+- playground project packs under `daedalus/projects/**`
+- experimental skills and local migration helpers
+
+We can refactor those freely as long as the stable surfaces above keep working.
+
+## Supported workflow
+
+The first bundled public workflow is:
+
+- `workflow: code-review`
+
+Additional workflow types should not be advertised as public contract until they have the same scaffold, schema, docs, and smoke-test coverage.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,6 @@
+name: daedalus
+version: 0.3.0
+description: Daedalus workflow engine and operator control surface.
+author: Hermes Agent
+provides_hooks: []
+provides_tools: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=66", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hermes-plugin-daedalus"
+version = "0.3.0"
+description = "Daedalus workflow engine and operator control surface."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+  {name = "Hermes Agent"},
+]
+dependencies = [
+  "PyYAML",
+  "jsonschema",
+  "rich",
+]
+keywords = ["hermes-agent", "plugin", "workflow", "sdlc"]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+Homepage = "https://github.com/attmous/daedalus"
+Repository = "https://github.com/attmous/daedalus"
+Documentation = "https://github.com/attmous/daedalus/tree/main/docs"
+
+[project.entry-points."hermes_agent.plugins"]
+daedalus = "daedalus"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["daedalus*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+PyYAML
+jsonschema
+rich
+pytest
+pytest-cov

--- a/runtime.py
+++ b/runtime.py
@@ -1,0 +1,12 @@
+"""Repo-root wrapper for the official Hermes plugin layout."""
+
+try:
+    from .daedalus.runtime import *  # noqa: F401,F403
+    from .daedalus.runtime import main as _main
+except ImportError:
+    from daedalus.runtime import *  # noqa: F401,F403
+    from daedalus.runtime import main as _main
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,6 @@
+"""Repo-root wrapper for the official Hermes plugin layout."""
+
+try:
+    from .daedalus.schemas import *  # noqa: F401,F403
+except ImportError:
+    from daedalus.schemas import *  # noqa: F401,F403

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+import sys
 from pathlib import Path
 
 PLUGIN_NAME = "daedalus"
@@ -30,7 +31,12 @@ PAYLOAD_ITEMS = [
 
 
 def _check_runtime_deps() -> None:
-    """Fail early if PyYAML or jsonschema are missing on the host python."""
+    """Fail early if the supported host python/runtime deps are missing."""
+    if sys.version_info < (3, 10):
+        raise RuntimeError(
+            "daedalus plugin requires python3 >= 3.10 on the host "
+            "(see docs/operator/installation.md)"
+        )
     missing = []
     try:
         import yaml  # noqa: F401
@@ -44,6 +50,7 @@ def _check_runtime_deps() -> None:
         raise RuntimeError(
             "daedalus plugin requires the following python modules on the host: "
             + ", ".join(missing)
+            + " (see docs/operator/installation.md)"
         )
 
 

--- a/scripts/migrate_config.py
+++ b/scripts/migrate_config.py
@@ -1,39 +1,113 @@
 #!/usr/bin/env python3
 """One-shot migrator: legacy workflow JSON -> workflow.yaml.
 
-Usage: python3 scripts/migrate_config.py <old-json-path> <new-yaml-path>
-
-Reads the legacy JSON, projects each setting into its new YAML location
-under the shape defined by workflows/code_review/schema.yaml, and writes
-the YAML file. The legacy JSON is NOT deleted by this script — do that
-manually after verifying the migration.
+This script exists only to carry older JSON configs into the public
+``workflow.yaml`` contract. It is not the primary onboarding path for new
+installs; new users should use ``scaffold-workflow`` instead.
 """
 from __future__ import annotations
 
+import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
 import yaml
 
 
-def convert(old: dict) -> dict:
+def _normalize_segment(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    if not normalized:
+        raise ValueError(f"unable to derive instance name segment from {value!r}")
+    return normalized
+
+
+def _derive_instance_name(*, github_slug: str, new_path: Path, old: dict) -> str:
+    if new_path.name == "workflow.yaml" and new_path.parent.name == "config":
+        root_name = new_path.parent.parent.name.strip()
+        if root_name:
+            return root_name
+    legacy_name = Path(old.get("ledgerPath", "")).parent.parent.name.strip()
+    if legacy_name:
+        return legacy_name
+    owner, repo = _parse_github_slug(github_slug)
+    return f"{_normalize_segment(owner)}-{_normalize_segment(repo)}-code-review"
+
+
+def _parse_github_slug(value: str) -> tuple[str, str]:
+    parts = [part.strip() for part in value.split("/", 1)]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("expected owner/repo")
+    return parts[0], parts[1]
+
+
+def _resolve_github_slug(*, old: dict, override: str | None) -> str:
+    github_slug = (
+        (override or "").strip()
+        or str(old.get("githubSlug") or "").strip()
+        or str(old.get("repositorySlug") or "").strip()
+    )
+    if not github_slug:
+        raise ValueError(
+            "github slug missing in legacy config; pass --github-slug owner/repo"
+        )
+    _parse_github_slug(github_slug)
+    return github_slug
+
+
+def _resolve_milestone_chat_id(*, old: dict, override: str | None) -> str | None:
+    if override:
+        return override
+    schedules = old.get("schedules") or {}
+    milestone = schedules.get("milestone-notifier") or schedules.get("milestoneNotifier") or {}
+    delivery = milestone.get("delivery") or {}
+    for candidate in (
+        delivery.get("chat-id"),
+        delivery.get("chatId"),
+        old.get("milestoneNotifierChatId"),
+    ):
+        value = str(candidate or "").strip()
+        if value:
+            return value
+    return None
+
+
+def convert(
+    old: dict,
+    *,
+    new_path: Path,
+    github_slug_override: str | None = None,
+    milestone_chat_id: str | None = None,
+) -> dict:
     session = old.get("sessionPolicy", {}) or {}
     review = old.get("reviewPolicy", {}) or {}
     labels = old.get("agentLabels", {}) or {}
 
     engine_owner = old.get("engineOwner", "openclaw")
     repo_path = old.get("repoPath", "")
-    # Infer workspace name from paths (used as instance.name).
-    instance_name = Path(old.get("ledgerPath", "")).parent.parent.name or "default"
-
-    # Do not guess a repository slug from host-specific path conventions.
-    # Carry any explicit legacy field forward; otherwise require operator fixup.
-    github_slug = (
-        old.get("githubSlug")
-        or old.get("repositorySlug")
-        or "FIXME/FIXME"
+    github_slug = _resolve_github_slug(old=old, override=github_slug_override)
+    instance_name = _derive_instance_name(
+        github_slug=github_slug,
+        new_path=new_path,
+        old=old,
     )
+    resolved_milestone_chat_id = _resolve_milestone_chat_id(
+        old=old,
+        override=milestone_chat_id,
+    )
+
+    schedules = {
+        "watchdog-tick": {"interval-minutes": 5},
+    }
+    if resolved_milestone_chat_id:
+        schedules["milestone-notifier"] = {
+            "interval-hours": 1,
+            "delivery": {
+                "channel": "telegram",
+                "chat-id": resolved_milestone_chat_id,
+            },
+        }
 
     return {
         "workflow": "code-review",
@@ -148,16 +222,7 @@ def convert(old: dict) -> dict:
             "lane-counter-increment-min-seconds": int(session.get("laneCounterIncrementMinSeconds", 240)),
         },
 
-        "schedules": {
-            "watchdog-tick": {"interval-minutes": 5},
-            "milestone-notifier": {
-                "interval-hours": 1,
-                "delivery": {
-                    "channel": "telegram",
-                    "chat-id": "FIXME_CHAT_ID",
-                },
-            },
-        },
+        "schedules": schedules,
 
         "prompts": {
             "internal-review": "internal-review-strict",
@@ -182,12 +247,27 @@ def convert(old: dict) -> dict:
     }
 
 
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Migrate a legacy workflow JSON config into workflow.yaml.",
+    )
+    parser.add_argument("old_json_path", help="Path to the legacy JSON config.")
+    parser.add_argument("new_yaml_path", help="Destination workflow.yaml path.")
+    parser.add_argument(
+        "--github-slug",
+        help="Repository slug in owner/repo form. Required when the legacy JSON does not carry one.",
+    )
+    parser.add_argument(
+        "--milestone-chat-id",
+        help="Optional Telegram chat id for the milestone-notifier schedule. When omitted, that schedule is left out.",
+    )
+    return parser
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print("usage: migrate_config.py <old-json-path> <new-yaml-path>", file=sys.stderr)
-        return 2
-    old_path = Path(argv[0]).expanduser().resolve()
-    new_path = Path(argv[1]).expanduser().resolve()
+    args = build_parser().parse_args(argv)
+    old_path = Path(args.old_json_path).expanduser().resolve()
+    new_path = Path(args.new_yaml_path).expanduser().resolve()
     if not old_path.exists():
         print(f"input JSON not found: {old_path}", file=sys.stderr)
         return 1
@@ -195,7 +275,16 @@ def main(argv: list[str]) -> int:
         print(f"refusing to overwrite existing file: {new_path}", file=sys.stderr)
         return 1
     old = json.loads(old_path.read_text(encoding="utf-8"))
-    new = convert(old)
+    try:
+        new = convert(
+            old,
+            new_path=new_path,
+            github_slug_override=args.github_slug,
+            milestone_chat_id=args.milestone_chat_id,
+        )
+    except ValueError as exc:
+        print(f"migration error: {exc}", file=sys.stderr)
+        return 2
     new_path.parent.mkdir(parents=True, exist_ok=True)
     new_path.write_text(yaml.safe_dump(new, sort_keys=False, default_flow_style=False), encoding="utf-8")
     print(f"wrote {new_path}")

--- a/tests/test_migrate_config.py
+++ b/tests/test_migrate_config.py
@@ -62,10 +62,20 @@ def _sample_old_json():
 def test_migrate_emits_valid_workflow_yaml(tmp_path):
     json_path = tmp_path / "legacy-workflow.json"
     json_path.write_text(json.dumps(_sample_old_json()), encoding="utf-8")
-    yaml_path = tmp_path / "workflow.yaml"
+    workflow_root = tmp_path / "attmous-daedalus-code-review"
+    yaml_path = workflow_root / "config" / "workflow.yaml"
 
     result = subprocess.run(
-        [sys.executable, str(MIGRATE_SCRIPT), str(json_path), str(yaml_path)],
+        [
+            sys.executable,
+            str(MIGRATE_SCRIPT),
+            str(json_path),
+            str(yaml_path),
+            "--github-slug",
+            "attmous/daedalus",
+            "--milestone-chat-id",
+            "123456",
+        ],
         capture_output=True, text=True, check=False,
     )
     assert result.returncode == 0, result.stderr
@@ -82,14 +92,50 @@ def test_migrate_emits_valid_workflow_yaml(tmp_path):
     assert cfg["workflow"] == "code-review"
     assert cfg["schema-version"] == 1
     assert cfg["instance"]["engine-owner"] == "hermes"
+    assert cfg["instance"]["name"] == "attmous-daedalus-code-review"
     assert cfg["repository"]["local-path"] == "/home/radxa/.hermes/workspaces/example-repo"
     assert cfg["runtimes"]["acpx-codex"]["session-idle-freshness-seconds"] == 900
     assert cfg["runtimes"]["claude-cli"]["max-turns-per-invocation"] == 24
     assert cfg["agents"]["coder"]["default"]["model"] == "gpt-5.3-codex-spark/high"
     assert cfg["agents"]["internal-reviewer"]["model"] == "claude-sonnet-4-6"
     assert cfg["agents"]["external-reviewer"]["provider"] == "codex-cloud"
-    assert cfg["repository"]["github-slug"] == "FIXME/FIXME"
-    assert cfg["schedules"]["milestone-notifier"]["delivery"]["chat-id"] == "FIXME_CHAT_ID"
+    assert cfg["repository"]["github-slug"] == "attmous/daedalus"
+    assert cfg["schedules"]["milestone-notifier"]["delivery"]["chat-id"] == "123456"
+
+
+def test_migrate_requires_github_slug_when_legacy_json_has_none(tmp_path):
+    json_path = tmp_path / "legacy-workflow.json"
+    payload = _sample_old_json()
+    payload.pop("githubSlug", None)
+    payload.pop("repositorySlug", None)
+    json_path.write_text(json.dumps(payload), encoding="utf-8")
+    yaml_path = tmp_path / "workflow.yaml"
+
+    result = subprocess.run(
+        [sys.executable, str(MIGRATE_SCRIPT), str(json_path), str(yaml_path)],
+        capture_output=True, text=True, check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--github-slug" in result.stderr
+    assert not yaml_path.exists()
+
+
+def test_migrate_omits_milestone_notifier_when_no_chat_id_is_available(tmp_path):
+    json_path = tmp_path / "legacy-workflow.json"
+    payload = _sample_old_json()
+    payload["githubSlug"] = "attmous/daedalus"
+    json_path.write_text(json.dumps(payload), encoding="utf-8")
+    yaml_path = tmp_path / "workflow.yaml"
+
+    result = subprocess.run(
+        [sys.executable, str(MIGRATE_SCRIPT), str(json_path), str(yaml_path)],
+        capture_output=True, text=True, check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    cfg = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    assert "milestone-notifier" not in cfg["schedules"]
 
 
 def test_migrate_refuses_to_overwrite_existing_yaml(tmp_path):

--- a/tests/test_official_plugin_layout.py
+++ b/tests/test_official_plugin_layout.py
@@ -1,0 +1,76 @@
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repo_root_exposes_official_hermes_plugin_layout():
+    expected = [
+        REPO_ROOT / "plugin.yaml",
+        REPO_ROOT / "__init__.py",
+        REPO_ROOT / "schemas.py",
+        REPO_ROOT / "tools.py",
+        REPO_ROOT / "runtime.py",
+        REPO_ROOT / "workflows" / "__init__.py",
+        REPO_ROOT / "workflows" / "__main__.py",
+        REPO_ROOT / "workflows" / "code_review" / "__init__.py",
+        REPO_ROOT / "workflows" / "code_review" / "__main__.py",
+    ]
+    missing = [str(path.relative_to(REPO_ROOT)) for path in expected if not path.exists()]
+    assert not missing, f"missing repo-root plugin files: {missing}"
+
+
+def test_repo_root_manifest_matches_installed_payload_manifest():
+    repo_manifest = yaml.safe_load((REPO_ROOT / "plugin.yaml").read_text(encoding="utf-8"))
+    payload_manifest = yaml.safe_load((REPO_ROOT / "daedalus" / "plugin.yaml").read_text(encoding="utf-8"))
+    assert repo_manifest == payload_manifest
+
+
+def test_repo_root_plugin_entrypoint_registers_same_commands_and_skill():
+    plugin = _load_module("daedalus_repo_root_plugin_test", REPO_ROOT / "__init__.py")
+
+    calls = {
+        "commands": [],
+        "cli_commands": [],
+        "skills": [],
+    }
+
+    class FakeCtx:
+        def register_command(self, name, handler, description=""):
+            calls["commands"].append((name, description, handler))
+
+        def register_cli_command(self, **kwargs):
+            calls["cli_commands"].append(kwargs)
+
+        def register_skill(self, name, path, description=""):
+            calls["skills"].append((name, Path(path), description))
+
+    plugin.register(FakeCtx())
+
+    command_names = {name for name, _desc, _handler in calls["commands"]}
+    assert {"daedalus", "workflow"} <= command_names
+    assert any(item["name"] == "daedalus" for item in calls["cli_commands"])
+    assert any(name == "operator" for name, _path, _desc in calls["skills"])
+
+
+def test_repo_root_tools_wrapper_dispatches_scaffold(tmp_path):
+    tools = _load_module("daedalus_repo_root_tools_test", REPO_ROOT / "tools.py")
+    workflow_root = tmp_path / "attmous-daedalus-code-review"
+
+    out = tools.execute_raw_args(
+        f"scaffold-workflow --workflow-root {workflow_root} --github-slug attmous/daedalus"
+    )
+
+    assert "daedalus error:" not in out, out
+    assert (workflow_root / "config" / "workflow.yaml").exists()

--- a/tests/test_pip_plugin_packaging.py
+++ b/tests/test_pip_plugin_packaging.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_wheel(tmp_path: Path) -> Path:
+    dist_dir = tmp_path / "dist"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(dist_dir),
+            str(REPO_ROOT),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, found {wheels}"
+    return wheels[0]
+
+
+def _read_wheel_text(wheel_path: Path, suffix: str) -> str:
+    with zipfile.ZipFile(wheel_path) as zf:
+        match = next(name for name in zf.namelist() if name.endswith(suffix))
+        return zf.read(match).decode("utf-8")
+
+
+def test_wheel_metadata_matches_plugin_manifest(tmp_path):
+    wheel_path = _build_wheel(tmp_path)
+    metadata = Parser().parsestr(_read_wheel_text(wheel_path, ".dist-info/METADATA"))
+    entry_points = _read_wheel_text(wheel_path, ".dist-info/entry_points.txt")
+    manifest = yaml.safe_load((REPO_ROOT / "daedalus" / "plugin.yaml").read_text(encoding="utf-8"))
+
+    assert metadata["Name"] == "hermes-plugin-daedalus"
+    assert metadata["Version"] == manifest["version"]
+    assert metadata["Summary"] == manifest["description"]
+    assert metadata["Requires-Python"] == ">=3.10"
+    requires_dist = metadata.get_all("Requires-Dist") or []
+    assert any(req.startswith("PyYAML") for req in requires_dist)
+    assert any(req.startswith("jsonschema") for req in requires_dist)
+    assert any(req.startswith("rich") for req in requires_dist)
+    assert "[hermes_agent.plugins]" in entry_points
+    assert "daedalus = daedalus" in entry_points
+
+
+def test_wheel_contains_runtime_loaded_plugin_payload(tmp_path):
+    wheel_path = _build_wheel(tmp_path)
+    with zipfile.ZipFile(wheel_path) as zf:
+        names = set(zf.namelist())
+
+    expected = {
+        "daedalus/plugin.yaml",
+        "daedalus/skills/operator/SKILL.md",
+        "daedalus/workflows/code_review/schema.yaml",
+        "daedalus/workflows/code_review/workflow.template.yaml",
+        "daedalus/workflows/code_review/prompts/coder.md",
+        "daedalus/projects/yoyopod_core/config/project.json",
+    }
+    missing = sorted(path for path in expected if path not in names)
+    assert not missing, f"wheel missing runtime payload files: {missing}"
+
+
+def test_wheel_extracts_to_working_plugin_package(tmp_path):
+    wheel_path = _build_wheel(tmp_path)
+    site_packages = tmp_path / "site-packages"
+    with zipfile.ZipFile(wheel_path) as zf:
+        zf.extractall(site_packages)
+
+    plugin_dir = site_packages / "daedalus"
+    plugin = _load_module("daedalus_packaged_plugin_test", plugin_dir / "__init__.py")
+    tools = _load_module("daedalus_packaged_tools_test", plugin_dir / "tools.py")
+
+    calls = {
+        "commands": [],
+        "cli_commands": [],
+        "skills": [],
+    }
+
+    class FakeCtx:
+        def register_command(self, name, handler, description=""):
+            calls["commands"].append((name, description, handler))
+
+        def register_cli_command(self, **kwargs):
+            calls["cli_commands"].append(kwargs)
+
+        def register_skill(self, name, path, description=""):
+            calls["skills"].append((name, Path(path), description))
+
+    plugin.register(FakeCtx())
+
+    command_names = {name for name, _desc, _handler in calls["commands"]}
+    assert {"daedalus", "workflow"} <= command_names
+    assert any(item["name"] == "daedalus" for item in calls["cli_commands"])
+    assert any(name == "operator" and path.exists() for name, path, _desc in calls["skills"])
+
+    workflow_root = tmp_path / "attmous-daedalus-code-review"
+    out = tools.execute_raw_args(
+        f"scaffold-workflow --workflow-root {workflow_root} --github-slug attmous/daedalus"
+    )
+    assert "daedalus error:" not in out, out
+    assert (workflow_root / "config" / "workflow.yaml").exists()

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -1,0 +1,84 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_public_onboarding_path_install_scaffold_init_and_supervise(tmp_path, monkeypatch):
+    install = _load_module("daedalus_install_smoke", REPO_ROOT / "scripts" / "install.py")
+    hermes_home = tmp_path / ".hermes"
+    plugin_dir = install.install_plugin(repo_root=REPO_ROOT, hermes_home=hermes_home)
+
+    monkeypatch.syspath_prepend(str(plugin_dir))
+    tools = _load_module("daedalus_tools_smoke", plugin_dir / "tools.py")
+
+    systemd_user_dir = tmp_path / "systemd-user"
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_user_dir))
+
+    captured_commands = []
+
+    def fake_run(cmd, **kwargs):
+        captured_commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(tools.subprocess, "run", fake_run)
+
+    workflow_root = hermes_home / "workflows" / "attmous-daedalus-code-review"
+
+    scaffold_out = tools.execute_raw_args(
+        f"scaffold-workflow --workflow-root {workflow_root} --github-slug attmous/daedalus"
+    )
+    assert "scaffolded workflow root" in scaffold_out
+
+    init_out = tools.execute_raw_args(f"init --workflow-root {workflow_root} --json")
+    init_payload = json.loads(init_out)
+    assert init_payload["ok"] is True
+
+    status_out = tools.execute_raw_args(f"status --workflow-root {workflow_root} --format json")
+    status_payload = json.loads(status_out)
+    assert status_payload["runtime_status"] == "initialized"
+    assert status_payload["project_key"] == "attmous-daedalus-code-review"
+
+    install_out = tools.execute_raw_args(
+        f"service-install --workflow-root {workflow_root} --service-mode active --json"
+    )
+    install_payload = json.loads(install_out)
+    assert install_payload["installed"] is True
+    assert Path(install_payload["unit_path"]).exists()
+
+    enable_out = tools.execute_raw_args(
+        f"service-enable --workflow-root {workflow_root} --service-mode active --json"
+    )
+    enable_payload = json.loads(enable_out)
+    assert enable_payload["ok"] is True
+
+    start_out = tools.execute_raw_args(
+        f"service-start --workflow-root {workflow_root} --service-mode active --json"
+    )
+    start_payload = json.loads(start_out)
+    assert start_payload["ok"] is True
+
+    assert ["systemctl", "--user", "daemon-reload"] in captured_commands
+    assert ["systemctl", "--user", "enable", "daedalus-active@attmous-daedalus-code-review.service"] in captured_commands
+    assert ["systemctl", "--user", "start", "daedalus-active@attmous-daedalus-code-review.service"] in captured_commands
+
+
+def test_readme_quickstart_mentions_supported_public_path():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "scaffold-workflow" in readme
+    assert "service-install" in readme
+    assert "docs/operator/installation.md" in readme
+    assert "docs/public-contract.md" in readme

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -78,7 +78,13 @@ def test_public_onboarding_path_install_scaffold_init_and_supervise(tmp_path, mo
 def test_readme_quickstart_mentions_supported_public_path():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
+    assert "hermes plugins install attmous/daedalus --enable" in readme
+    assert "hermes daedalus scaffold-workflow" in readme
     assert "scaffold-workflow" in readme
     assert "service-install" in readme
     assert "docs/operator/installation.md" in readme
     assert "docs/public-contract.md" in readme
+    assert "python3 -m pip install ." in readme
+    assert "hermes plugins enable daedalus" in readme
+    assert "HERMES_ENABLE_PROJECT_PLUGINS=true" in readme
+    assert "project-local plugins" in readme

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,16 @@
+"""Repo-root wrapper for the official Hermes plugin layout."""
+
+try:
+    from .daedalus.tools import *  # noqa: F401,F403
+    from .daedalus.tools import execute_raw_args as _execute_raw_args
+except ImportError:
+    from daedalus.tools import *  # noqa: F401,F403
+    from daedalus.tools import execute_raw_args as _execute_raw_args
+
+
+if __name__ == "__main__":
+    import sys
+
+    result = _execute_raw_args(" ".join(sys.argv[1:]))
+    print(result)
+    sys.exit(0 if not result.startswith("daedalus error:") else 1)

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -1,0 +1,11 @@
+"""Repo-root workflow wrapper package for official Hermes plugin installs."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+from daedalus.workflows import *  # noqa: F401,F403

--- a/workflows/__main__.py
+++ b/workflows/__main__.py
@@ -1,0 +1,16 @@
+"""Repo-root workflow dispatcher wrapper for official Hermes plugin installs."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+from daedalus.workflows.__main__ import *  # noqa: F401,F403
+from daedalus.workflows.__main__ import main as _main
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/workflows/code_review/__init__.py
+++ b/workflows/code_review/__init__.py
@@ -1,0 +1,11 @@
+"""Repo-root code-review workflow wrapper for official Hermes plugin installs."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+from daedalus.workflows.code_review import *  # noqa: F401,F403

--- a/workflows/code_review/__main__.py
+++ b/workflows/code_review/__main__.py
@@ -1,0 +1,16 @@
+"""Repo-root code-review workflow entrypoint wrapper."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+from daedalus.workflows.code_review.__main__ import *  # noqa: F401,F403
+from daedalus.workflows.code_review.__main__ import main as _main
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())


### PR DESCRIPTION
## What changed
This PR tightens Daedalus for public release around one consistent Hermes plugin story.

It:
- standardizes the public onboarding/install path around `workflow.yaml`, `scaffold-workflow`, and the documented workflow-root convention
- adds repo-root Hermes plugin wrappers so the repository itself matches the official plugin layout expected by `hermes plugins install ...`
- adds Python packaging metadata and a `hermes_agent.plugins` entry point so Daedalus is also discoverable as a pip-installed Hermes plugin
- ships the runtime-loaded payload in the package artifact, including plugin metadata, workflow templates, prompts, skills, and project-pack files
- refreshes operator and contributor docs to describe the supported install, enable, scaffold, and service-management path
- adds smoke and packaging tests that exercise the documented public surfaces

## Why
Before this change, Daedalus was functionally usable but the distribution surface was inconsistent:
- the public repo did not cleanly match the official Hermes plugin install model
- the install/enable docs mixed global and project-local plugin stories
- there was no package entry point for the documented pip discovery path
- the public onboarding contract was not pinned by artifact-level tests

This PR makes the Git install path, the pip plugin path, the docs, and the tests line up.

## Operator impact
Community users can now follow one supported path:
- `hermes plugins install attmous/daedalus --enable`
- `hermes daedalus scaffold-workflow ...`
- edit `config/workflow.yaml`
- verify with `hermes daedalus doctor`
- supervise with `hermes daedalus service-*`

The repo also now exposes the official Hermes pip plugin discovery surface:
- `python3 -m pip install .`
- `hermes plugins enable daedalus`

## Validation
Ran:
- `pytest tests/test_pip_plugin_packaging.py tests/test_public_onboarding_smoke.py tests/test_official_plugin_layout.py tests/test_install.py tests/test_tools_scaffold_workflow.py tests/test_tools_new_command_dispatch.py tests/test_tools_run_cli_command_dispatch.py tests/test_workflows_dispatcher.py`
- `python3 -m pip wheel --no-deps --no-build-isolation --wheel-dir /tmp/daedalus-wheel-smoke .`

Notes:
- Focused validation passed locally (`35 passed`)
- In this sandbox, the known `tests/test_status_server.py` socket-bind cases still fail with `PermissionError: [Errno 1] Operation not permitted`, so those were not treated as regressions in this PR