### PR TITLE
[codex] add Symphony workflow contract compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ A **labeled issue** is the trigger. The **engine** ticks; for every active issue
 - **[docs/architecture.md](docs/architecture.md)** — the big picture, end to end.
 - **[docs/operator/installation.md](docs/operator/installation.md)** — the supported install, scaffold, verify, and supervise path.
 - **[docs/public-contract.md](docs/public-contract.md)** — the stability boundary for the first public release.
+- **[docs/symphony-conformance.md](docs/symphony-conformance.md)** — what is already Symphony-aligned, what is only partial, and what is still missing.
+- **[docs/security.md](docs/security.md)** — the trust model, shell/runtime posture, and secret-handling expectations.
 - **[docs/concepts/](docs/concepts/)** — short explainers for each moving part: lanes, leases, runtimes, events, hot-reload, stalls.
 - **[docs/operator/](docs/operator/)** — day-to-day commands, the operator cheat sheet, the full slash-command catalogue.
 

--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
 
+from workflows.contract import WorkflowContractError, load_workflow_contract
 from workflows.code_review.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -1261,14 +1262,13 @@ def cmd_get_observability(args, parser) -> str:
 
     workflow_root = Path(args.workflow_root).expanduser().resolve()
     workflow_name = args.workflow
-    config_yaml_path = workflow_root / "config" / "workflow.yaml"
     workflow_yaml = {}
-    if config_yaml_path.exists():
-        try:
-            import yaml as _yaml
-            workflow_yaml = _yaml.safe_load(config_yaml_path.read_text(encoding="utf-8")) or {}
-        except Exception as exc:
-            return f"error reading workflow.yaml: {exc}"
+    try:
+        workflow_yaml = load_workflow_contract(workflow_root).config
+    except FileNotFoundError:
+        workflow_yaml = {}
+    except (WorkflowContractError, OSError, UnicodeDecodeError) as exc:
+        return f"error reading workflow contract: {exc}"
 
     eff = resolve_effective_config(
         workflow_yaml=workflow_yaml,

--- a/daedalus/workflows/__init__.py
+++ b/daedalus/workflows/__init__.py
@@ -17,11 +17,8 @@ from pathlib import Path
 from types import ModuleType
 
 import jsonschema
-import yaml
 
-
-class WorkflowContractError(RuntimeError):
-    """Raised when a workflow package does not meet the required contract."""
+from .contract import WorkflowContractError, load_workflow_contract
 
 
 _REQUIRED_ATTRS = (
@@ -60,19 +57,16 @@ def run_cli(
     *,
     require_workflow: str | None = None,
 ) -> int:
-    """Read <workflow_root>/config/workflow.yaml, dispatch to the named workflow.
+    """Read the workflow contract under ``workflow_root`` and dispatch.
 
     When ``require_workflow`` is set, the dispatcher asserts that the YAML's
     ``workflow:`` field matches before dispatching. Used by the per-workflow
     direct form (``python3 -m workflows.code_review ...``) to pin the module
     regardless of what the YAML declares.
     """
-    config_path = workflow_root / "config" / "workflow.yaml"
-    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    if not isinstance(cfg, dict):
-        raise WorkflowContractError(
-            f"{config_path} must contain a YAML mapping at the top level"
-        )
+    contract = load_workflow_contract(workflow_root)
+    config_path = contract.source_path
+    cfg = contract.config
     workflow_name = cfg.get("workflow")
     if not workflow_name:
         raise WorkflowContractError(
@@ -85,6 +79,8 @@ def run_cli(
         )
 
     module = load_workflow(workflow_name)
+
+    import yaml
 
     schema = yaml.safe_load(module.CONFIG_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(cfg, schema)

--- a/daedalus/workflows/code_review/config_watcher.py
+++ b/daedalus/workflows/code_review/config_watcher.py
@@ -1,7 +1,7 @@
-"""Hot-reload of workflow.yaml (Symphony §6.2).
+"""Hot-reload of the workflow contract (Symphony §6.2).
 
 `ConfigWatcher.poll()` is called every tick. It mtime-checks the
-workflow file; on change, reparses + validates and swaps the
+workflow contract file; on change, reparses + validates and swaps the
 `AtomicRef[ConfigSnapshot]`. On failure, the last-known-good snapshot
 is kept and `daedalus.config_reload_failed` is emitted.
 """
@@ -16,15 +16,16 @@ import yaml
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import ValidationError as _JSValidationError
 
+from workflows.contract import WorkflowContractError, load_workflow_contract_file
 from workflows.code_review.config_snapshot import AtomicRef, ConfigSnapshot
 
 
 class ParseError(Exception):
-    """Raised when workflow.yaml cannot be parsed as YAML."""
+    """Raised when the workflow contract cannot be parsed or projected."""
 
 
 class ValidationError(Exception):
-    """Raised when workflow.yaml parses but violates schema.yaml."""
+    """Raised when the workflow contract parses but violates schema.yaml."""
 
 
 _SCHEMA_PATH = Path(__file__).resolve().parent / "schema.yaml"
@@ -34,20 +35,18 @@ def _load_schema() -> dict:
     return yaml.safe_load(_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
-def parse_and_validate(workflow_yaml_path: Path) -> ConfigSnapshot:
-    """Parse `workflow.yaml`, validate against `schema.yaml`, return snapshot.
+def parse_and_validate(workflow_contract_path: Path) -> ConfigSnapshot:
+    """Parse the workflow contract, validate against `schema.yaml`, return snapshot.
 
     Raises:
-        ParseError: yaml.YAMLError or non-dict top-level.
+        ParseError: contract parse/project errors.
         ValidationError: schema validation failure.
     """
     try:
-        text = workflow_yaml_path.read_text(encoding="utf-8")
-        config = yaml.safe_load(text)
-    except yaml.YAMLError as exc:
-        raise ParseError(f"YAML parse error: {exc}") from exc
-    if not isinstance(config, dict):
-        raise ParseError(f"workflow.yaml top-level must be a mapping, got {type(config).__name__}")
+        contract = load_workflow_contract_file(workflow_contract_path)
+    except WorkflowContractError as exc:
+        raise ParseError(str(exc)) from exc
+    config = contract.config
 
     try:
         Draft7Validator(_load_schema()).validate(config)
@@ -55,7 +54,7 @@ def parse_and_validate(workflow_yaml_path: Path) -> ConfigSnapshot:
         raise ValidationError(f"schema validation failed: {exc.message}") from exc
 
     prompts = config.get("prompts") or {}
-    st = workflow_yaml_path.stat()
+    st = contract.source_path.stat()
     return ConfigSnapshot(
         config=config,
         prompts=prompts,
@@ -69,7 +68,7 @@ def parse_and_validate(workflow_yaml_path: Path) -> ConfigSnapshot:
 class ConfigWatcher:
     """mtime-polled config-reload driver. Call `.poll()` once per tick."""
 
-    workflow_yaml_path: Path
+    workflow_contract_path: Path
     snapshot_ref: AtomicRef[ConfigSnapshot]
     emit_event: Callable[[str, dict], None]
     _last_key: tuple[float, int] = (0.0, 0)
@@ -93,7 +92,7 @@ class ConfigWatcher:
         or mtime-preserving copies (NFS, rsync -t, overlayfs).
         """
         try:
-            st = self.workflow_yaml_path.stat()
+            st = self.workflow_contract_path.stat()
         except OSError:
             return  # file vanished mid-poll (atomic rename); keep last-known-good
         key = (st.st_mtime, st.st_size)
@@ -107,7 +106,7 @@ class ConfigWatcher:
         # An uncaught exception here would propagate out of poll() and crash
         # the watcher loop instead of preserving last-known-good config.
         try:
-            new_snapshot = parse_and_validate(self.workflow_yaml_path)
+            new_snapshot = parse_and_validate(self.workflow_contract_path)
         except (ParseError, ValidationError, OSError, UnicodeDecodeError) as exc:
             self.emit_event(
                 "daedalus.config_reload_failed",

--- a/daedalus/workflows/code_review/dispatch.py
+++ b/daedalus/workflows/code_review/dispatch.py
@@ -75,6 +75,33 @@ def resolve_prompt_template_path(
     return bundled
 
 
+def resolve_inline_prompt_template(
+    *,
+    workspace,
+    role: str,
+    agent_cfg: dict,
+) -> str | None:
+    """Return an inline prompt override from ``workspace.config.prompts``.
+
+    Explicit file paths still win. Inline prompts are the bridge used by the
+    ``WORKFLOW.md`` compatibility loader, which injects the Markdown body into
+    ``prompts.<role>``.
+    """
+    if agent_cfg.get("prompt"):
+        return None
+    prompts = (workspace.config or {}).get("prompts") or {}
+    if not prompts:
+        return None
+    template = prompts.get(role)
+    if template is None:
+        return None
+    if not isinstance(template, str):
+        raise DispatchConfigError(
+            f"workspace.config.prompts[{role!r}] must be a string"
+        )
+    return template
+
+
 def _materialize_prompt(*, worktree: Path, role: str, tier: str | None, rendered_text: str) -> Path:
     """Write the already-rendered prompt to a deterministic file under
     <worktree>/.daedalus/dispatch/, return the path."""
@@ -126,8 +153,9 @@ def dispatch_agent(
       - Resolves agent role (tiered for 'coder', flat otherwise).
       - Resolves runtime via ``workspace.runtime(<name>)``.
       - Resolves command (agent override -> runtime default -> None).
-      - Resolves prompt template path (agent.prompt -> workspace override ->
-        bundled), loads it, and renders via ``.format(**prompt_kwargs)``.
+      - Resolves prompt template text (agent.prompt file -> inline
+        ``workspace.config.prompts`` -> workspace override file -> bundled),
+        then renders via ``.format(**prompt_kwargs)``.
       - If a command is present: materializes the rendered text to a file,
         substitutes placeholders, invokes ``runtime.run_command(...)``.
       - If no command is present: invokes ``runtime.run_prompt(...)`` with the
@@ -144,10 +172,16 @@ def dispatch_agent(
 
     # Resolve + load + render the template (the dispatcher, not the caller,
     # owns this so workspace/agent overrides actually take effect).
-    template_path = resolve_prompt_template_path(
+    inline_template = resolve_inline_prompt_template(
         workspace=workspace, role=role, agent_cfg=cfg,
     )
-    template_text = template_path.read_text(encoding="utf-8")
+    if inline_template is not None:
+        template_text = inline_template
+    else:
+        template_path = resolve_prompt_template_path(
+            workspace=workspace, role=role, agent_cfg=cfg,
+        )
+        template_text = template_path.read_text(encoding="utf-8")
     rendered_text = template_text.format(**(prompt_kwargs or {}))
 
     command = _resolve_command(agent_cfg=cfg, runtime_cfg=runtime_cfg)

--- a/daedalus/workflows/code_review/paths.py
+++ b/daedalus/workflows/code_review/paths.py
@@ -5,8 +5,16 @@ import re
 from pathlib import Path
 from typing import Mapping
 
+from workflows.contract import (
+    DEFAULT_WORKFLOW_CONFIG_FILENAME,
+    DEFAULT_WORKFLOW_MARKDOWN_FILENAME,
+    find_workflow_contract_path,
+    load_workflow_contract,
+    workflow_markdown_path as _workflow_markdown_path,
+    workflow_yaml_path as _workflow_yaml_path,
+)
+
 DEFAULT_WORKFLOW_ROOT_ENV_VARS = ("DAEDALUS_WORKFLOW_ROOT",)
-DEFAULT_WORKFLOW_CONFIG_FILENAME = "config/workflow.yaml"
 
 _PROJECT_KEY_CHARS_RE = re.compile(r"[^a-z0-9._-]+")
 _PROJECT_KEY_SEPARATORS_RE = re.compile(r"[-._]{2,}")
@@ -40,27 +48,35 @@ def derive_workflow_instance_name(*, github_slug: str, workflow_name: str) -> st
 
 
 def workflow_config_path(workflow_root: Path) -> Path:
-    return workflow_root.resolve() / DEFAULT_WORKFLOW_CONFIG_FILENAME
+    return _workflow_yaml_path(workflow_root)
+
+
+def workflow_markdown_path(workflow_root: Path) -> Path:
+    return _workflow_markdown_path(workflow_root)
+
+
+def workflow_contract_path(workflow_root: Path) -> Path:
+    path = find_workflow_contract_path(workflow_root)
+    if path is None:
+        raise FileNotFoundError(
+            f"workflow contract not found under {Path(workflow_root).resolve()} "
+            f"(looked for {DEFAULT_WORKFLOW_CONFIG_FILENAME} and {DEFAULT_WORKFLOW_MARKDOWN_FILENAME})"
+        )
+    return path
 
 
 def load_workflow_config(workflow_root: Path) -> dict:
-    import yaml  # type: ignore[import]
-
-    path = workflow_config_path(workflow_root)
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"{path} must contain a YAML mapping at the top level")
-    return payload
+    return load_workflow_contract(workflow_root).config
 
 
 def workflow_instance_name(workflow_root: Path) -> str:
     config = load_workflow_config(workflow_root)
     instance = config.get("instance")
     if not isinstance(instance, dict):
-        raise ValueError(f"{workflow_config_path(workflow_root)} is missing required instance config")
+        raise ValueError(f"{workflow_contract_path(workflow_root)} is missing required instance config")
     name = str(instance.get("name") or "").strip()
     if not name:
-        raise ValueError(f"{workflow_config_path(workflow_root)} is missing instance.name")
+        raise ValueError(f"{workflow_contract_path(workflow_root)} is missing instance.name")
     return name
 
 
@@ -70,6 +86,17 @@ def project_key_for_workflow_root(workflow_root: Path) -> str:
 
 def _has_project_runtime_layout(workflow_root: Path) -> bool:
     return any((workflow_root / name).exists() for name in ("runtime", "config", "workspace", "docs"))
+
+
+def _is_discoverable_markdown_workflow_root(workflow_root: Path) -> bool:
+    """Guard cwd auto-detection against repo-local ``WORKFLOW.md`` files.
+
+    Symphony's default contract is repo-owned, but Daedalus still uses a
+    workflow-instance root with mutable runtime/state directories. Only treat a
+    Markdown contract as a workflow-root marker during ancestor discovery when
+    the candidate also looks like a Daedalus instance root.
+    """
+    return any((workflow_root / name).exists() for name in ("runtime", "memory", "state"))
 
 
 def runtime_base_dir(workflow_root: Path) -> Path:
@@ -165,6 +192,8 @@ def _find_workflow_root(start: Path) -> Path | None:
     for candidate in (path, *path.parents):
         if workflow_config_path(candidate).exists():
             return candidate
+        if workflow_markdown_path(candidate).exists() and _is_discoverable_markdown_workflow_root(candidate):
+            return candidate
     return None
 
 
@@ -190,5 +219,7 @@ def resolve_default_workflow_root(
     plugin_dir = plugin_root_path(plugin_dir=plugin_dir)
     repo_parent = plugin_dir.parent.resolve()
     if workflow_config_path(repo_parent).exists():
+        return repo_parent
+    if workflow_markdown_path(repo_parent).exists() and _is_discoverable_markdown_workflow_root(repo_parent):
         return repo_parent
     return cwd_path

--- a/daedalus/workflows/code_review/workspace.py
+++ b/daedalus/workflows/code_review/workspace.py
@@ -162,12 +162,14 @@ Two factories are provided:
   ``orchestrator``, etc.) looks up workspace attributes by name, so any
   duck-typed accessor works.
 * :func:`load_workspace_from_config` — convenience wrapper that reads the
-  project workflow config from ``config/workflow.yaml`` and applies the same
-  derived constants the workspace uses internally.
+  project workflow contract from either ``config/workflow.yaml`` or
+  ``WORKFLOW.md`` and applies the same derived constants the workspace uses
+  internally.
 """
 
 
 DEFAULT_YAML_CONFIG_FILENAME = "config/workflow.yaml"
+DEFAULT_WORKFLOW_MARKDOWN_FILENAME = "WORKFLOW.md"
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -2093,16 +2095,17 @@ def load_workspace_from_config(
     workspace_root: Path,
     config_path: Path | None = None,
 ) -> SimpleNamespace:
-    """Convenience factory: read ``config/workflow.yaml`` and build a workspace."""
+    """Convenience factory: read the workflow contract and build a workspace."""
+    from workflows.contract import load_workflow_contract, load_workflow_contract_file
+
     workspace_root = Path(workspace_root)
     if config_path is not None:
         path = Path(config_path)
-        if path.suffix.lower() not in {".yaml", ".yml"}:
-            raise ValueError(f"workflow config must be YAML: {path}")
-        config = _load_yaml(path)
+        if path.suffix.lower() not in {".yaml", ".yml", ".md"}:
+            raise ValueError(f"workflow config must be YAML or WORKFLOW.md: {path}")
+        config = load_workflow_contract_file(path).config
         return make_workspace(workspace_root=workspace_root, config=config)
 
-    yaml_path = workspace_root / DEFAULT_YAML_CONFIG_FILENAME
     return make_workspace(
-        workspace_root=workspace_root, config=_load_yaml(yaml_path)
+        workspace_root=workspace_root, config=load_workflow_contract(workspace_root).config
     )

--- a/daedalus/workflows/contract.py
+++ b/daedalus/workflows/contract.py
@@ -1,0 +1,186 @@
+"""Workflow contract loading for Daedalus.
+
+Daedalus currently supports two workflow-contract entrypoints:
+
+- ``config/workflow.yaml``: the native Daedalus instance config
+- ``WORKFLOW.md``: a Symphony-style Markdown contract with YAML front matter
+
+The Markdown form is a compatibility/front-door layer. It does not yet map the
+entire Symphony front matter directly into Daedalus runtime settings; instead,
+it expects a ``daedalus.workflow-config`` mapping containing the native
+Daedalus config and optionally injects the Markdown body into
+``prompts.<role>``.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_WORKFLOW_CONFIG_FILENAME = "config/workflow.yaml"
+DEFAULT_WORKFLOW_MARKDOWN_FILENAME = "WORKFLOW.md"
+
+
+class WorkflowContractError(RuntimeError):
+    """Raised when the workflow contract file cannot be loaded or projected."""
+
+
+@dataclass(frozen=True)
+class WorkflowContract:
+    """Loaded workflow contract plus prompt body metadata."""
+
+    source_path: Path
+    config: dict[str, Any]
+    prompt_template: str
+    front_matter: dict[str, Any]
+
+
+def workflow_yaml_path(workflow_root: Path) -> Path:
+    return workflow_root.resolve() / DEFAULT_WORKFLOW_CONFIG_FILENAME
+
+
+def workflow_markdown_path(workflow_root: Path) -> Path:
+    return workflow_root.resolve() / DEFAULT_WORKFLOW_MARKDOWN_FILENAME
+
+
+def find_workflow_contract_path(workflow_root: Path) -> Path | None:
+    """Return the preferred contract path for a workflow root, if any.
+
+    ``config/workflow.yaml`` remains the first choice so existing instances do
+    not change behavior if both files are present.
+    """
+    yaml_path = workflow_yaml_path(workflow_root)
+    if yaml_path.exists():
+        return yaml_path
+    markdown_path = workflow_markdown_path(workflow_root)
+    if markdown_path.exists():
+        return markdown_path
+    return None
+
+
+def load_workflow_contract(workflow_root: Path) -> WorkflowContract:
+    path = find_workflow_contract_path(workflow_root)
+    if path is None:
+        raise FileNotFoundError(
+            f"workflow contract not found under {Path(workflow_root).resolve()} "
+            f"(looked for {DEFAULT_WORKFLOW_CONFIG_FILENAME} and {DEFAULT_WORKFLOW_MARKDOWN_FILENAME})"
+        )
+    return load_workflow_contract_file(path)
+
+
+def load_workflow_contract_file(path: Path) -> WorkflowContract:
+    resolved = Path(path).expanduser().resolve()
+    suffix = resolved.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml_contract(resolved)
+    if suffix == ".md":
+        return _load_markdown_contract(resolved)
+    raise WorkflowContractError(
+        f"unsupported workflow contract format for {resolved}; "
+        "expected YAML (.yaml/.yml) or Markdown (.md)"
+    )
+
+
+def _load_yaml_contract(path: Path) -> WorkflowContract:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise WorkflowContractError(f"YAML parse error in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise WorkflowContractError(
+            f"{path} must contain a YAML mapping at the top level"
+        )
+    return WorkflowContract(
+        source_path=path,
+        config=payload,
+        prompt_template="",
+        front_matter={},
+    )
+
+
+def _load_markdown_contract(path: Path) -> WorkflowContract:
+    text = path.read_text(encoding="utf-8")
+    front_matter, prompt_template = _parse_markdown_contract(path, text)
+    config = _project_markdown_front_matter(
+        path=path,
+        front_matter=front_matter,
+        prompt_template=prompt_template,
+    )
+    return WorkflowContract(
+        source_path=path,
+        config=config,
+        prompt_template=prompt_template,
+        front_matter=front_matter,
+    )
+
+
+def _parse_markdown_contract(path: Path, text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---"):
+        return {}, text.strip()
+
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text.strip()
+
+    closing_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing_index = index
+            break
+    if closing_index is None:
+        raise WorkflowContractError(
+            f"{path} starts with YAML front matter but is missing the closing --- delimiter"
+        )
+
+    front_matter_text = "\n".join(lines[1:closing_index])
+    prompt_body = "\n".join(lines[closing_index + 1 :]).strip()
+    try:
+        parsed = yaml.safe_load(front_matter_text) if front_matter_text.strip() else {}
+    except yaml.YAMLError as exc:
+        raise WorkflowContractError(f"YAML front-matter parse error in {path}: {exc}") from exc
+    if parsed is None:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        raise WorkflowContractError(
+            f"{path} front matter must decode to a YAML mapping at the top level"
+        )
+    return parsed, prompt_body
+
+
+def _project_markdown_front_matter(
+    *,
+    path: Path,
+    front_matter: dict[str, Any],
+    prompt_template: str,
+) -> dict[str, Any]:
+    extension = front_matter.get("daedalus") or {}
+    if not isinstance(extension, dict):
+        raise WorkflowContractError(f"{path} must define daedalus: as a mapping")
+
+    raw_config = extension.get("workflow-config")
+    if raw_config is None:
+        raise WorkflowContractError(
+            f"{path} must define daedalus.workflow-config to map WORKFLOW.md "
+            "into the current Daedalus workflow schema"
+        )
+    if not isinstance(raw_config, dict):
+        raise WorkflowContractError(f"{path} daedalus.workflow-config must be a mapping")
+
+    config = deepcopy(raw_config)
+    prompt_role = extension.get("prompt-role", "coder")
+    if not isinstance(prompt_role, str) or not prompt_role.strip():
+        raise WorkflowContractError(f"{path} daedalus.prompt-role must be a non-empty string")
+
+    if prompt_template:
+        prompts = config.get("prompts")
+        if prompts is None:
+            prompts = {}
+            config["prompts"] = prompts
+        if not isinstance(prompts, dict):
+            raise WorkflowContractError(f"{path} prompts must be a mapping when present")
+        prompts[prompt_role.strip()] = prompt_template
+
+    return config

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Entry point for everything that won't fit on the [project landing page](../READM
 - **[operator/installation.md](operator/installation.md)** — the supported install, scaffold, verify, and supervise flow.
 - **[examples/code-review.workflow.yaml](examples/code-review.workflow.yaml)** — copyable public baseline for `config/workflow.yaml`.
 - **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
+- **[symphony-conformance.md](symphony-conformance.md)** — where Daedalus matches the current Symphony draft, and where it still differs.
+- **[security.md](security.md)** — the trust model, shell/network posture, and secret-handling expectations.
 
 ## Concepts
 
@@ -20,7 +22,7 @@ What each abstraction *means* — read these before reading code.
 | [Runtimes](concepts/runtimes.md) | The `claude-cli` / `acpx-codex` / `hermes-agent` adapters. |
 | [Events](concepts/events.md) | The append-only history. Symphony §10.4 taxonomy + `daedalus.*` namespace. |
 | [Stalls](concepts/stalls.md) | `last_activity_ts()` + `stall.timeout_ms` (Symphony §8.5). |
-| [Hot-reload & preflight](concepts/hot-reload.md) | `workflow.yaml` reload + per-tick preflight (Symphony §6.2 + §6.3). |
+| [Hot-reload & preflight](concepts/hot-reload.md) | Workflow-contract reload (`workflow.yaml` or `WORKFLOW.md`) + per-tick preflight (Symphony §6.2 + §6.3). |
 | [Shadow → active](concepts/shadow-active.md) | The promotion gate from observation to execution. |
 
 ## Operator surface
@@ -44,6 +46,8 @@ docs/
 ├── README.md                this file
 ├── architecture.md          big picture
 ├── public-contract.md       stable public surfaces for the first release
+├── symphony-conformance.md  current spec alignment vs. remaining gaps
+├── security.md              trust model + execution posture
 │
 ├── concepts/                "what does X mean" — one file per abstraction
 ├── examples/                copyable config baselines

--- a/docs/concepts/hot-reload.md
+++ b/docs/concepts/hot-reload.md
@@ -1,14 +1,14 @@
 # Hot-reload & per-tick preflight
 
-Symphony §6.2 + §6.3. The two halves of "edits to `workflow.yaml` should never crash the loop."
+Symphony §6.2 + §6.3. The two halves of "edits to the workflow contract should never crash the loop."
 
 ## §6.2 Hot-reload
 
-`workflow.yaml` is re-parsed and re-validated on every tick. The new config replaces the old one **only if** parse + validate both succeed. A bad edit keeps the previous good config alive — the next valid save picks up automatically.
+The workflow contract (`config/workflow.yaml` or `WORKFLOW.md`) is re-parsed and re-validated on every tick. The new config replaces the old one **only if** parse + validate both succeed. A bad edit keeps the previous good config alive — the next valid save picks up automatically.
 
 ```mermaid
 flowchart TD
-  A[tick begins] --> B[read workflow.yaml<br/>stat: mtime+size]
+  A[tick begins] --> B[read workflow contract<br/>stat: mtime+size]
   B --> C{key changed?}
   C -- no --> D[reuse last ConfigSnapshot]
   C -- yes --> E[parse + validate]
@@ -46,8 +46,8 @@ flowchart LR
 
 ### What preflight actually checks
 
-- `workflow.yaml` parses
-- `workflow.yaml` matches `schema.yaml`
+- The workflow contract parses
+- The projected workflow config matches `schema.yaml`
 - Every referenced runtime kind (`runtimes.<name>.kind`, `agents.external-reviewer.kind`) is registered
 - Lane-selection config, if present, is internally consistent
 

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -7,6 +7,7 @@ This document defines the stability boundary for the first public Daedalus relea
 These are the surfaces we should treat as `v1` public contract:
 
 - `config/workflow.yaml` for workflow instance configuration
+- `WORKFLOW.md` compatibility loading for `workflow: code-review`, using `daedalus.workflow-config`
 - `hermes plugins install attmous/daedalus --enable`
 - the `hermes_agent.plugins` entry point name `daedalus`
 - `hermes daedalus scaffold-workflow`
@@ -37,3 +38,12 @@ The first bundled public workflow is:
 - `workflow: code-review`
 
 Additional workflow types should not be advertised as public contract until they have the same scaffold, schema, docs, and smoke-test coverage.
+
+## Contract preference
+
+The preferred public path is still `config/workflow.yaml`, because it is what
+the scaffold command generates and what the operator docs teach first.
+
+`WORKFLOW.md` support exists to improve Symphony compatibility, but it is
+currently a compatibility layer over the native schema, not a replacement for
+the scaffolded YAML path.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,35 @@
+# Security Posture
+
+Daedalus is built for a **trusted local operator** running on a **trusted host**. It is not a hardened multi-tenant control plane.
+
+## Trust Model
+
+- The operator controls the workflow root, runtime binaries, hooks, and host credentials.
+- The target repository may be buggy or malicious. Daedalus does **not** assume repo contents are safe to execute.
+- Runtime adapters and hooks are allowed to run shell commands. Treat them as code execution surfaces.
+
+## Filesystem and Process Scope
+
+- Plugin code lives under `~/.hermes/plugins/daedalus`.
+- Workflow config and mutable state live under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`.
+- Agent turns are intended to operate inside the configured repo/worktree, but Daedalus does not enforce a universal filesystem sandbox.
+- Hooks can execute arbitrary shell and can escape the worktree if you configure them to.
+
+## Network and External Side Effects
+
+- GitHub mutations happen through the configured runtime/tooling and inherit that runtime's credentials.
+- Daedalus may post comments, push branches, open PRs, or merge when the workflow and runtime are configured to do so.
+- There is no global approval gate enforced by Daedalus itself. Approval and sandbox behavior are runtime-specific.
+
+## Secrets and Logging
+
+- Keep secrets in environment variables, host credential stores, or runtime-specific auth surfaces.
+- Do not commit secrets into `workflow.yaml`, `WORKFLOW.md`, prompts, or hook scripts.
+- Daedalus writes structured status/events/audit data for observability. It does not guarantee universal secret redaction across operator-configured prompts, hook output, or third-party runtime stderr/stdout.
+
+## Safe Deployment Guidance
+
+- Run Daedalus only on machines where shell execution by the selected runtimes is acceptable.
+- Prefer dedicated credentials scoped to the target repository.
+- Review hook scripts as carefully as application code.
+- Treat `WORKFLOW.md` and prompt changes as security-sensitive configuration changes.

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -1,0 +1,43 @@
+# Symphony Conformance
+
+This note tracks Daedalus against the public `openai/symphony` draft spec as reviewed on **April 29, 2026**.
+
+The short version: Daedalus is already **Symphony-aligned** in architecture, but only **partially Symphony-compatible** at the contract and integration boundaries.
+
+## Positioning
+
+- Daedalus is a long-running workflow orchestrator with durable state, hot reload, isolated lane worktrees, recovery, and operator observability.
+- Daedalus is still **GitHub-first**. The current Symphony draft is still **Linear-first**.
+- Daedalus now accepts a Symphony-style `WORKFLOW.md`, but it is a compatibility layer over the native `code-review` schema, not a full native Symphony front matter implementation.
+
+## Status Matrix
+
+| Symphony concept | Daedalus status | Notes |
+|---|---|---|
+| `WORKFLOW.md` loader | Partial | Supported at the workflow root. `WORKFLOW.md` must provide `daedalus.workflow-config`, and the Markdown body is injected into `prompts.<role>`. |
+| Typed config + hot reload | Implemented | Current `code-review` schema is validated and hot-reloaded with last-known-good behavior. |
+| Issue tracker client boundary | Partial | GitHub issue selection exists, but there is no generic tracker protocol or Linear adapter yet. |
+| Workspace manager | Partial | Per-lane worktrees and lane-local files exist; generic lifecycle hooks are not first-class yet. |
+| Bounded concurrency | Partial | Ownership and recovery exist; Symphony-style global/per-state scheduler limits are not yet config-first. |
+| Retry/backoff policy | Partial | Durable retry and recovery bookkeeping exist, but backoff policy is not exposed as a clean public contract yet. |
+| Coding-agent protocol | Partial | CLI/session runtimes ship today; a real Codex app-server adapter is still missing. |
+| Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; token/rate-limit accounting is still incomplete. |
+| Trust/safety posture | Implemented | See [security.md](security.md). |
+| Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
+
+## Important Differences
+
+Daedalus currently differs from the Symphony draft in three material ways:
+
+1. The primary public workflow contract is still `config/workflow.yaml`.
+2. The first workflow is GitHub-backed `code-review`, not a Linear-backed generic scheduler.
+3. Runtime adapters are CLI-oriented today, not Codex app-server-native.
+
+## Recommended Next Gaps
+
+1. Extract a real tracker interface and add a Linear adapter.
+2. Add configurable workspace root + lifecycle hooks.
+3. Promote concurrency and retry policy into the public schema.
+4. Add a Codex app-server runtime with token and rate-limit accounting.
+
+Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -50,6 +50,16 @@ _VALID_YAML = textwrap.dedent("""\
 """)
 
 
+def _valid_workflow_markdown() -> str:
+    front_matter = textwrap.dedent(f"""\
+        daedalus:
+          prompt-role: coder
+          workflow-config:
+{textwrap.indent(_VALID_YAML, '            ')}
+    """)
+    return f"---\n{front_matter}---\n\nYou are the workflow prompt.\n"
+
+
 def test_parse_and_validate_returns_snapshot(tmp_path):
     from workflows.code_review.config_watcher import parse_and_validate
 
@@ -59,6 +69,17 @@ def test_parse_and_validate_returns_snapshot(tmp_path):
     assert snap.config["workflow"] == "code-review"
     assert snap.source_mtime == p.stat().st_mtime
     assert snap.loaded_at > 0
+
+
+def test_parse_and_validate_accepts_workflow_markdown(tmp_path):
+    from workflows.code_review.config_watcher import parse_and_validate
+
+    p = tmp_path / "WORKFLOW.md"
+    p.write_text(_valid_workflow_markdown())
+    snap = parse_and_validate(p)
+
+    assert snap.config["workflow"] == "code-review"
+    assert snap.prompts["coder"] == "You are the workflow prompt."
 
 
 def test_parse_and_validate_raises_on_yaml_syntax_error(tmp_path):

--- a/tests/test_official_plugin_layout.py
+++ b/tests/test_official_plugin_layout.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 from pathlib import Path
 
 import yaml
@@ -74,3 +75,16 @@ def test_repo_root_tools_wrapper_dispatches_scaffold(tmp_path):
 
     assert "daedalus error:" not in out, out
     assert (workflow_root / "config" / "workflow.yaml").exists()
+
+
+def test_repo_root_workflows_wrapper_exposes_code_review_submodules():
+    for module_name in list(sys.modules):
+        if module_name == "workflows" or module_name.startswith("workflows."):
+            del sys.modules[module_name]
+
+    import importlib
+
+    runtimes = importlib.import_module("workflows.code_review.runtimes")
+
+    assert runtimes.__file__ is not None
+    assert "daedalus/workflows/code_review/runtimes" in runtimes.__file__

--- a/tests/test_runtime_agnostic_phase_a.py
+++ b/tests/test_runtime_agnostic_phase_a.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from workflows.code_review.runtimes import _RUNTIME_KINDS, SessionHandle
+from workflows.code_review.runtimes import SessionHandle
 
 
 def test_acpx_runtime_has_run_command():
@@ -59,8 +59,10 @@ def test_claude_cli_run_command_invokes_run(tmp_path):
 
 def test_hermes_agent_runtime_registered():
     # Trigger registration
+    from workflows.code_review import runtimes as runtime_module
     from workflows.code_review.runtimes import hermes_agent  # noqa: F401
-    assert "hermes-agent" in _RUNTIME_KINDS
+
+    assert "hermes-agent" in runtime_module._RUNTIME_KINDS
 
 
 def test_hermes_agent_run_command(tmp_path):
@@ -258,6 +260,30 @@ def test_dispatch_agent_falls_back_to_bundled(tmp_path):
     p = resolve_prompt_template_path(workspace=ws, role="coder", agent_cfg={})
     assert p.name == "coder.md"
     assert "workflows/code_review/prompts" in str(p)
+
+
+def test_dispatch_agent_prefers_inline_prompt_template_from_config(tmp_path):
+    from workflows.code_review.dispatch import dispatch_agent
+
+    fake_run = MagicMock(return_value=MagicMock(stdout="ok"))
+    agents = {
+        "coder": {
+            "default": {"name": "c", "model": "gpt-5", "runtime": "codex-acpx"},
+        },
+    }
+    ws = _make_workspace(tmp_path, agents, _runtimes_cfg(), fake_run)
+    ws.config["prompts"] = {"coder": "Inline contract prompt"}
+
+    out = dispatch_agent(
+        workspace=ws, role="coder", tier="default",
+        prompt_kwargs={}, session_name="lane-9", worktree=tmp_path,
+    )
+
+    assert out == "ok"
+    argv = fake_run.call_args[0][0]
+    prompt_files = [a for a in argv if a.endswith(".txt")]
+    assert len(prompt_files) == 1
+    assert Path(prompt_files[0]).read_text() == "Inline contract prompt"
 
 
 def test_dispatch_agent_legacy_fallback_calls_run_prompt(tmp_path):

--- a/tests/test_workflow_contract_loader.py
+++ b/tests/test_workflow_contract_loader.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from workflows.contract import (
+    WorkflowContractError,
+    find_workflow_contract_path,
+    load_workflow_contract,
+    load_workflow_contract_file,
+)
+
+
+def _native_config() -> dict:
+    return {
+        "workflow": "code-review",
+        "schema-version": 1,
+        "instance": {"name": "attmous-daedalus-code-review", "engine-owner": "hermes"},
+        "repository": {
+            "local-path": "/tmp/repo",
+            "github-slug": "attmous/daedalus",
+            "active-lane-label": "active-lane",
+        },
+        "runtimes": {"r1": {"kind": "claude-cli", "max-turns-per-invocation": 8, "timeout-seconds": 60}},
+        "agents": {
+            "coder": {"default": {"name": "coder", "model": "gpt-5", "runtime": "r1"}},
+            "internal-reviewer": {"name": "reviewer", "model": "claude", "runtime": "r1"},
+            "external-reviewer": {"enabled": False, "name": "external"},
+        },
+        "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+        "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+        "storage": {
+            "ledger": "memory/workflow-status.json",
+            "health": "memory/workflow-health.json",
+            "audit-log": "memory/workflow-audit.jsonl",
+        },
+    }
+
+
+def _workflow_markdown(config: dict, *, prompt_role: str = "coder", body: str = "You are the workflow prompt.") -> str:
+    front_matter = {
+        "tracker": {"kind": "github-issues"},
+        "daedalus": {
+            "prompt-role": prompt_role,
+            "workflow-config": config,
+        },
+    }
+    return "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n"
+
+
+def test_load_workflow_contract_reads_yaml_mapping(tmp_path):
+    root = tmp_path / "wf"
+    (root / "config").mkdir(parents=True)
+    path = root / "config" / "workflow.yaml"
+    path.write_text(yaml.safe_dump(_native_config()), encoding="utf-8")
+
+    contract = load_workflow_contract(root)
+
+    assert contract.source_path == path
+    assert contract.config["workflow"] == "code-review"
+    assert contract.prompt_template == ""
+
+
+def test_load_workflow_contract_reads_markdown_and_injects_prompt(tmp_path):
+    root = tmp_path / "wf"
+    root.mkdir()
+    path = root / "WORKFLOW.md"
+    path.write_text(
+        _workflow_markdown(
+            _native_config(),
+            prompt_role="internal-reviewer",
+            body="Review the lane strictly.",
+        ),
+        encoding="utf-8",
+    )
+
+    contract = load_workflow_contract(root)
+
+    assert contract.source_path == path
+    assert contract.config["workflow"] == "code-review"
+    assert contract.config["prompts"]["internal-reviewer"] == "Review the lane strictly."
+    assert contract.prompt_template == "Review the lane strictly."
+
+
+def test_load_workflow_contract_markdown_requires_daedalus_workflow_config(tmp_path):
+    path = tmp_path / "WORKFLOW.md"
+    path.write_text(
+        "---\ntracker:\n  kind: linear\n---\n\nPrompt body.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkflowContractError, match="daedalus.workflow-config"):
+        load_workflow_contract_file(path)
+
+
+def test_find_workflow_contract_path_prefers_yaml_when_both_exist(tmp_path):
+    root = tmp_path / "wf"
+    (root / "config").mkdir(parents=True)
+    yaml_path = root / "config" / "workflow.yaml"
+    yaml_path.write_text(yaml.safe_dump(_native_config()), encoding="utf-8")
+    (root / "WORKFLOW.md").write_text(_workflow_markdown(_native_config()), encoding="utf-8")
+
+    assert find_workflow_contract_path(root) == yaml_path

--- a/tests/test_workflows_code_review_paths.py
+++ b/tests/test_workflows_code_review_paths.py
@@ -49,6 +49,47 @@ def _write_workflow_yaml(workflow_root: Path, *, instance_name: str = "blueprint
     )
 
 
+def _write_workflow_markdown(workflow_root: Path, *, instance_name: str = "blueprint-engine") -> None:
+    config = {
+        "workflow": "code-review",
+        "schema-version": 1,
+        "instance": {"name": instance_name, "engine-owner": "hermes"},
+        "repository": {
+            "local-path": str(workflow_root / "repo"),
+            "github-slug": "owner/repo",
+            "active-lane-label": "active-lane",
+        },
+        "runtimes": {"acpx-codex": {"kind": "acpx-codex"}},
+        "agents": {
+            "coder": {"default": {"name": "Internal_Coder_Agent", "model": "gpt-5.3-codex", "runtime": "acpx-codex"}},
+            "internal-reviewer": {"name": "Internal_Reviewer_Agent", "model": "claude-sonnet-4-6", "runtime": "acpx-codex"},
+            "external-reviewer": {"enabled": True, "name": "External_Reviewer_Agent"},
+        },
+        "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+        "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+        "storage": {
+            "ledger": "memory/workflow-status.json",
+            "health": "memory/workflow-health.json",
+            "audit-log": "memory/workflow-audit.jsonl",
+        },
+    }
+    workflow_root.mkdir(parents=True, exist_ok=True)
+    (workflow_root / "WORKFLOW.md").write_text(
+        "---\n"
+        + yaml.safe_dump(
+            {
+                "daedalus": {
+                    "prompt-role": "coder",
+                    "workflow-config": config,
+                },
+            },
+            sort_keys=False,
+        )
+        + "---\n\nPrompt body\n",
+        encoding="utf-8",
+    )
+
+
 def test_runtime_paths_use_project_runtime_subdirs_when_present(tmp_path):
     paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
     workflow_root = tmp_path / "blueprint"
@@ -112,6 +153,25 @@ def test_resolve_default_workflow_root_detects_cwd_ancestor_with_config(tmp_path
     assert resolved == workflow_root.resolve()
 
 
+def test_resolve_default_workflow_root_detects_cwd_ancestor_with_workflow_markdown(tmp_path):
+    paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
+    workflow_root = tmp_path / "workflow-root"
+    nested = workflow_root / "workspace" / "repo" / "src"
+    _write_workflow_markdown(workflow_root)
+    (workflow_root / "runtime").mkdir(parents=True, exist_ok=True)
+    (workflow_root / "memory").mkdir(parents=True, exist_ok=True)
+    (workflow_root / "state").mkdir(parents=True, exist_ok=True)
+    nested.mkdir(parents=True)
+
+    resolved = paths_module.resolve_default_workflow_root(
+        plugin_dir=tmp_path / "plugin" / "daedalus",
+        env={},
+        cwd=nested,
+    )
+
+    assert resolved == workflow_root.resolve()
+
+
 def test_resolve_default_workflow_root_falls_back_to_cwd_when_no_config(tmp_path):
     paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
     cwd = tmp_path / "scratch"
@@ -155,6 +215,13 @@ def test_project_key_for_workflow_root_reads_instance_name_from_workflow_yaml(tm
     paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
     workflow_root = tmp_path / "workflow"
     _write_workflow_yaml(workflow_root, instance_name="Blueprint Engine")
+    assert paths_module.project_key_for_workflow_root(workflow_root) == "blueprint-engine"
+
+
+def test_project_key_for_workflow_root_reads_instance_name_from_workflow_markdown(tmp_path):
+    paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
+    workflow_root = tmp_path / "workflow"
+    _write_workflow_markdown(workflow_root, instance_name="Blueprint Engine")
     assert paths_module.project_key_for_workflow_root(workflow_root) == "blueprint-engine"
 
 

--- a/tests/test_workflows_dispatcher.py
+++ b/tests/test_workflows_dispatcher.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 def test_load_workflow_returns_module_when_contract_is_complete(tmp_path, monkeypatch):
@@ -127,6 +128,22 @@ def _reset_workflows_module_cache():
             del sys.modules[mod]
 
 
+def _write_workflow_markdown(workspace_root: Path, *, workflow_name: str = "demo-wf", body: str = "Prompt body") -> None:
+    front_matter = {
+        "daedalus": {
+            "prompt-role": "coder",
+            "workflow-config": {
+                "workflow": workflow_name,
+                "schema-version": 1,
+            },
+        },
+    }
+    (workspace_root / "WORKFLOW.md").write_text(
+        "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_run_cli_dispatches_to_named_workflow_and_returns_its_exit_code(tmp_path, monkeypatch, capsys):
     _write_stub_workflow(tmp_path, name="demo-wf")
     workspace_root = tmp_path / "workspace"
@@ -143,6 +160,21 @@ def test_run_cli_dispatches_to_named_workflow_and_returns_its_exit_code(tmp_path
 
     assert code == 0
     assert "ran demo-wf with argv=['status', '--json']" in capsys.readouterr().out
+
+
+def test_run_cli_dispatches_when_workflow_contract_is_markdown(tmp_path, monkeypatch, capsys):
+    _write_stub_workflow(tmp_path, name="demo-wf")
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _write_workflow_markdown(workspace_root, workflow_name="demo-wf", body="Markdown prompt body")
+    _reset_workflows_module_cache()
+    workflows = importlib.import_module("workflows")
+    monkeypatch.setattr(workflows, "__path__", list(workflows.__path__) + [str(tmp_path / "workflows")])
+
+    code = workflows.run_cli(workspace_root, ["status"])
+
+    assert code == 0
+    assert "ran demo-wf with argv=['status']" in capsys.readouterr().out
 
 
 def test_run_cli_raises_when_workflow_key_missing(tmp_path, monkeypatch):

--- a/tests/test_workspace_yaml_loader.py
+++ b/tests/test_workspace_yaml_loader.py
@@ -1,4 +1,4 @@
-"""Regression tests for YAML-only workflow workspace loading."""
+"""Regression tests for workflow contract workspace loading."""
 import importlib.util
 from pathlib import Path
 
@@ -83,6 +83,16 @@ def _yaml_config(repo_path: Path) -> dict:
     }
 
 
+def _workflow_markdown(config: dict, *, prompt_role: str = "coder", body: str = "Contract prompt") -> str:
+    front_matter = {
+        "daedalus": {
+            "prompt-role": prompt_role,
+            "workflow-config": config,
+        },
+    }
+    return "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n"
+
+
 def test_load_workspace_from_config_prefers_workflow_yaml(tmp_path):
     """When workflow.yaml exists, it must be read to build the workspace."""
     workspace = _load_workspace_module()
@@ -118,6 +128,20 @@ def test_load_workspace_from_config_accepts_explicit_yaml_path(tmp_path):
     assert ws.ENGINE_OWNER == "hermes"
 
 
+def test_load_workspace_from_config_accepts_explicit_markdown_path(tmp_path):
+    workspace = _load_workspace_module()
+    workspace_root = tmp_path / "workflow"
+    workspace_root.mkdir()
+    cfg = _yaml_config(tmp_path / "markdown-repo")
+    path = workspace_root / "WORKFLOW.md"
+    path.write_text(_workflow_markdown(cfg, prompt_role="internal-reviewer"), encoding="utf-8")
+
+    ws = workspace.load_workspace_from_config(workspace_root=workspace_root, config_path=path)
+
+    assert ws.REPO_PATH == Path(tmp_path / "markdown-repo")
+    assert ws.ENGINE_OWNER == "hermes"
+
+
 def test_load_workspace_from_config_rejects_json_config_path(tmp_path):
     workspace = _load_workspace_module()
     workspace_root = tmp_path / "workflow"
@@ -129,8 +153,21 @@ def test_load_workspace_from_config_rejects_json_config_path(tmp_path):
     with pytest.raises(ValueError):
         workspace.load_workspace_from_config(workspace_root=workspace_root, config_path=json_path)
 
+def test_load_workspace_from_config_falls_back_to_workflow_markdown(tmp_path):
+    workspace = _load_workspace_module()
+    workspace_root = tmp_path / "workflow"
+    workspace_root.mkdir()
+    cfg = _yaml_config(tmp_path / "markdown-repo")
+    (workspace_root / "WORKFLOW.md").write_text(_workflow_markdown(cfg), encoding="utf-8")
+
+    ws = workspace.load_workspace_from_config(workspace_root=workspace_root)
+
+    assert ws.REPO_PATH == Path(tmp_path / "markdown-repo")
+    assert ws.ENGINE_OWNER == "hermes"
+
+
 def test_load_workspace_from_config_raises_when_no_config_present(tmp_path):
-    """If workflow.yaml is missing, raise FileNotFoundError."""
+    """If no workflow contract is present, raise FileNotFoundError."""
     workspace = _load_workspace_module()
     workspace_root = tmp_path / "workflow"
     (workspace_root / "config").mkdir(parents=True)

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -8,4 +8,9 @@ _PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
 if _PLUGIN_ROOT_STR not in sys.path:
     sys.path.insert(0, _PLUGIN_ROOT_STR)
 
+_REAL_WORKFLOWS_DIR = _PLUGIN_ROOT / "daedalus" / "workflows"
+_real_dir_str = str(_REAL_WORKFLOWS_DIR)
+if _real_dir_str not in __path__:
+    __path__.append(_real_dir_str)
+
 from daedalus.workflows import *  # noqa: F401,F403

--- a/workflows/code_review/__init__.py
+++ b/workflows/code_review/__init__.py
@@ -8,4 +8,9 @@ _PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
 if _PLUGIN_ROOT_STR not in sys.path:
     sys.path.insert(0, _PLUGIN_ROOT_STR)
 
+_REAL_WORKFLOW_DIR = _PLUGIN_ROOT / "daedalus" / "workflows" / "code_review"
+_real_dir_str = str(_REAL_WORKFLOW_DIR)
+if _real_dir_str not in __path__:
+    __path__.append(_real_dir_str)
+
 from daedalus.workflows.code_review import *  # noqa: F401,F403

--- a/workflows/contract.py
+++ b/workflows/contract.py
@@ -1,0 +1,11 @@
+"""Repo-root workflow-contract wrapper for official Hermes plugin installs."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+from daedalus.workflows.contract import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary

This PR adds a Symphony-facing workflow contract layer without breaking the current Daedalus workflow model.

- add `WORKFLOW.md` compatibility loading alongside `config/workflow.yaml`
- wire the contract loader through dispatch, workspace loading, path resolution, hot reload, and observability reads
- let `WORKFLOW.md` prompt bodies flow into dispatch via inline `prompts.<role>` overrides
- add public docs for Symphony conformance and the Daedalus security/trust posture
- harden the repo-root `workflows/` shims so official plugin-layout imports resolve submodules correctly

## Why

Daedalus already matches much of Symphony's architecture, but the repo was still missing the contract layer and explicit public documentation needed to describe that position accurately.

This keeps the existing `code-review` workflow stable while making Daedalus partially Symphony-compatible today instead of only Symphony-inspired.

## Impact

- `workflow.yaml` remains the primary scaffolded and documented operator path
- `WORKFLOW.md` is now accepted at the workflow root as a compatibility layer using `daedalus.workflow-config`
- hot reload and workspace bootstrap now operate on the workflow contract, not only YAML files
- public docs now distinguish between Symphony alignment, partial compatibility, and remaining gaps

## Validation

```bash
pytest tests/test_workflow_contract_loader.py tests/test_workflows_dispatcher.py tests/test_workspace_yaml_loader.py tests/test_runtime_agnostic_phase_a.py tests/test_workflows_code_review_paths.py tests/test_config_watcher.py tests/test_official_plugin_layout.py tests/test_daedalus_observability_cli.py tests/test_tools_new_command_dispatch.py tests/test_tools_run_cli_command_dispatch.py tests/test_workflows_code_review_entrypoint.py tests/test_workflows_preflight_cli_integration.py

pytest tests/test_public_onboarding_smoke.py tests/test_install.py tests/test_pip_plugin_packaging.py tests/test_workflows_code_review_schema.py
```
