### PR TITLE
[codex] make WORKFLOW.md primary and simplify workflow onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .pytest_cache/
 .DS_Store
 .claude/
+.hermes/daedalus/workflow-root
 build/
 dist/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Daedalus warned Icarus, then flew home. Edits take effect on the next tick. A ba
 
 ## What's in the box
 
-- **Configurable agent per role.** Pick which agent and model handles each role in your workflow — Codex for review, Claude for code, your own agent for merge. Set in `workflow.yaml`.
-- **Hot-reload.** Edit `workflow.yaml` and the next tick picks it up. Bad edits don't crash the loop; they get ignored until you fix them.
+- **Configurable agent per role.** Pick which agent and model handles each role in your workflow — Codex for review, Claude for code, your own agent for merge. Set in `WORKFLOW.md`.
+- **Hot-reload.** Edit `WORKFLOW.md` and the next tick picks it up. Bad edits don't crash the loop; they get ignored until you fix them.
 - **Stall detection.** Wedged agents get terminated automatically and the lane retries. No zombie workers.
 - **Symphony-aligned event vocabulary** — events follow the [openai/symphony](https://github.com/openai/symphony) taxonomy, so observability tools work across systems.
 - **Operator commands** — `/daedalus status`, `/daedalus doctor`, `/workflow code-review status`, `/workflow code-review tick`.
@@ -71,7 +71,7 @@ Daedalus is ready to publish on one explicit path:
 - **Workflow root:** `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
 - **Host Python:** `python3` with `yaml` and `jsonschema` available
 - **24/7 supervision:** `systemd --user`
-- **Runtime adapters:** whatever `workflow.yaml` names must exist on the host (`acpx-codex`, `claude-cli`, `hermes-agent`, ...).
+- **Runtime adapters:** whatever `WORKFLOW.md` names must exist on the host (`acpx-codex`, `claude-cli`, `hermes-agent`, ...).
 
 If you want the exact operator contract we support, read [docs/public-contract.md](docs/public-contract.md).
 
@@ -91,11 +91,14 @@ hermes daedalus scaffold-workflow \
   --github-slug your-org/your-repo
 ```
 
-Edit `~/.hermes/workflows/your-org-your-repo-code-review/config/workflow.yaml` before starting the engine:
+Edit `~/.hermes/workflows/your-org-your-repo-code-review/WORKFLOW.md` before starting the engine:
 
 - set `repository.local-path`
 - confirm the runtime kinds you actually have installed
 - tune agents/models/gates for your repo
+
+The YAML front matter is the machine config. The Markdown body below it is the
+shared workflow policy Daedalus applies across its role-specific prompts.
 
 Then initialize, verify, and supervise it:
 
@@ -172,7 +175,7 @@ flowchart LR
 
   subgraph DAEDALUS["Daedalus engine"]
     direction TB
-    WF["workflow.yaml<br/>stages, roles, gates"]
+    WF["WORKFLOW.md<br/>stages, roles, gates"]
     LANE["Lane<br/>one run per active issue"]
     WF -.-> LANE
   end
@@ -191,12 +194,12 @@ flowchart LR
   AGENTS ==> PR
 ```
 
-A **labeled issue** is the trigger. The **engine** ticks; for every active issue, it spins up a **lane** — one run of the workflow defined in `workflow.yaml` — and dispatches to the **agent** configured for the current stage. Agents write commits, post review comments, and eventually merge. When the workflow's last gate clears, the PR closes the loop.
+A **labeled issue** is the trigger. The **engine** ticks; for every active issue, it spins up a **lane** — one run of the workflow defined in `WORKFLOW.md` — and dispatches to the **agent** configured for the current stage. Agents write commits, post review comments, and eventually merge. When the workflow's last gate clears, the PR closes the loop.
 
 ## Philosophy
 
 - **State is tracked, not guessed.** The workflow always knows where each issue stands.
-- **A bad edit in the workflow.yaml doesn't crash anything.** It just gets ignored until you fix it.
+- **A bad edit in `WORKFLOW.md` doesn't crash anything.** It just gets ignored until you fix it.
 - **Recovery is automatic.** Lost workers never block forward motion.
 - **No packaging theater.** This is a plugin payload — flat top level, on purpose.
 - **`--json` is the default operator dialect.** Humans read formatters, scripts read JSON.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,30 @@ sudo apt install python3-yaml python3-jsonschema
 # 2. Install and enable the plugin
 hermes plugins install attmous/daedalus --enable
 
-# 3. Scaffold one workflow instance
+# 3. Bootstrap one workflow instance from your repo checkout
+cd /path/to/your/repo
+hermes daedalus bootstrap
+```
+
+`bootstrap` infers the git repo root, derives `github-slug` from `origin`, and
+creates:
+
+```text
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>
+```
+
+It also writes a repo-local pointer at:
+
+```text
+./.hermes/daedalus/workflow-root
+```
+
+So later `hermes daedalus ...` commands can resolve the workflow root directly
+from the repo checkout.
+
+If you need explicit control, the lower-level command is still available:
+
+```bash
 hermes daedalus scaffold-workflow \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --github-slug your-org/your-repo
@@ -103,33 +126,32 @@ shared workflow policy Daedalus applies across its role-specific prompts.
 Then initialize, verify, and supervise it:
 
 ```bash
+hermes daedalus service-up
+```
+
+`service-up` initializes the runtime, validates `WORKFLOW.md`, installs the
+user systemd unit, enables it, and starts it. If you want to inspect before
+starting, the lower-level commands still exist:
+
+```bash
 hermes daedalus init \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
 
 hermes daedalus doctor \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --format json
-
-hermes daedalus service-install \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
-  --service-mode active
-
-hermes daedalus service-enable \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
-  --service-mode active
-
-hermes daedalus service-start \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
-  --service-mode active
 ```
 
 Start Hermes in your repo:
 
 ```bash
-export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
 cd /path/to/your/repo
 hermes
 ```
+
+Daedalus resolves the workflow root from the repo-local pointer written by
+`bootstrap`. `DAEDALUS_WORKFLOW_ROOT` remains available when you need to
+override it explicitly.
 
 Inside Hermes:
 

--- a/daedalus/observability_overrides.py
+++ b/daedalus/observability_overrides.py
@@ -13,7 +13,7 @@ Schema::
         }
     }
 
-Override is per-workflow and overrides the workflow.yaml value at
+Override is per-workflow and overrides the workflow-contract value at
 resolution time. Used by ``/daedalus set-observability``.
 """
 from __future__ import annotations

--- a/daedalus/projects/README.md
+++ b/daedalus/projects/README.md
@@ -4,7 +4,7 @@ Each subdirectory under `projects/` is one **project pack** — optional
 playground material for a specific repository or operator setup.
 
 Project packs are not the public workflow contract. The engine is
-configured from `<workflow-root>/config/workflow.yaml`; `projects/` is
+configured from `<workflow-root>/WORKFLOW.md`; `projects/` is
 where you keep project-specific docs, helper skills, and local metadata
 that you do not want in the generic plugin surface.
 
@@ -41,6 +41,6 @@ fresh clone.
    `projects/<your-slug>/workspace/README.md` placeholders.
 3. Add `projects/<your-slug>/docs/` and `projects/<your-slug>/skills/`
    if you need project-only runbooks or automations.
-4. Point your real workflow root's `config/workflow.yaml` at the repo
+4. Point your real workflow root's `WORKFLOW.md` at the repo
    and policy for that project. Daedalus selects work by
    `--workflow-root`, not by project-pack slug.

--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -11,7 +11,14 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
 
-from workflows.contract import WorkflowContractError, load_workflow_contract
+from workflows.contract import (
+    WorkflowContractError,
+    load_workflow_contract,
+    load_workflow_contract_file,
+    render_workflow_markdown,
+    workflow_yaml_path as legacy_workflow_config_path,
+    workflow_markdown_path,
+)
 from workflows.code_review.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -1009,7 +1016,7 @@ def _lazy_cmd_watch(args, parser):
 
 def _workflow_template_path(workflow_name: str) -> Path:
     templates = {
-        "code-review": PLUGIN_DIR / "workflows" / "code_review" / "workflow.template.yaml",
+        "code-review": PLUGIN_DIR / "workflows" / "code_review" / "workflow.template.md",
     }
     path = templates.get(workflow_name)
     if path is None:
@@ -1027,19 +1034,23 @@ def scaffold_workflow_root(
     engine_owner: str,
     force: bool,
 ) -> dict[str, Any]:
-    import yaml  # type: ignore[import]
-
     root = workflow_root.expanduser().resolve()
-    config_path = root / "config" / "workflow.yaml"
-    if config_path.exists() and not force:
+    contract_path = workflow_markdown_path(root)
+    legacy_config_path = legacy_workflow_config_path(root)
+    existing_contract_path = contract_path if contract_path.exists() else legacy_config_path
+    if existing_contract_path.exists() and not force:
         raise DaedalusCommandError(
-            f"refusing to overwrite existing config: {config_path} (pass --force to replace it)"
+            f"refusing to overwrite existing workflow contract: {existing_contract_path} "
+            "(pass --force to replace it)"
         )
 
     template_path = _workflow_template_path(workflow_name)
-    config = yaml.safe_load(template_path.read_text(encoding="utf-8"))
-    if not isinstance(config, dict):
-        raise DaedalusCommandError(f"workflow template must be a YAML mapping: {template_path}")
+    try:
+        template_contract = load_workflow_contract_file(template_path)
+    except (WorkflowContractError, OSError, UnicodeDecodeError) as exc:
+        raise DaedalusCommandError(f"unable to load workflow template {template_path}: {exc}") from exc
+    config = dict(template_contract.config)
+    workflow_policy = template_contract.prompt_template
 
     resolved_github_slug = github_slug.strip()
     if not resolved_github_slug:
@@ -1086,18 +1097,22 @@ def scaffold_workflow_root(
         root / "runtime" / "state" / "daedalus",
         root / "workspace",
         resolved_repo_path,
+        root / "config",
     ]
     for path in created_dirs:
         path.mkdir(parents=True, exist_ok=True)
 
-    config_path.write_text(
-        yaml.safe_dump(config, sort_keys=False),
+    contract_path.write_text(
+        render_workflow_markdown(config=config, prompt_template=workflow_policy),
         encoding="utf-8",
     )
+    if force and legacy_config_path.exists():
+        legacy_config_path.unlink()
     return {
         "ok": True,
         "workflow_root": str(root),
-        "config_path": str(config_path),
+        "contract_path": str(contract_path),
+        "config_path": str(contract_path),
         "workflow": workflow_name,
         "instance_name": resolved_instance_name,
         "engine_owner": engine_owner,
@@ -1122,7 +1137,7 @@ def cmd_scaffold_workflow(args, parser) -> str:
         return json.dumps(result, indent=2, sort_keys=True)
     lines = [
         f"scaffolded workflow root: {result['workflow_root']}",
-        f"config: {result['config_path']}",
+        f"contract: {result['contract_path']}",
         f"workflow: {result['workflow']}",
         f"instance: {result['instance_name']}",
         f"repo-path: {result['repo_path']}",
@@ -1548,7 +1563,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
 
     scaffold_cmd = sub.add_parser(
         "scaffold-workflow",
-        help="Create a new workflow root and starter config/workflow.yaml.",
+        help="Create a new workflow root and starter WORKFLOW.md.",
     )
     scaffold_cmd.add_argument(
         "--workflow-root",
@@ -1960,7 +1975,7 @@ def execute_workflow_command(raw_args: str) -> str:
     Single arg (workflow name): shows that workflow's ``--help``.
     Full invocation: routes through ``workflows.run_cli`` with
     ``require_workflow=<name>`` so the dispatcher pins the named module
-    regardless of what the workflow.yaml declares.
+    regardless of what the workflow contract declares.
     """
     workflow_root = resolve_default_workflow_root()
     parts = raw_args.strip().split() if raw_args else []

--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -11,6 +11,8 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from workflows.contract import (
     WorkflowContractError,
     load_workflow_contract,
@@ -23,6 +25,7 @@ from workflows.code_review.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
     project_key_for_workflow_root,
+    repo_local_workflow_pointer_path,
     resolve_default_workflow_root as resolve_workflow_root_default,
     workflow_cli_argv,
 )
@@ -320,6 +323,126 @@ def install_supervised_service(
         "instance_id": resolved_instance_id,
         "unit_path": str(template_path),
         "daemon_reload": reload_result,
+    }
+
+
+def _validate_workflow_contract_preflight(workflow_root: Path) -> dict[str, Any]:
+    import jsonschema
+    from workflows import load_workflow
+
+    contract = load_workflow_contract(workflow_root)
+    config = contract.config
+    workflow_name = config.get("workflow")
+    if not workflow_name:
+        raise DaedalusCommandError(
+            f"{contract.source_path} is missing top-level `workflow:` field"
+        )
+    module = load_workflow(str(workflow_name))
+    schema = yaml.safe_load(module.CONFIG_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(config, schema)
+    schema_version = int(config.get("schema-version", 1))
+    if schema_version not in module.SUPPORTED_SCHEMA_VERSIONS:
+        raise DaedalusCommandError(
+            f"workflow {workflow_name!r} does not support schema-version={schema_version}; "
+            f"supported: {list(module.SUPPORTED_SCHEMA_VERSIONS)}"
+        )
+    preflight_fn = getattr(module, "run_preflight", None)
+    if callable(preflight_fn):
+        result = preflight_fn(config)
+        if not getattr(result, "ok", True):
+            raise DaedalusCommandError(
+                f"workflow preflight failed for {workflow_name!r}: "
+                f"code={getattr(result, 'error_code', None)} "
+                f"detail={getattr(result, 'error_detail', None)}"
+            )
+        return {
+            "ok": True,
+            "workflow": workflow_name,
+            "schema_version": schema_version,
+            "preflight": {
+                "ok": True,
+                "error_code": getattr(result, "error_code", None),
+                "error_detail": getattr(result, "error_detail", None),
+            },
+            "source_path": str(contract.source_path),
+        }
+    return {
+        "ok": True,
+        "workflow": workflow_name,
+        "schema_version": schema_version,
+        "preflight": {"ok": True, "error_code": None, "error_detail": None},
+        "source_path": str(contract.source_path),
+    }
+
+
+def service_up(
+    *,
+    workflow_root: Path,
+    project_key: str,
+    instance_id: str | None,
+    interval_seconds: int,
+    service_name: str | None = None,
+    service_mode: str = "active",
+) -> dict[str, Any]:
+    daedalus = _load_daedalus_module(workflow_root)
+    init_result = daedalus.init_daedalus_db(workflow_root=workflow_root, project_key=project_key)
+    preflight_result = _validate_workflow_contract_preflight(workflow_root)
+
+    install_result = install_supervised_service(
+        workflow_root=workflow_root,
+        project_key=project_key,
+        instance_id=instance_id,
+        interval_seconds=interval_seconds,
+        service_name=service_name,
+        service_mode=service_mode,
+    )
+    if not install_result.get("installed"):
+        daemon_reload = install_result.get("daemon_reload") or {}
+        raise DaedalusCommandError(
+            "unable to install systemd service: "
+            f"{daemon_reload.get('stderr') or daemon_reload.get('stdout') or 'daemon-reload failed'}"
+        )
+
+    enable_result = service_control(
+        "enable",
+        workflow_root=workflow_root,
+        service_name=service_name,
+        service_mode=service_mode,
+    )
+    if not enable_result.get("ok"):
+        raise DaedalusCommandError(
+            "unable to enable systemd service: "
+            f"{enable_result.get('stderr') or enable_result.get('stdout') or enable_result.get('returncode')}"
+        )
+
+    start_result = service_control(
+        "start",
+        workflow_root=workflow_root,
+        service_name=service_name,
+        service_mode=service_mode,
+    )
+    if not start_result.get("ok"):
+        raise DaedalusCommandError(
+            "unable to start systemd service: "
+            f"{start_result.get('stderr') or start_result.get('stdout') or start_result.get('returncode')}"
+        )
+
+    service_status_result = service_status(
+        workflow_root=workflow_root,
+        service_name=service_name,
+        service_mode=service_mode,
+    )
+    return {
+        "ok": True,
+        "workflow_root": str(workflow_root),
+        "project_key": project_key,
+        "service_mode": service_mode,
+        "init": init_result,
+        "preflight": preflight_result,
+        "service_install": install_result,
+        "service_enable": enable_result,
+        "service_start": start_result,
+        "service_status": service_status_result,
     }
 
 
@@ -1024,6 +1147,111 @@ def _workflow_template_path(workflow_name: str) -> Path:
     return path
 
 
+_GITHUB_REMOTE_RE = re.compile(
+    r"^(?:git@github\.com:|ssh://git@github\.com/|https?://(?:www\.)?github\.com/)"
+    r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+def _git_stdout(*args: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "git command failed"
+        raise DaedalusCommandError(f"`git {' '.join(args)}` failed in {cwd}: {detail}")
+    return completed.stdout.strip()
+
+
+def _discover_git_repo_root(start_path: Path | None) -> Path:
+    start = (start_path or Path.cwd()).expanduser().resolve()
+    if not start.exists():
+        raise DaedalusCommandError(f"repo path does not exist: {start}")
+    cwd = start.parent if start.is_file() else start
+    try:
+        repo_root = _git_stdout("rev-parse", "--show-toplevel", cwd=cwd)
+    except DaedalusCommandError as exc:
+        raise DaedalusCommandError(
+            "bootstrap must run inside a git repository or use --repo-path pointing at one"
+        ) from exc
+    return Path(repo_root).expanduser().resolve()
+
+
+def _github_slug_from_remote_url(remote_url: str) -> str:
+    match = _GITHUB_REMOTE_RE.match(remote_url.strip())
+    if not match:
+        raise DaedalusCommandError(
+            "unable to derive --github-slug from git origin; use a GitHub remote or pass --github-slug explicitly"
+        )
+    owner = match.group("owner").strip()
+    repo = match.group("repo").strip()
+    if not owner or not repo:
+        raise DaedalusCommandError(
+            "unable to derive --github-slug from git origin; use a GitHub remote or pass --github-slug explicitly"
+        )
+    return f"{owner}/{repo}"
+
+
+def bootstrap_workflow_root(
+    *,
+    repo_path: Path | None,
+    workflow_name: str,
+    workflow_root: Path | None,
+    github_slug: str | None,
+    active_lane_label: str,
+    engine_owner: str,
+    force: bool,
+) -> dict[str, Any]:
+    repo_root = _discover_git_repo_root(repo_path)
+    remote_url = None
+    resolved_github_slug = (github_slug or "").strip()
+    if not resolved_github_slug:
+        remote_url = _git_stdout("remote", "get-url", "origin", cwd=repo_root)
+        resolved_github_slug = _github_slug_from_remote_url(remote_url)
+
+    try:
+        instance_name = derive_workflow_instance_name(
+            github_slug=resolved_github_slug,
+            workflow_name=workflow_name,
+        )
+    except ValueError as exc:
+        raise DaedalusCommandError(f"--github-slug {resolved_github_slug!r} is invalid: {exc}") from exc
+
+    resolved_workflow_root = (
+        workflow_root.expanduser().resolve()
+        if workflow_root is not None
+        else (Path.home() / ".hermes" / "workflows" / instance_name).resolve()
+    )
+
+    result = scaffold_workflow_root(
+        workflow_root=resolved_workflow_root,
+        workflow_name=workflow_name,
+        repo_path=repo_root,
+        github_slug=resolved_github_slug,
+        active_lane_label=active_lane_label,
+        engine_owner=engine_owner,
+        force=force,
+    )
+    pointer_path = repo_local_workflow_pointer_path(repo_root)
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    pointer_path.write_text(str(resolved_workflow_root) + "\n", encoding="utf-8")
+    result.update(
+        {
+            "bootstrap": True,
+            "detected_repo_root": str(repo_root),
+            "remote_url": remote_url,
+            "repo_pointer_path": str(pointer_path),
+            "next_edit_path": result["contract_path"],
+            "next_command": "hermes daedalus service-up",
+        }
+    )
+    return result
+
+
 def scaffold_workflow_root(
     *,
     workflow_root: Path,
@@ -1143,6 +1371,32 @@ def cmd_scaffold_workflow(args, parser) -> str:
         f"repo-path: {result['repo_path']}",
         f"github-slug: {result['github_slug']}",
     ]
+    return "\n".join(lines)
+
+
+def cmd_bootstrap_workflow(args, parser) -> str:
+    result = bootstrap_workflow_root(
+        repo_path=Path(args.repo_path) if args.repo_path else None,
+        workflow_name=args.workflow,
+        workflow_root=Path(args.workflow_root) if args.workflow_root else None,
+        github_slug=args.github_slug,
+        active_lane_label=args.active_lane_label,
+        engine_owner=args.engine_owner,
+        force=args.force,
+    )
+    if getattr(args, "json", False):
+        return json.dumps(result, indent=2, sort_keys=True)
+    lines = [
+        f"bootstrapped workflow root: {result['workflow_root']}",
+        f"contract: {result['contract_path']}",
+        f"repo-path: {result['repo_path']}",
+        f"github-slug: {result['github_slug']}",
+        f"repo pointer: {result['repo_pointer_path']}",
+        f"edit next: {result['next_edit_path']}",
+        f"then run: {result['next_command']}",
+    ]
+    if result.get("remote_url"):
+        lines.insert(4, f"origin: {result['remote_url']}")
     return "\n".join(lines)
 
 
@@ -1312,15 +1566,17 @@ def cmd_get_observability(args, parser) -> str:
 def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="daedalus_command")
     sub.required = True
+    default_workflow_root_str = str(resolve_default_workflow_root())
+    default_workflow_root_path = resolve_default_workflow_root()
 
     init_cmd = sub.add_parser("init", help="Initialize Daedalus DB and filesystem paths.")
-    init_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    init_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     init_cmd.add_argument("--project-key")
     init_cmd.add_argument("--json", action="store_true")
     init_cmd.set_defaults(func=run_cli_command)
 
     start_cmd = sub.add_parser("start", help="Bootstrap Daedalus runtime and acquire runtime lease.")
-    start_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    start_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     start_cmd.add_argument("--project-key")
     start_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     start_cmd.add_argument("--mode", default="shadow", choices=["shadow", "active", "maintenance"])
@@ -1328,7 +1584,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     start_cmd.set_defaults(func=run_cli_command)
 
     status_cmd = sub.add_parser("status", help="Show Daedalus runtime status.")
-    status_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    status_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     status_cmd.add_argument("--json", action="store_true")
     status_cmd.add_argument(
         "--format",
@@ -1339,7 +1595,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     status_cmd.set_defaults(func=run_cli_command)
 
     report_cmd = sub.add_parser("shadow-report", help="Summarize the live legacy lane, Daedalus shadow decision, compatibility, and recent shadow actions.")
-    report_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    report_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     report_cmd.add_argument("--recent-actions-limit", type=int, default=5)
     report_cmd.add_argument("--json", action="store_true")
     report_cmd.add_argument(
@@ -1351,7 +1607,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     report_cmd.set_defaults(func=run_cli_command)
 
     doctor_cmd = sub.add_parser("doctor", help="Diagnose Daedalus runtime freshness, lease ownership, shadow parity, and active-lane consistency.")
-    doctor_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    doctor_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     doctor_cmd.add_argument("--recent-actions-limit", type=int, default=5)
     doctor_cmd.add_argument("--json", action="store_true")
     doctor_cmd.add_argument(
@@ -1363,7 +1619,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     doctor_cmd.set_defaults(func=run_cli_command)
 
     service_install_cmd = sub.add_parser("service-install", help="Install the supervised Daedalus systemd user service.")
-    service_install_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_install_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_install_cmd.add_argument("--project-key")
     service_install_cmd.add_argument("--instance-id")
     service_install_cmd.add_argument("--interval-seconds", type=int, default=30)
@@ -1372,50 +1628,63 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     service_install_cmd.add_argument("--json", action="store_true")
     service_install_cmd.set_defaults(func=run_cli_command)
 
+    service_up_cmd = sub.add_parser(
+        "service-up",
+        help="Initialize, preflight, install, enable, and start the supervised Daedalus systemd user service.",
+    )
+    service_up_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    service_up_cmd.add_argument("--project-key")
+    service_up_cmd.add_argument("--instance-id")
+    service_up_cmd.add_argument("--interval-seconds", type=int, default=30)
+    service_up_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="active")
+    service_up_cmd.add_argument("--service-name")
+    service_up_cmd.add_argument("--json", action="store_true")
+    service_up_cmd.set_defaults(func=run_cli_command)
+
     service_uninstall_cmd = sub.add_parser("service-uninstall", help="Remove the supervised Daedalus systemd user service.")
-    service_uninstall_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_uninstall_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_uninstall_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_uninstall_cmd.add_argument("--service-name")
     service_uninstall_cmd.add_argument("--json", action="store_true")
     service_uninstall_cmd.set_defaults(func=run_cli_command)
 
     service_start_cmd = sub.add_parser("service-start", help="Start the supervised Daedalus systemd user service.")
-    service_start_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_start_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_start_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_start_cmd.add_argument("--service-name")
     service_start_cmd.add_argument("--json", action="store_true")
     service_start_cmd.set_defaults(func=run_cli_command)
 
     service_stop_cmd = sub.add_parser("service-stop", help="Stop the supervised Daedalus systemd user service.")
-    service_stop_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_stop_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_stop_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_stop_cmd.add_argument("--service-name")
     service_stop_cmd.add_argument("--json", action="store_true")
     service_stop_cmd.set_defaults(func=run_cli_command)
 
     service_restart_cmd = sub.add_parser("service-restart", help="Restart the supervised Daedalus systemd user service.")
-    service_restart_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_restart_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_restart_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_restart_cmd.add_argument("--service-name")
     service_restart_cmd.add_argument("--json", action="store_true")
     service_restart_cmd.set_defaults(func=run_cli_command)
 
     service_enable_cmd = sub.add_parser("service-enable", help="Enable the supervised Daedalus systemd user service.")
-    service_enable_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_enable_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_enable_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_enable_cmd.add_argument("--service-name")
     service_enable_cmd.add_argument("--json", action="store_true")
     service_enable_cmd.set_defaults(func=run_cli_command)
 
     service_disable_cmd = sub.add_parser("service-disable", help="Disable the supervised Daedalus systemd user service.")
-    service_disable_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_disable_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_disable_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_disable_cmd.add_argument("--service-name")
     service_disable_cmd.add_argument("--json", action="store_true")
     service_disable_cmd.set_defaults(func=run_cli_command)
 
     service_status_cmd = sub.add_parser("service-status", help="Show supervised Daedalus systemd user service status.")
-    service_status_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_status_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_status_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_status_cmd.add_argument("--service-name")
     service_status_cmd.add_argument("--json", action="store_true")
@@ -1428,7 +1697,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     service_status_cmd.set_defaults(func=run_cli_command)
 
     service_logs_cmd = sub.add_parser("service-logs", help="Show recent logs for the supervised Daedalus systemd user service.")
-    service_logs_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    service_logs_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_logs_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES), default="shadow")
     service_logs_cmd.add_argument("--service-name")
     service_logs_cmd.add_argument("--lines", type=int, default=50)
@@ -1436,25 +1705,25 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     service_logs_cmd.set_defaults(func=run_cli_command)
 
     ingest_cmd = sub.add_parser("ingest-live", help="Ingest current workflow status into Daedalus shadow state.")
-    ingest_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    ingest_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     ingest_cmd.add_argument("--json", action="store_true")
     ingest_cmd.set_defaults(func=run_cli_command)
 
     heartbeat_cmd = sub.add_parser("heartbeat", help="Refresh Daedalus runtime lease and heartbeat timestamp.")
-    heartbeat_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    heartbeat_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     heartbeat_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     heartbeat_cmd.add_argument("--ttl-seconds", type=int, default=60)
     heartbeat_cmd.add_argument("--json", action="store_true")
     heartbeat_cmd.set_defaults(func=run_cli_command)
 
     iterate_cmd = sub.add_parser("iterate-shadow", help="Run one shadow-mode loop iteration.")
-    iterate_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    iterate_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     iterate_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     iterate_cmd.add_argument("--json", action="store_true")
     iterate_cmd.set_defaults(func=run_cli_command)
 
     run_cmd = sub.add_parser("run-shadow", help="Run the shadow-mode loop shell for one or more iterations.")
-    run_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    run_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     run_cmd.add_argument("--project-key")
     run_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     run_cmd.add_argument("--interval-seconds", type=int, default=30)
@@ -1463,7 +1732,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     run_cmd.set_defaults(func=run_cli_command)
 
     active_gate_status_cmd = sub.add_parser("active-gate-status", help="Show Daedalus active-execution gate state.")
-    active_gate_status_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    active_gate_status_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     active_gate_status_cmd.add_argument("--json", action="store_true")
     active_gate_status_cmd.add_argument(
         "--format",
@@ -1474,19 +1743,19 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     active_gate_status_cmd.set_defaults(func=run_cli_command)
 
     set_active_execution_cmd = sub.add_parser("set-active-execution", help="Enable or disable Daedalus active execution.")
-    set_active_execution_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    set_active_execution_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     set_active_execution_cmd.add_argument("--enabled", required=True, choices=["true", "false"])
     set_active_execution_cmd.add_argument("--json", action="store_true")
     set_active_execution_cmd.set_defaults(func=run_cli_command)
 
     iterate_active_cmd = sub.add_parser("iterate-active", help="Run one guarded active-mode loop iteration.")
-    iterate_active_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    iterate_active_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     iterate_active_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     iterate_active_cmd.add_argument("--json", action="store_true")
     iterate_active_cmd.set_defaults(func=run_cli_command)
 
     run_active_cmd = sub.add_parser("run-active", help="Run the guarded active-mode loop shell for one or more iterations.")
-    run_active_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    run_active_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     run_active_cmd.add_argument("--project-key")
     run_active_cmd.add_argument("--instance-id", default=DEFAULT_INSTANCE_ID)
     run_active_cmd.add_argument("--interval-seconds", type=int, default=30)
@@ -1495,19 +1764,19 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     run_active_cmd.set_defaults(func=run_cli_command)
 
     request_active_cmd = sub.add_parser("request-active-actions", help="Derive and persist active requested actions for one lane.")
-    request_active_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    request_active_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     request_active_cmd.add_argument("--lane-id", required=True)
     request_active_cmd.add_argument("--json", action="store_true")
     request_active_cmd.set_defaults(func=run_cli_command)
 
     execute_action_cmd = sub.add_parser("execute-action", help="Execute one active requested action by action id.")
-    execute_action_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    execute_action_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     execute_action_cmd.add_argument("--action-id", required=True)
     execute_action_cmd.add_argument("--json", action="store_true")
     execute_action_cmd.set_defaults(func=run_cli_command)
 
     analyze_failure_cmd = sub.add_parser("analyze-failure", help="Run bounded failure analysis for a recorded failure id.")
-    analyze_failure_cmd.add_argument("--workflow-root", default=str(DEFAULT_WORKFLOW_ROOT))
+    analyze_failure_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     analyze_failure_cmd.add_argument("--failure-id", required=True)
     analyze_failure_cmd.add_argument("--json", action="store_true")
     analyze_failure_cmd.set_defaults(func=run_cli_command)
@@ -1519,7 +1788,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     migrate_fs_cmd.add_argument(
         "--workflow-root",
         type=Path,
-        default=DEFAULT_WORKFLOW_ROOT,
+        default=default_workflow_root_path,
         help="Workflow root to migrate (default: %(default)s)",
     )
     migrate_fs_cmd.set_defaults(handler=cmd_migrate_filesystem, func=run_cli_command)
@@ -1531,7 +1800,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     migrate_systemd_cmd.add_argument(
         "--workflow-root",
         type=Path,
-        default=DEFAULT_WORKFLOW_ROOT,
+        default=default_workflow_root_path,
     )
     migrate_systemd_cmd.set_defaults(handler=cmd_migrate_systemd, func=run_cli_command)
 
@@ -1539,7 +1808,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         "watch",
         help="Live operator TUI: lanes, alerts, recent events.",
     )
-    watch_cmd.add_argument("--workflow-root", type=Path, default=DEFAULT_WORKFLOW_ROOT)
+    watch_cmd.add_argument("--workflow-root", type=Path, default=default_workflow_root_path)
     watch_cmd.add_argument("--once", action="store_true", help="Render one frame and exit (default when stdout is not a TTY).")
     watch_cmd.add_argument("--interval", type=float, default=2.0, help="Poll interval in live mode.")
     watch_cmd.set_defaults(handler=_lazy_cmd_watch, func=run_cli_command)
@@ -1548,7 +1817,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         "set-observability",
         help="Override observability config for a workflow (writes runtime override file).",
     )
-    set_obs_cmd.add_argument("--workflow-root", type=Path, default=DEFAULT_WORKFLOW_ROOT)
+    set_obs_cmd.add_argument("--workflow-root", type=Path, default=default_workflow_root_path)
     set_obs_cmd.add_argument("--workflow", required=True, help="Workflow name (e.g. code-review)")
     set_obs_cmd.add_argument("--github-comments", choices=["on", "off", "unset"], required=True)
     set_obs_cmd.set_defaults(handler=cmd_set_observability, func=run_cli_command)
@@ -1557,7 +1826,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         "get-observability",
         help="Show effective observability config + which layer (default/yaml/override) won.",
     )
-    get_obs_cmd.add_argument("--workflow-root", type=Path, default=DEFAULT_WORKFLOW_ROOT)
+    get_obs_cmd.add_argument("--workflow-root", type=Path, default=default_workflow_root_path)
     get_obs_cmd.add_argument("--workflow", required=True)
     get_obs_cmd.set_defaults(handler=cmd_get_observability, func=run_cli_command)
 
@@ -1579,6 +1848,20 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     scaffold_cmd.add_argument("--force", action="store_true")
     scaffold_cmd.add_argument("--json", action="store_true")
     scaffold_cmd.set_defaults(handler=cmd_scaffold_workflow, func=run_cli_command)
+
+    bootstrap_cmd = sub.add_parser(
+        "bootstrap",
+        help="Infer repo settings from the current git checkout and scaffold a starter WORKFLOW.md.",
+    )
+    bootstrap_cmd.add_argument("--repo-path", type=Path, help="Git checkout to inspect (defaults to current working directory).")
+    bootstrap_cmd.add_argument("--workflow-root", type=Path, help="Optional explicit workflow root override.")
+    bootstrap_cmd.add_argument("--workflow", default="code-review", choices=["code-review"])
+    bootstrap_cmd.add_argument("--github-slug", help="Override the inferred GitHub slug from git origin.")
+    bootstrap_cmd.add_argument("--active-lane-label", default="active-lane")
+    bootstrap_cmd.add_argument("--engine-owner", default="hermes", choices=["hermes", "openclaw"])
+    bootstrap_cmd.add_argument("--force", action="store_true")
+    bootstrap_cmd.add_argument("--json", action="store_true")
+    bootstrap_cmd.set_defaults(handler=cmd_bootstrap_workflow, func=run_cli_command)
 
     return parser
 
@@ -1668,7 +1951,7 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     if workflow_root is not None and daedalus is not None and getattr(args, "daedalus_command", None):
         _record_operator_command_event(workflow_root=workflow_root, args=args, daedalus=daedalus)
     command = getattr(args, "daedalus_command", None)
-    project_key_commands = {"init", "start", "service-install", "run-shadow", "run-active"}
+    project_key_commands = {"init", "start", "service-install", "service-up", "run-shadow", "run-active"}
     resolved_project_key = (
         _resolved_project_key(
             daedalus=daedalus,
@@ -1703,6 +1986,15 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
         )
     if args.daedalus_command == "service-install":
         return install_supervised_service(
+            workflow_root=workflow_root,
+            project_key=resolved_project_key,
+            instance_id=args.instance_id,
+            interval_seconds=args.interval_seconds,
+            service_name=args.service_name,
+            service_mode=args.service_mode,
+        )
+    if args.daedalus_command == "service-up":
+        return service_up(
             workflow_root=workflow_root,
             project_key=resolved_project_key,
             instance_id=args.instance_id,
@@ -1887,6 +2179,15 @@ def render_result(
         return _fmt(result)
     if command == "service-install":
         return f"service installed mode={result.get('service_mode')} unit={result.get('unit_path')} ok={result.get('installed')}"
+    if command == "service-up":
+        status = result.get("service_status") or {}
+        preflight = result.get("preflight") or {}
+        return (
+            f"service up mode={result.get('service_mode')} "
+            f"workflow={preflight.get('workflow')} "
+            f"enabled={status.get('enabled')} active={status.get('active')} "
+            f"service={status.get('service_name')}"
+        )
     if command == "service-uninstall":
         return f"service uninstalled mode={result.get('service_mode')} unit={result.get('unit_path')} ok={result.get('uninstalled')}"
     if command in {"service-start", "service-stop", "service-restart", "service-enable", "service-disable"}:
@@ -2031,6 +2332,8 @@ def execute_raw_args(raw_args: str) -> str:
             return cmd_get_observability(args, parser)
         if args.daedalus_command == "scaffold-workflow":
             return cmd_scaffold_workflow(args, parser)
+        if args.daedalus_command == "bootstrap":
+            return cmd_bootstrap_workflow(args, parser)
         result = execute_namespace(args)
         fmt = _resolve_format(getattr(args, "format", None), getattr(args, "json", False))
         return render_result(args.daedalus_command, result, output_format=fmt)
@@ -2057,6 +2360,7 @@ def run_cli_command(args: argparse.Namespace) -> None:
         "set-observability",
         "get-observability",
         "scaffold-workflow",
+        "bootstrap",
     }
     if getattr(args, "daedalus_command", None) in string_returning:
         handler = getattr(args, "handler", None)

--- a/daedalus/workflows/README.md
+++ b/daedalus/workflows/README.md
@@ -12,10 +12,10 @@ expose `NAME`, `SUPPORTED_SCHEMA_VERSIONS`, `CONFIG_SCHEMA_PATH`,
 
 ## Naming
 
-- Workflow type: external contract in `workflow.yaml`, always `lower-kebab-case` such as `code-review`.
+- Workflow type: external contract in `WORKFLOW.md` front matter, always `lower-kebab-case` such as `code-review`.
 - Workflow package: Python slug under `workflows/`, always `lower_snake_case` such as `code_review/`.
 - Workflow instance root: directory under `~/.hermes/workflows/`, always `<owner>-<repo>-<workflow-type>`.
-- `instance.name` in `workflow.yaml` should match the workflow root directory name.
+- `instance.name` in `WORKFLOW.md` should match the workflow root directory name.
 
 ## Layout
 
@@ -34,7 +34,7 @@ workflows/
     ├── lane_selection.py    # picks which issues become active lanes
     ├── stall.py             # stall detection (Symphony §8.5)
     ├── config_snapshot.py   # AtomicRef-backed hot-reload (Symphony §6.2)
-    ├── config_watcher.py    # file watcher for workflow.yaml
+    ├── config_watcher.py    # file watcher for the workflow contract
     ├── event_taxonomy.py    # Symphony-aligned event names (§10.4)
     ├── github.py            # GitHub API surface (issues, PRs, labels)
     ├── reviews.py           # review aggregation across reviewer agents
@@ -60,8 +60,8 @@ workflows/
 
 ## How a workflow runs
 
-1. Daedalus's tick loop loads `workflow.yaml` from the project's
-   workspace directory.
+1. Daedalus's tick loop loads `WORKFLOW.md` from the workflow root
+   (or legacy `config/workflow.yaml` when migrating older instances).
 2. The dispatcher imports the workflow package referenced by
    `workflow:` in the config (e.g. `code-review`).
 3. `make_workspace(workflow_root, config)` returns the workspace
@@ -76,7 +76,7 @@ workflows/
 2. Add a `schema.yaml` defining the workflow's config shape.
 3. Implement `cli_main(workspace, argv)` so operators can run
    `/workflow <your-name> status` and friends.
-4. Reference it from `workflow.yaml` in the project workspace:
+4. Reference it from `WORKFLOW.md` front matter in the workflow root:
    `workflow: <your-name>`.
 
 The `code_review/` package is the reference implementation — start by

--- a/daedalus/workflows/__init__.py
+++ b/daedalus/workflows/__init__.py
@@ -59,10 +59,10 @@ def run_cli(
 ) -> int:
     """Read the workflow contract under ``workflow_root`` and dispatch.
 
-    When ``require_workflow`` is set, the dispatcher asserts that the YAML's
+    When ``require_workflow`` is set, the dispatcher asserts that the contract's
     ``workflow:`` field matches before dispatching. Used by the per-workflow
     direct form (``python3 -m workflows.code_review ...``) to pin the module
-    regardless of what the YAML declares.
+    regardless of what the contract declares.
     """
     contract = load_workflow_contract(workflow_root)
     config_path = contract.source_path

--- a/daedalus/workflows/code_review/__init__.py
+++ b/daedalus/workflows/code_review/__init__.py
@@ -8,7 +8,7 @@ This package satisfies the daedalus workflow-plugin contract:
 
 - NAME: the canonical hyphenated workflow name ("code-review")
 - SUPPORTED_SCHEMA_VERSIONS: tuple of config schema versions this module accepts
-- CONFIG_SCHEMA_PATH: Path to the JSON Schema validating the workflow.yaml config
+- CONFIG_SCHEMA_PATH: Path to the JSON Schema validating the workflow contract
 - make_workspace(*, workflow_root, config): factory returning the workspace accessor
 - cli_main(workspace, argv): argparse-backed CLI dispatcher
 """

--- a/daedalus/workflows/code_review/dispatch.py
+++ b/daedalus/workflows/code_review/dispatch.py
@@ -83,9 +83,9 @@ def resolve_inline_prompt_template(
 ) -> str | None:
     """Return an inline prompt override from ``workspace.config.prompts``.
 
-    Explicit file paths still win. Inline prompts are the bridge used by the
-    ``WORKFLOW.md`` compatibility loader, which injects the Markdown body into
-    ``prompts.<role>``.
+    Explicit file paths still win. Inline prompts remain available for role-
+    specific overrides, but the shared ``WORKFLOW.md`` body now flows through
+    ``workflow-policy`` instead.
     """
     if agent_cfg.get("prompt"):
         return None
@@ -100,6 +100,32 @@ def resolve_inline_prompt_template(
             f"workspace.config.prompts[{role!r}] must be a string"
         )
     return template
+
+
+def resolve_workflow_policy(*, workspace) -> str | None:
+    policy = (workspace.config or {}).get("workflow-policy")
+    if policy is None:
+        return None
+    if not isinstance(policy, str):
+        raise DispatchConfigError("workspace.config['workflow-policy'] must be a string")
+    return policy
+
+
+def _compose_with_workflow_policy(prompt_text: str, workflow_policy: str | None) -> str:
+    policy = str(workflow_policy or "").strip()
+    if not policy:
+        return prompt_text
+    return "\n".join(
+        [
+            "# Shared Workflow Policy",
+            "",
+            policy,
+            "",
+            "# Role-Specific Instructions",
+            "",
+            prompt_text.lstrip(),
+        ]
+    )
 
 
 def _materialize_prompt(*, worktree: Path, role: str, tier: str | None, rendered_text: str) -> Path:
@@ -182,6 +208,10 @@ def dispatch_agent(
             workspace=workspace, role=role, agent_cfg=cfg,
         )
         template_text = template_path.read_text(encoding="utf-8")
+    template_text = _compose_with_workflow_policy(
+        template_text,
+        resolve_workflow_policy(workspace=workspace),
+    )
     rendered_text = template_text.format(**(prompt_kwargs or {}))
 
     command = _resolve_command(agent_cfg=cfg, runtime_cfg=runtime_cfg)

--- a/daedalus/workflows/code_review/lane_selection.py
+++ b/daedalus/workflows/code_review/lane_selection.py
@@ -1,8 +1,8 @@
 """Lane-selection config parser.
 
 Synthesizes a fully-populated config dict from the (optional) ``lane-selection:``
-block in workflow.yaml. Defaults preserve current behavior exactly so workspaces
-without the block see no change in promotion semantics.
+block in the workflow contract. Defaults preserve current behavior exactly so
+workspaces without the block see no change in promotion semantics.
 """
 from __future__ import annotations
 

--- a/daedalus/workflows/code_review/observability.py
+++ b/daedalus/workflows/code_review/observability.py
@@ -4,11 +4,11 @@ Resolution precedence (highest first):
 
 1. Override file at ``<override_dir>/observability-overrides.json`` (per-workflow,
    set by the operator via the ``/daedalus set-observability`` slash command).
-2. ``observability:`` block in ``workflow.yaml``.
+2. ``observability:`` block in the workflow contract (normally ``WORKFLOW.md``).
 3. Hardcoded defaults (everything off).
 
 The override file is canonical for "right now this workflow's observability is X"
-without forcing an edit-and-redeploy cycle on workflow.yaml.
+without forcing an edit-and-redeploy cycle on the workflow contract.
 """
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ OVERRIDE_FILENAME = "observability-overrides.json"
 
 # The default include-events whitelist matches design spec §5 — these are the
 # six lifecycle transitions that are interesting to a human reader of the
-# ticket. An empty list (explicitly set in workflow.yaml or override) means
+# ticket. An empty list (explicitly set in the workflow contract or override) means
 # "firehose, render every audit action" — useful for debugging only.
 _DEFAULT_INCLUDE_EVENTS = [
     "dispatch-implementation-turn",

--- a/daedalus/workflows/code_review/paths.py
+++ b/daedalus/workflows/code_review/paths.py
@@ -190,9 +190,9 @@ def workflow_cli_argv(workflow_root: Path, *command_args: str) -> list[str]:
 def _find_workflow_root(start: Path) -> Path | None:
     path = start.expanduser().resolve()
     for candidate in (path, *path.parents):
-        if workflow_config_path(candidate).exists():
-            return candidate
         if workflow_markdown_path(candidate).exists() and _is_discoverable_markdown_workflow_root(candidate):
+            return candidate
+        if workflow_config_path(candidate).exists():
             return candidate
     return None
 
@@ -218,8 +218,8 @@ def resolve_default_workflow_root(
 
     plugin_dir = plugin_root_path(plugin_dir=plugin_dir)
     repo_parent = plugin_dir.parent.resolve()
-    if workflow_config_path(repo_parent).exists():
-        return repo_parent
     if workflow_markdown_path(repo_parent).exists() and _is_discoverable_markdown_workflow_root(repo_parent):
+        return repo_parent
+    if workflow_config_path(repo_parent).exists():
         return repo_parent
     return cwd_path

--- a/daedalus/workflows/code_review/paths.py
+++ b/daedalus/workflows/code_review/paths.py
@@ -15,6 +15,7 @@ from workflows.contract import (
 )
 
 DEFAULT_WORKFLOW_ROOT_ENV_VARS = ("DAEDALUS_WORKFLOW_ROOT",)
+REPO_LOCAL_WORKFLOW_POINTER_RELATIVE_PATH = Path(".hermes") / "daedalus" / "workflow-root"
 
 _PROJECT_KEY_CHARS_RE = re.compile(r"[^a-z0-9._-]+")
 _PROJECT_KEY_SEPARATORS_RE = re.compile(r"[-._]{2,}")
@@ -53,6 +54,10 @@ def workflow_config_path(workflow_root: Path) -> Path:
 
 def workflow_markdown_path(workflow_root: Path) -> Path:
     return _workflow_markdown_path(workflow_root)
+
+
+def repo_local_workflow_pointer_path(repo_root: Path) -> Path:
+    return repo_root.resolve() / REPO_LOCAL_WORKFLOW_POINTER_RELATIVE_PATH
 
 
 def workflow_contract_path(workflow_root: Path) -> Path:
@@ -194,6 +199,20 @@ def _find_workflow_root(start: Path) -> Path | None:
             return candidate
         if workflow_config_path(candidate).exists():
             return candidate
+        pointer_path = repo_local_workflow_pointer_path(candidate)
+        if pointer_path.exists():
+            try:
+                pointer_value = pointer_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                pointer_value = ""
+            if pointer_value:
+                target = Path(pointer_value).expanduser()
+                if not target.is_absolute():
+                    target = (candidate / target).resolve()
+                else:
+                    target = target.resolve()
+                if find_workflow_contract_path(target) is not None:
+                    return target
     return None
 
 

--- a/daedalus/workflows/code_review/prompts.py
+++ b/daedalus/workflows/code_review/prompts.py
@@ -11,6 +11,25 @@ def _load_template(name: str) -> str:
     return (_PROMPT_BUNDLE / f"{name}.md").read_text(encoding="utf-8")
 
 
+def apply_workflow_policy(prompt_text: str, workflow_policy: str | None) -> str:
+    """Prefix shared workflow policy ahead of role-specific instructions."""
+    policy = str(workflow_policy or "").strip()
+    if not policy:
+        return prompt_text
+    body = prompt_text.lstrip()
+    return "\n".join(
+        [
+            "# Shared Workflow Policy",
+            "",
+            policy,
+            "",
+            "# Role-Specific Instructions",
+            "",
+            body,
+        ]
+    )
+
+
 """Workflow prompt rendering helpers.
 
 This slice extracts deterministic prompt construction from the legacy wrapper so
@@ -92,6 +111,7 @@ def render_implementation_dispatch_prompt(
     open_pr: dict[str, Any] | None,
     action: str,
     workflow_state: str | None,
+    workflow_policy: str | None = None,
 ) -> str:
     issue_body = (issue_details or {}).get("body") or "No issue body provided. Use the title plus existing repo context honestly."
     compact_turn = action in {"continue-session", "poke-session"}
@@ -137,7 +157,7 @@ def render_implementation_dispatch_prompt(
             issue_body.strip() or "No issue body provided.",
         ])
 
-    return _load_template("coder").format(
+    prompt_text = _load_template("coder").format(
         issue_number=issue.get("number"),
         issue_title=issue.get("title"),
         issue_url=issue.get("url"),
@@ -148,6 +168,7 @@ def render_implementation_dispatch_prompt(
         action_and_workflow_block=action_and_workflow_block,
         compact_or_issue_block=compact_or_issue_block,
     )
+    return apply_workflow_policy(prompt_text, workflow_policy)
 
 
 def render_external_reviewer_repair_handoff_prompt(
@@ -159,13 +180,14 @@ def render_external_reviewer_repair_handoff_prompt(
     lane_state_path: Path | None,
     pr_url: str | None,
     external_reviewer_agent_name: str,
+    workflow_policy: str | None = None,
 ) -> str:
     review = external_review or {}
     must_fix = [item.get("summary", "") for item in (repair_brief or {}).get("mustFix", []) if item.get("summary")][:8]
     should_fix = [item.get("summary", "") for item in (repair_brief or {}).get("shouldFix", []) if item.get("summary")][:8]
     must_fix_lines = "\n".join([f"- {item}" for item in must_fix] or ["- none recorded"])
     should_fix_lines = "\n".join([f"- {item}" for item in should_fix] or ["- none recorded"])
-    return _load_template("external-reviewer-repair-handoff").format(
+    prompt_text = _load_template("external-reviewer-repair-handoff").format(
         external_reviewer_agent_name=external_reviewer_agent_name,
         issue_number=(issue or {}).get("number"),
         issue_title=(issue or {}).get("title"),
@@ -177,6 +199,7 @@ def render_external_reviewer_repair_handoff_prompt(
         must_fix_lines=must_fix_lines,
         should_fix_lines=should_fix_lines,
     )
+    return apply_workflow_policy(prompt_text, workflow_policy)
 
 
 def render_claude_repair_handoff_prompt(
@@ -187,13 +210,14 @@ def render_claude_repair_handoff_prompt(
     lane_memo_path: Path | None,
     lane_state_path: Path | None,
     internal_reviewer_agent_name: str,
+    workflow_policy: str | None = None,
 ) -> str:
     review = internal_review or {}
     must_fix = [item.get("summary", "") for item in (repair_brief or {}).get("mustFix", []) if item.get("summary")][:8]
     should_fix = [item.get("summary", "") for item in (repair_brief or {}).get("shouldFix", []) if item.get("summary")][:8]
     must_fix_lines = "\n".join([f"- {item}" for item in must_fix] or ["- none recorded"])
     should_fix_lines = "\n".join([f"- {item}" for item in should_fix] or ["- none recorded"])
-    return _load_template("repair-handoff").format(
+    prompt_text = _load_template("repair-handoff").format(
         internal_reviewer_agent_name=internal_reviewer_agent_name,
         issue_number=(issue or {}).get("number"),
         issue_title=(issue or {}).get("title"),
@@ -204,6 +228,7 @@ def render_claude_repair_handoff_prompt(
         must_fix_lines=must_fix_lines,
         should_fix_lines=should_fix_lines,
     )
+    return apply_workflow_policy(prompt_text, workflow_policy)
 
 
 def render_inter_review_agent_prompt(
@@ -213,8 +238,9 @@ def render_inter_review_agent_prompt(
     lane_memo_path: Path | None,
     lane_state_path: Path | None,
     head_sha: str,
+    workflow_policy: str | None = None,
 ) -> str:
-    return _load_template("internal-reviewer").format(
+    prompt_text = _load_template("internal-reviewer").format(
         worktree=worktree,
         head_sha=head_sha,
         issue_number=issue.get("number"),
@@ -223,3 +249,4 @@ def render_inter_review_agent_prompt(
         lane_memo_line=f"Lane memo: {lane_memo_path}" if lane_memo_path else "Lane memo: none",
         lane_state_line=f"Lane state: {lane_state_path}" if lane_state_path else "Lane state: none",
     )
+    return apply_workflow_policy(prompt_text, workflow_policy)

--- a/daedalus/workflows/code_review/runtimes/acpx_codex.py
+++ b/daedalus/workflows/code_review/runtimes/acpx_codex.py
@@ -159,7 +159,7 @@ class AcpxCodexRuntime:
     ) -> str:
         """Execute a fully-formed argv against this runtime's working dir.
 
-        Used when an agent role supplies a `command:` override in workflow.yaml.
+        Used when an agent role supplies a `command:` override in the workflow contract.
         Session plumbing (ensure/close) is the caller's responsibility.
         """
         completed = self._run(command_argv, cwd=worktree)

--- a/daedalus/workflows/code_review/workflow.template.md
+++ b/daedalus/workflows/code_review/workflow.template.md
@@ -1,14 +1,4 @@
-# Public docs copy.
-# Canonical installable source:
-#   daedalus/workflows/code_review/workflow.template.yaml
-
-# Public baseline for the bundled `code-review` workflow.
-#
-# Copy this file to:
-#   ~/.hermes/workflows/<owner>-<repo>-<workflow-type>/config/workflow.yaml
-#
-# All relative paths below are resolved from <workflow-root>.
-
+---
 workflow: code-review
 schema-version: 1
 
@@ -22,8 +12,6 @@ repository:
   active-lane-label: active-lane
 
 runtimes:
-  # These runtime kinds are host prerequisites. Change them if your
-  # environment uses a different adapter mix.
   coder-runtime:
     kind: acpx-codex
     session-idle-freshness-seconds: 900
@@ -77,7 +65,6 @@ storage:
   health: memory/workflow-health.json
   audit-log: memory/workflow-audit.jsonl
 
-# Optional operator-facing blocks.
 lane-selection:
   exclude-labels:
     - blocked
@@ -86,22 +73,22 @@ lane-selection:
 observability:
   github-comments:
     enabled: false
+---
 
-# Optional HTTP status surface.
-# server:
-#   port: 8765
-#   bind: 127.0.0.1
+# Workflow Policy
 
-# Optional outbound notifications.
-# webhooks:
-#   - name: ops-webhook
-#     kind: http-json
-#     enabled: true
-#     url: https://example.com/daedalus
-#     events:
-#       - daedalus.turn_completed
-#       - daedalus.operator_attention_transition
-#     headers:
-#       Authorization: Bearer replace-me
-#     timeout-seconds: 5
-#     retry-count: 1
+Daedalus runs the `code-review` workflow for the repository configured above.
+
+Shared rules:
+
+- Keep scope narrow to the active issue and current lane state.
+- Prefer small, reviewable diffs over speculative refactors.
+- Run focused validation and report it honestly.
+- Stop and surface blockers instead of guessing.
+- Do not publish generated artifacts or unrelated files.
+
+Role intent:
+
+- `coder`: implement the next correct change and leave a clean handoff.
+- `internal-reviewer`: review correctness, regressions, and test honesty before publish.
+- `external-reviewer`: provide an optional second-pass review when enabled.

--- a/daedalus/workflows/code_review/workspace.py
+++ b/daedalus/workflows/code_review/workspace.py
@@ -15,7 +15,7 @@ from workflows.code_review.runtimes import build_runtimes
 
 
 def _derive_lane_selection_cfg(yaml_cfg, *, active_lane_label):
-    """Synthesize the parsed lane-selection config from raw workflow.yaml.
+    """Synthesize the parsed lane-selection config from the raw workflow config.
 
     Lazy-import to avoid a circular-import at module load (workspace is the
     central bootstrap site).
@@ -35,7 +35,7 @@ def _derive_lane_selection_cfg(yaml_cfg, *, active_lane_label):
 
 
 def _yaml_to_legacy_view(yaml_cfg: dict, workspace_root: "Path | None" = None) -> dict:
-    """Project workflow.yaml onto the internal workspace config shape.
+    """Project workflow config onto the internal workspace config shape.
 
     workspace_root must be supplied so that relative storage paths (e.g.
     ``memory/workflow-status.json``) are anchored to the workflow root dir
@@ -437,7 +437,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
 
     workspace_root = Path(workspace_root).resolve()
 
-    # Detect workflow.yaml shape (top-level `workflow:` + `runtimes:` +
+    # Detect workflow-contract shape (top-level `workflow:` + `runtimes:` +
     # `agents:`) and project it onto the internal config view the existing
     # implementation body still consumes.
     if "workflow" in config and "runtimes" in config and "agents" in config:
@@ -445,6 +445,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         config = _yaml_to_legacy_view(config, workspace_root=workspace_root)
     else:
         yaml_cfg = None
+    workflow_policy = str((yaml_cfg or {}).get("workflow-policy") or "").strip()
 
     # -- paths -----------------------------------------------------------
     repo_path = Path(config["repoPath"])
@@ -619,7 +620,8 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         # --- workspace globals ---
         WORKSPACE=workspace_root,
         CONFIG=config,
-        DEFAULT_CONFIG_PATH=workspace_root / DEFAULT_YAML_CONFIG_FILENAME,
+        WORKFLOW_POLICY=workflow_policy,
+        DEFAULT_CONFIG_PATH=workspace_root / DEFAULT_WORKFLOW_MARKDOWN_FILENAME,
         SESSIONS_STATE_PATH=sessions_state_path,
         REPO_PATH=repo_path,
         REPO_SLUG=_repo_slug,
@@ -1324,26 +1326,14 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _render_inter_review_agent_prompt(*, issue, worktree, lane_memo_path, lane_state_path, head_sha):
-        lines = [
-            'You are reviewing the unpublished local lane head as a strict pre-publish code review gate.',
-            f'Repository: {worktree}',
-            f'Target local head SHA: {head_sha}',
-            'Scope: local-prepublish only. Review the actual current local HEAD in this worktree.',
-            f'Issue: #{issue.get("number")} {issue.get("title")}',
-            f'Issue URL: {issue.get("url")}',
-            f'Lane memo: {lane_memo_path}' if lane_memo_path else 'Lane memo: none',
-            f'Lane state: {lane_state_path}' if lane_state_path else 'Lane state: none',
-            'Read the lane memo/state if present before reviewing.',
-            'Focus on correctness, regressions, test honesty, and whether the code is actually ready to publish.',
-            'Return JSON only, no markdown fences, with this exact schema:',
-            '{"verdict":"PASS_CLEAN"|"PASS_WITH_FINDINGS"|"REWORK","summary":"short paragraph","blockingFindings":["..."],"majorConcerns":["..."],"minorSuggestions":["..."],"requiredNextAction":"string or null"}',
-            'Rules:',
-            '- Use REWORK only for blocking issues that must be fixed before publish.',
-            '- Use PASS_WITH_FINDINGS for non-blocking but real concerns worth recording.',
-            '- Use PASS_CLEAN only if you genuinely found nothing worth recording.',
-            '- Be concise and tie findings to the actual current local diff/head.',
-        ]
-        return '\n'.join(lines)
+        return ns._load_adapter_prompts_module().render_inter_review_agent_prompt(
+            issue=issue,
+            worktree=worktree,
+            lane_memo_path=lane_memo_path,
+            lane_state_path=lane_state_path,
+            head_sha=head_sha,
+            workflow_policy=ns.WORKFLOW_POLICY,
+        )
 
     def _run_inter_review_agent_review(*, issue, worktree, lane_memo_path, lane_state_path, head_sha):
         adapter_reviews = ns._load_adapter_reviews_module()
@@ -1388,6 +1378,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             open_pr=open_pr,
             action=action,
             workflow_state=workflow_state,
+            workflow_policy=ns.WORKFLOW_POLICY,
         )
 
     def _normalize_implementation_for_active_lane(implementation, *, active_lane, open_pr):
@@ -1610,6 +1601,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             lane_state_path=lane_state_path,
             pr_url=pr_url,
             external_reviewer_agent_name=ns.EXTERNAL_REVIEWER_AGENT_NAME,
+            workflow_policy=ns.WORKFLOW_POLICY,
         )
 
     def build_claude_repair_handoff_payload(*, session_action, issue, internal_review, repair_brief, lane_memo_path, lane_state_path, now_iso):
@@ -1640,6 +1632,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             lane_memo_path=lane_memo_path,
             lane_state_path=lane_state_path,
             internal_reviewer_agent_name=ns.INTERNAL_REVIEWER_AGENT_NAME,
+            workflow_policy=ns.WORKFLOW_POLICY,
         )
 
     def _classify_lane_failure(*, implementation, reviews, preflight):

--- a/daedalus/workflows/contract.py
+++ b/daedalus/workflows/contract.py
@@ -1,15 +1,13 @@
 """Workflow contract loading for Daedalus.
 
-Daedalus currently supports two workflow-contract entrypoints:
+Daedalus supports two workflow-contract entrypoints:
 
-- ``config/workflow.yaml``: the native Daedalus instance config
-- ``WORKFLOW.md``: a Symphony-style Markdown contract with YAML front matter
+- ``WORKFLOW.md``: the native public contract
+- ``config/workflow.yaml``: a legacy load-only input
 
-The Markdown form is a compatibility/front-door layer. It does not yet map the
-entire Symphony front matter directly into Daedalus runtime settings; instead,
-it expects a ``daedalus.workflow-config`` mapping containing the native
-Daedalus config and optionally injects the Markdown body into
-``prompts.<role>``.
+Both ultimately feed the same internal config object. ``WORKFLOW.md`` uses YAML
+front matter for the structured config and its Markdown body as the shared
+workflow policy text.
 """
 from __future__ import annotations
 
@@ -22,6 +20,7 @@ import yaml
 
 DEFAULT_WORKFLOW_CONFIG_FILENAME = "config/workflow.yaml"
 DEFAULT_WORKFLOW_MARKDOWN_FILENAME = "WORKFLOW.md"
+WORKFLOW_POLICY_KEY = "workflow-policy"
 
 
 class WorkflowContractError(RuntimeError):
@@ -49,15 +48,15 @@ def workflow_markdown_path(workflow_root: Path) -> Path:
 def find_workflow_contract_path(workflow_root: Path) -> Path | None:
     """Return the preferred contract path for a workflow root, if any.
 
-    ``config/workflow.yaml`` remains the first choice so existing instances do
-    not change behavior if both files are present.
+    ``WORKFLOW.md`` is the native public contract and wins when both forms are
+    present. ``config/workflow.yaml`` remains loadable for legacy instances.
     """
-    yaml_path = workflow_yaml_path(workflow_root)
-    if yaml_path.exists():
-        return yaml_path
     markdown_path = workflow_markdown_path(workflow_root)
     if markdown_path.exists():
         return markdown_path
+    yaml_path = workflow_yaml_path(workflow_root)
+    if yaml_path.exists():
+        return yaml_path
     return None
 
 
@@ -96,7 +95,9 @@ def _load_yaml_contract(path: Path) -> WorkflowContract:
     return WorkflowContract(
         source_path=path,
         config=payload,
-        prompt_template="",
+        prompt_template=str(payload.get(WORKFLOW_POLICY_KEY) or "").strip()
+        if isinstance(payload.get(WORKFLOW_POLICY_KEY), str)
+        else "",
         front_matter={},
     )
 
@@ -156,31 +157,40 @@ def _project_markdown_front_matter(
     front_matter: dict[str, Any],
     prompt_template: str,
 ) -> dict[str, Any]:
-    extension = front_matter.get("daedalus") or {}
-    if not isinstance(extension, dict):
-        raise WorkflowContractError(f"{path} must define daedalus: as a mapping")
-
-    raw_config = extension.get("workflow-config")
-    if raw_config is None:
+    config = deepcopy(front_matter)
+    existing_policy = config.get(WORKFLOW_POLICY_KEY)
+    if existing_policy is not None and not isinstance(existing_policy, str):
+        raise WorkflowContractError(f"{path} {WORKFLOW_POLICY_KEY} must be a string when present")
+    if existing_policy and prompt_template:
         raise WorkflowContractError(
-            f"{path} must define daedalus.workflow-config to map WORKFLOW.md "
-            "into the current Daedalus workflow schema"
+            f"{path} defines both front-matter {WORKFLOW_POLICY_KEY!r} and a Markdown body; "
+            "use the body as the workflow policy source"
         )
-    if not isinstance(raw_config, dict):
-        raise WorkflowContractError(f"{path} daedalus.workflow-config must be a mapping")
-
-    config = deepcopy(raw_config)
-    prompt_role = extension.get("prompt-role", "coder")
-    if not isinstance(prompt_role, str) or not prompt_role.strip():
-        raise WorkflowContractError(f"{path} daedalus.prompt-role must be a non-empty string")
-
     if prompt_template:
-        prompts = config.get("prompts")
-        if prompts is None:
-            prompts = {}
-            config["prompts"] = prompts
-        if not isinstance(prompts, dict):
-            raise WorkflowContractError(f"{path} prompts must be a mapping when present")
-        prompts[prompt_role.strip()] = prompt_template
-
+        config[WORKFLOW_POLICY_KEY] = prompt_template
     return config
+
+
+def render_workflow_markdown(*, config: dict[str, Any], prompt_template: str | None = None) -> str:
+    """Render a native ``WORKFLOW.md`` file from config + policy text."""
+    front_matter = deepcopy(config)
+    body = prompt_template
+    if body is None:
+        policy = front_matter.pop(WORKFLOW_POLICY_KEY, "")
+        if policy is None:
+            body = ""
+        elif isinstance(policy, str):
+            body = policy
+        else:
+            raise WorkflowContractError(f"{WORKFLOW_POLICY_KEY} must be a string when rendering WORKFLOW.md")
+    else:
+        front_matter.pop(WORKFLOW_POLICY_KEY, None)
+
+    if not isinstance(front_matter, dict):
+        raise WorkflowContractError("workflow config must be a mapping when rendering WORKFLOW.md")
+
+    front_matter_text = yaml.safe_dump(front_matter, sort_keys=False).strip()
+    body_text = str(body or "").strip()
+    if body_text:
+        return f"---\n{front_matter_text}\n---\n\n{body_text}\n"
+    return f"---\n{front_matter_text}\n---\n"

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Entry point for everything that won't fit on the [project landing page](../READM
 
 - **[architecture.md](architecture.md)** — the big picture. What Daedalus is, what it isn't, how the pieces fit together.
 - **[operator/installation.md](operator/installation.md)** — the supported install, scaffold, verify, and supervise flow.
-- **[examples/code-review.workflow.yaml](examples/code-review.workflow.yaml)** — copyable public baseline for `config/workflow.yaml`.
+- **[examples/code-review.workflow.md](examples/code-review.workflow.md)** — copyable public baseline for `WORKFLOW.md`.
 - **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
 - **[symphony-conformance.md](symphony-conformance.md)** — where Daedalus matches the current Symphony draft, and where it still differs.
 - **[security.md](security.md)** — the trust model, shell/network posture, and secret-handling expectations.
@@ -22,7 +22,7 @@ What each abstraction *means* — read these before reading code.
 | [Runtimes](concepts/runtimes.md) | The `claude-cli` / `acpx-codex` / `hermes-agent` adapters. |
 | [Events](concepts/events.md) | The append-only history. Symphony §10.4 taxonomy + `daedalus.*` namespace. |
 | [Stalls](concepts/stalls.md) | `last_activity_ts()` + `stall.timeout_ms` (Symphony §8.5). |
-| [Hot-reload & preflight](concepts/hot-reload.md) | Workflow-contract reload (`workflow.yaml` or `WORKFLOW.md`) + per-tick preflight (Symphony §6.2 + §6.3). |
+| [Hot-reload & preflight](concepts/hot-reload.md) | Workflow-contract reload (`WORKFLOW.md` first, legacy `workflow.yaml` still loadable) + per-tick preflight (Symphony §6.2 + §6.3). |
 | [Shadow → active](concepts/shadow-active.md) | The promotion gate from observation to execution. |
 
 ## Operator surface

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                         EXTERNAL TRIGGERS                                   │
-│   GitHub Issue (#42)    Operator (/daedalus)    workflow.yaml (hot-reload)  │
+│   GitHub Issue (#42)    Operator (/daedalus)    WORKFLOW.md (hot-reload)    │
 └─────────────────────────────────────────────────────────────────────────────┘
          │                       │                       │
          ▼                       ▼                       ▼
@@ -163,7 +163,7 @@ Never reconstruct current state by replaying events. That's what the `lanes` tab
 
 ```mermaid
 flowchart TD
-    A[tick begins] --> B{workflow.yaml changed?}
+    A[tick begins] --> B{workflow contract changed?}
     B -- no --> C[reuse last ConfigSnapshot]
     B -- yes --> D[parse + validate]
     D -- ok --> E[swap AtomicRef]
@@ -174,7 +174,7 @@ flowchart TD
     G --> H
 ```
 
-A bad `workflow.yaml` edit is **ignored**, not fatal. The next valid save picks up automatically.
+A bad `WORKFLOW.md` edit is **ignored**, not fatal. The next valid save picks up automatically.
 
 ### 5. Recovery Is Automatic
 

--- a/docs/assets/daedalus-architecture-diagram.svg
+++ b/docs/assets/daedalus-architecture-diagram.svg
@@ -35,7 +35,7 @@
   <text x="600" y="155" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">/daedalus commands</text>
 
   <rect x="860" y="115" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="930" y="138" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">workflow.yaml</text>
+  <text x="930" y="138" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">WORKFLOW.md</text>
   <text x="930" y="155" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Hot-reload config</text>
 
   <rect x="50" y="200" width="520" height="420" rx="16" fill="rgba(8,51,68,0.08)" stroke="#22d3ee" stroke-width="2" stroke-dasharray="12,6"/>

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -51,7 +51,7 @@ The beating heart of Daedalus. These five concepts explain how the engine keeps 
 | [**Lanes**](./lanes.md) | The unit of work. One GitHub issue becomes one lane, carried from discovery to merge. | ...you want to see the full lifecycle of an automated issue. |
 | [**Actions**](./actions.md) | The atomic unit of work. Queued, idempotent, tracked with composite keys. | ...you want to know how Daedalus guarantees exactly-once execution. |
 | [**Shadow → Active**](./shadow-active.md) | Two execution modes: observe safely, then promote to real side effects. | ...you want to validate Daedalus parity before letting it touch real PRs. |
-| [**Hot-reload**](./hot-reload.md) | Edit `workflow.yaml`, save, next tick picks it up. Bad edits are ignored, not fatal. | ...you want to change policy without restarting the service. |
+| [**Hot-reload**](./hot-reload.md) | Edit `WORKFLOW.md`, save, next tick picks it up. Bad edits are ignored, not fatal. | ...you want to change policy without restarting the service. |
 
 **The narrative arc:** *Leases* give you ownership → *Lanes* give you work → *Actions* give you execution → *Shadow/Active* gives you safety → *Hot-reload* gives you agility.
 

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -120,7 +120,7 @@ See [failures.md](failures.md) for the full failure/retry model. At the action l
 
 - `retry_count` starts at `0`.
 - Each retry attempt increments it.
-- `max_retries` is configured in `workflow.yaml` (default: `3`).
+- `max_retries` is configured in `WORKFLOW.md` (default: `3`).
 - The retry reason is recorded: `stall_timeout`, `runtime_error`, `operator_reset`, etc.
 
 ---

--- a/docs/concepts/comments.md
+++ b/docs/concepts/comments.md
@@ -32,7 +32,7 @@ observability:
 ### Resolution precedence
 
 1. **Override file** (`observability-overrides.json`) — set via `/daedalus set-observability`
-2. **`workflow.yaml`** `observability:` block
+2. **`WORKFLOW.md`** `observability:` block
 3. **Hardcoded defaults** (everything off)
 
 See [observability.md](observability.md) for the full override surface.

--- a/docs/concepts/failures.md
+++ b/docs/concepts/failures.md
@@ -92,7 +92,7 @@ Two hardening fixes during lane 220 work changed how failures interact with the 
 
 ## Retry policy
 
-Retries are governed by `workflow.yaml`:
+Retries are governed by `WORKFLOW.md`:
 
 ```yaml
 retry:

--- a/docs/concepts/hot-reload.md
+++ b/docs/concepts/hot-reload.md
@@ -4,7 +4,7 @@ Symphony §6.2 + §6.3. The two halves of "edits to the workflow contract should
 
 ## §6.2 Hot-reload
 
-The workflow contract (`config/workflow.yaml` or `WORKFLOW.md`) is re-parsed and re-validated on every tick. The new config replaces the old one **only if** parse + validate both succeed. A bad edit keeps the previous good config alive — the next valid save picks up automatically.
+The workflow contract (`WORKFLOW.md` for new instances, `config/workflow.yaml` for legacy ones) is re-parsed and re-validated on every tick. The new config replaces the old one **only if** parse + validate both succeed. A bad edit keeps the previous good config alive — the next valid save picks up automatically.
 
 ```mermaid
 flowchart TD

--- a/docs/concepts/lanes.md
+++ b/docs/concepts/lanes.md
@@ -53,7 +53,7 @@ States with no outgoing arrows in this diagram (other than terminal `merged` / `
 
 ## Lane selection
 
-Not every labeled issue becomes a lane. `lane_selection.py` filters and ranks issues using the `lane-selection:` block in `workflow.yaml`.
+Not every labeled issue becomes a lane. `lane_selection.py` filters and ranks issues using the `lane-selection:` block in the workflow contract (`WORKFLOW.md` for new instances).
 
 ### Config schema
 

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -96,7 +96,7 @@ observability:
 ### Resolution precedence
 
 1. **Override file** (`observability-overrides.json`) — set via `/daedalus set-observability`
-2. **`workflow.yaml`** `observability:` block
+2. **`WORKFLOW.md`** `observability:` block
 3. **Hardcoded defaults** (everything off)
 
 ### Modes

--- a/docs/concepts/operator-attention.md
+++ b/docs/concepts/operator-attention.md
@@ -13,7 +13,7 @@ A lane enters `operator_attention_required` when **either** threshold is crossed
 | **Failure retry budget exhausted** | 5 retries | The same action has failed 5 times without success. |
 | **No-progress tick budget exhausted** | 5 ticks | The lane has ticked 5 times without making any forward progress (new commits, new reviews, new state). |
 
-Both thresholds are configurable in `workflow.yaml`:
+Both thresholds are configurable in `WORKFLOW.md`:
 
 ```yaml
 policy:

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -29,7 +29,7 @@ class Runtime(Protocol):
 | `close_session` | no-op | `acpx codex sessions close` | no-op |
 | Records `last_activity_ts` | yes (before + after `_run`) | yes | yes |
 
-## Selection in `workflow.yaml`
+## Selection in `WORKFLOW.md`
 
 ```yaml
 runtimes:
@@ -56,7 +56,7 @@ The preflight pass walks `runtimes.<name>.kind` and `agents.external-reviewer.ki
 
 ### `hermes-agent` runtime
 
-The `hermes-agent` runtime delegates turns to a local Hermes agent process. It is **one-shot** (no persistent session) and requires a `command:` override in `workflow.yaml` because the exact invocation depends on the agent's entry point.
+The `hermes-agent` runtime delegates turns to a local Hermes agent process. It is **one-shot** (no persistent session) and requires a `command:` override in `WORKFLOW.md` because the exact invocation depends on the agent's entry point.
 
 ```yaml
 runtimes:

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -55,7 +55,7 @@ stateDiagram-v2
 ### `hermes-agent` (one-shot)
 
 - No persistent session.
-- Requires a `command:` override in `workflow.yaml`.
+- Requires a `command:` override in `WORKFLOW.md`.
 - `assess_health` always returns healthy.
 - `last_activity_ts` records subprocess start/end timestamps.
 

--- a/docs/concepts/stalls.md
+++ b/docs/concepts/stalls.md
@@ -7,7 +7,7 @@ Symphony §8.5. A wedged worker that's still holding a lease but producing no si
 A stall is detected from two sides:
 
 1. **Liveness** — `Runtime.last_activity_ts()` returns a monotonic timestamp the runtime *most recently* updated. Each adapter calls `_record_activity()` **before** the blocking `_run()` and again after, so a long invocation isn't classified as idle mid-flight.
-2. **Threshold** — `stall.timeout_ms` in `workflow.yaml` (default 300 000 ms = 5 minutes). Anything older than that is considered stalled.
+2. **Threshold** — `stall.timeout_ms` in `WORKFLOW.md` (default 300 000 ms = 5 minutes). Anything older than that is considered stalled.
 
 If a runtime *doesn't* implement `last_activity_ts`, the reconciler skips it entirely. That's the explicit opt-out — never fall back to `started_at_monotonic`, because every long-running adapter would look stalled forever.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -120,7 +120,7 @@ Every code change that affects operator-facing behavior must update docs:
 | New slash command | `docs/operator/slash-commands.md`, `docs/operator/cheat-sheet.md` |
 | New concept | `docs/concepts/<new-concept>.md`, `docs/architecture.md` |
 | Schema change | `docs/concepts/lanes.md`, `docs/concepts/actions.md` |
-| Config change | `daedalus/workflows/code_review/workflow.template.yaml`, `docs/examples/code-review.workflow.yaml`, `docs/concepts/hot-reload.md`, `docs/operator/cheat-sheet.md` |
+| Config change | `daedalus/workflows/code_review/workflow.template.md`, `docs/examples/code-review.workflow.md`, `docs/concepts/hot-reload.md`, `docs/operator/cheat-sheet.md` |
 | Rename/refactor | All docs + ADR in `docs/adr/` |
 
 ---

--- a/docs/examples/code-review.workflow.md
+++ b/docs/examples/code-review.workflow.md
@@ -1,10 +1,4 @@
-# Public baseline for the bundled `code-review` workflow.
-#
-# Copy this file to:
-#   ~/.hermes/workflows/<owner>-<repo>-<workflow-type>/config/workflow.yaml
-#
-# All relative paths below are resolved from <workflow-root>.
-
+---
 workflow: code-review
 schema-version: 1
 
@@ -18,8 +12,6 @@ repository:
   active-lane-label: active-lane
 
 runtimes:
-  # These runtime kinds are host prerequisites. Change them if your
-  # environment uses a different adapter mix.
   coder-runtime:
     kind: acpx-codex
     session-idle-freshness-seconds: 900
@@ -73,7 +65,6 @@ storage:
   health: memory/workflow-health.json
   audit-log: memory/workflow-audit.jsonl
 
-# Optional operator-facing blocks.
 lane-selection:
   exclude-labels:
     - blocked
@@ -82,22 +73,22 @@ lane-selection:
 observability:
   github-comments:
     enabled: false
+---
 
-# Optional HTTP status surface.
-# server:
-#   port: 8765
-#   bind: 127.0.0.1
+# Workflow Policy
 
-# Optional outbound notifications.
-# webhooks:
-#   - name: ops-webhook
-#     kind: http-json
-#     enabled: true
-#     url: https://example.com/daedalus
-#     events:
-#       - daedalus.turn_completed
-#       - daedalus.operator_attention_transition
-#     headers:
-#       Authorization: Bearer replace-me
-#     timeout-seconds: 5
-#     retry-count: 1
+Daedalus runs the `code-review` workflow for the repository configured above.
+
+Shared rules:
+
+- Keep scope narrow to the active issue and current lane state.
+- Prefer small, reviewable diffs over speculative refactors.
+- Run focused validation and report it honestly.
+- Stop and surface blockers instead of guessing.
+- Do not publish generated artifacts or unrelated files.
+
+Role intent:
+
+- `coder`: implement the next correct change and leave a clean handoff.
+- `internal-reviewer`: review correctness, regressions, and test honesty before publish.
+- `external-reviewer`: provide an optional second-pass review when enabled.

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -365,7 +365,7 @@ python3 ~/.hermes/plugins/daedalus/workflows/__main__.py \
 
 ## Config Hot-Reload
 
-### Check if a bad edit is being ignored
+### Check if a bad WORKFLOW.md edit is being ignored
 ```bash
 /daedalus doctor
 ```
@@ -374,7 +374,7 @@ Look for `config_reload_failed` in the event tail or doctor output.
 ### Force a config re-read
 ```bash
 # Touch the file; the next tick will pick it up.
-touch ~/.hermes/workflows/<profile>/workflow.yaml
+touch ~/.hermes/workflows/<owner>-<repo>-<workflow-type>/WORKFLOW.md
 ```
 
 ### Show effective config (merged layers)

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -4,7 +4,7 @@ Symphony §13.7. Optional localhost HTTP server that exposes lane state, recent 
 
 ## Enable it
 
-Add `server.port` to `workflow.yaml`:
+Add `server.port` to `WORKFLOW.md`:
 
 ```yaml
 server:

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -39,7 +39,29 @@ python3 -m pip install .
 hermes plugins enable daedalus
 ```
 
-## Scaffold a workflow root
+## Bootstrap a workflow root
+
+```bash
+cd /path/to/your/repo
+hermes daedalus bootstrap
+```
+
+This is the preferred path. `bootstrap`:
+
+- detects the git repo root from the current checkout
+- derives `github-slug` from `origin`
+- creates the supported instance layout below
+- writes a starter `WORKFLOW.md`
+- writes `./.hermes/daedalus/workflow-root` in the repo checkout so later
+  Daedalus commands can resolve the workflow root automatically
+
+```text
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>/
+```
+
+## Manual scaffold path
+
+If you want explicit control over the target root or slug:
 
 ```bash
 hermes daedalus scaffold-workflow \
@@ -47,7 +69,7 @@ hermes daedalus scaffold-workflow \
   --github-slug your-org/your-repo
 ```
 
-This creates the supported instance layout:
+That creates the same supported instance layout:
 
 ```text
 ~/.hermes/workflows/<owner>-<repo>-<workflow-type>/
@@ -70,7 +92,26 @@ At minimum, set:
 The YAML front matter is the structured config. The Markdown body below it is
 shared workflow policy that Daedalus prepends to its role-specific prompts.
 
-## Initialize and verify
+## Bring it up
+
+```bash
+hermes daedalus service-up
+```
+
+`service-up` runs the supported post-edit path in one command:
+
+- initialize runtime state
+- validate `WORKFLOW.md` and workflow preflight rules
+- install the user systemd unit
+- enable the unit
+- start the service
+
+Use `--service-mode shadow` if you want read-only parity validation first.
+
+## Manual low-level path
+
+If you want to inspect or script each step separately, the lower-level commands
+remain available:
 
 ```bash
 hermes daedalus init \
@@ -79,11 +120,7 @@ hermes daedalus init \
 hermes daedalus doctor \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --format json
-```
 
-## Supervise it
-
-```bash
 hermes daedalus service-install \
   --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
   --service-mode active
@@ -97,12 +134,9 @@ hermes daedalus service-start \
   --service-mode active
 ```
 
-Use `--service-mode shadow` if you want read-only parity validation first.
-
 ## Operate it from Hermes
 
 ```bash
-export DAEDALUS_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-code-review
 cd /path/to/your/repo
 hermes
 ```

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -8,14 +8,14 @@ This is the supported community install path for the first public release.
 - Hermes with plugin loading enabled
 - `python3` with `yaml` and `jsonschema` available
 - `systemd --user` for supervised active/shadow mode
-- the host CLIs required by the runtimes named in `workflow.yaml`
+- the host CLIs required by the runtimes named in `WORKFLOW.md`
 
 The bundled `code-review` template defaults to:
 
 - `acpx-codex` for the coder runtime
 - `claude-cli` for the internal reviewer runtime
 
-If your host does not have those runtimes, edit `workflow.yaml` before starting the service.
+If your host does not have those runtimes, edit `WORKFLOW.md` before starting the service.
 
 ## Install the plugin
 
@@ -58,7 +58,7 @@ This creates the supported instance layout:
 Edit:
 
 ```text
-~/.hermes/workflows/<owner>-<repo>-<workflow-type>/config/workflow.yaml
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>/WORKFLOW.md
 ```
 
 At minimum, set:
@@ -66,6 +66,9 @@ At minimum, set:
 - `repository.local-path`
 - runtime kinds/models that exist on your host
 - any gates, webhooks, or observability settings your repo needs
+
+The YAML front matter is the structured config. The Markdown body below it is
+shared workflow policy that Daedalus prepends to its role-specific prompts.
 
 ## Initialize and verify
 
@@ -149,4 +152,4 @@ hermes plugins enable daedalus
 
 ## Legacy migration
 
-`scripts/migrate_config.py` is only for migrating older JSON configs into the new `workflow.yaml` shape. It is not the primary onboarding path for new installs.
+`scripts/migrate_config.py` is only for migrating older JSON configs into the new `WORKFLOW.md` shape. It is not the primary onboarding path for new installs.

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -137,7 +137,7 @@ Daedalus service
 | Command | What it does |
 |---|---|
 | `/daedalus init` | Init/migrate the runtime DB (idempotent) |
-| `/daedalus scaffold-workflow` | Create a new workflow root named `<owner>-<repo>-<workflow-type>` with a starter `config/workflow.yaml` |
+| `/daedalus scaffold-workflow` | Create a new workflow root named `<owner>-<repo>-<workflow-type>` with a starter `WORKFLOW.md` |
 | `/daedalus ingest-live` | Pull workflow CLI status into the ledger |
 | `/daedalus heartbeat` | Refresh the runtime lease |
 | `/daedalus request-active-actions` | Inspect what *would* be dispatched on the next tick |

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -137,6 +137,7 @@ Daedalus service
 | Command | What it does |
 |---|---|
 | `/daedalus init` | Init/migrate the runtime DB (idempotent) |
+| `/daedalus bootstrap` | Infer repo root + GitHub slug from the current checkout, create a starter workflow root, and persist a repo-local workflow pointer |
 | `/daedalus scaffold-workflow` | Create a new workflow root named `<owner>-<repo>-<workflow-type>` with a starter `WORKFLOW.md` |
 | `/daedalus ingest-live` | Pull workflow CLI status into the ledger |
 | `/daedalus heartbeat` | Refresh the runtime lease |
@@ -148,7 +149,8 @@ Daedalus service
 
 | Command | What it does |
 |---|---|
-| `/daedalus service-install` | Install + enable the user unit |
+| `/daedalus service-up` | Validate `WORKFLOW.md`, then install, enable, and start the user unit |
+| `/daedalus service-install` | Install the user unit only |
 | `/daedalus service-uninstall` | Stop + remove the user unit |
 | `/daedalus service-start` | Start `daedalus-active@<workspace>.service` |
 | `/daedalus service-stop` | Stop the service |

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -10,12 +10,15 @@ These are the surfaces we should treat as `v1` public contract:
 - legacy `config/workflow.yaml` loading for existing instances
 - `hermes plugins install attmous/daedalus --enable`
 - the `hermes_agent.plugins` entry point name `daedalus`
+- `hermes daedalus bootstrap`
 - `hermes daedalus scaffold-workflow`
+- `hermes daedalus service-up`
 - `hermes daedalus init`
 - `hermes daedalus service-*`
 - `/daedalus ...` operator commands
 - `/workflow <name> ...` workflow commands
 - the workflow root naming convention: `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
+- the repo-local workflow pointer written by `bootstrap`: `./.hermes/daedalus/workflow-root`
 
 Changes to those surfaces should be documented, tested, and treated as compatibility-sensitive.
 

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -6,8 +6,8 @@ This document defines the stability boundary for the first public Daedalus relea
 
 These are the surfaces we should treat as `v1` public contract:
 
-- `config/workflow.yaml` for workflow instance configuration
-- `WORKFLOW.md` compatibility loading for `workflow: code-review`, using `daedalus.workflow-config`
+- `WORKFLOW.md` at the workflow root for workflow instance configuration
+- legacy `config/workflow.yaml` loading for existing instances
 - `hermes plugins install attmous/daedalus --enable`
 - the `hermes_agent.plugins` entry point name `daedalus`
 - `hermes daedalus scaffold-workflow`
@@ -41,9 +41,8 @@ Additional workflow types should not be advertised as public contract until they
 
 ## Contract preference
 
-The preferred public path is still `config/workflow.yaml`, because it is what
-the scaffold command generates and what the operator docs teach first.
+The preferred and scaffolded public path is `WORKFLOW.md`.
 
-`WORKFLOW.md` support exists to improve Symphony compatibility, but it is
-currently a compatibility layer over the native schema, not a replacement for
-the scaffolded YAML path.
+`config/workflow.yaml` remains loadable for legacy workflow roots, but new
+docs, templates, and operators should treat it as migration input rather than
+the primary contract.

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,7 +24,7 @@ Daedalus is built for a **trusted local operator** running on a **trusted host**
 ## Secrets and Logging
 
 - Keep secrets in environment variables, host credential stores, or runtime-specific auth surfaces.
-- Do not commit secrets into `workflow.yaml`, `WORKFLOW.md`, prompts, or hook scripts.
+- Do not commit secrets into `WORKFLOW.md`, legacy `workflow.yaml`, prompts, or hook scripts.
 - Daedalus writes structured status/events/audit data for observability. It does not guarantee universal secret redaction across operator-configured prompts, hook output, or third-party runtime stderr/stdout.
 
 ## Safe Deployment Guidance

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -8,13 +8,13 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 
 - Daedalus is a long-running workflow orchestrator with durable state, hot reload, isolated lane worktrees, recovery, and operator observability.
 - Daedalus is still **GitHub-first**. The current Symphony draft is still **Linear-first**.
-- Daedalus now accepts a Symphony-style `WORKFLOW.md`, but it is a compatibility layer over the native `code-review` schema, not a full native Symphony front matter implementation.
+- Daedalus now uses a Symphony-style `WORKFLOW.md` as the native public contract for the bundled workflow, but it remains GitHub-first and not fully spec-conformant.
 
 ## Status Matrix
 
 | Symphony concept | Daedalus status | Notes |
 |---|---|---|
-| `WORKFLOW.md` loader | Partial | Supported at the workflow root. `WORKFLOW.md` must provide `daedalus.workflow-config`, and the Markdown body is injected into `prompts.<role>`. |
+| `WORKFLOW.md` loader | Partial | Supported at the workflow root as the public contract. Front matter maps directly to the current `code-review` schema, and the Markdown body becomes shared workflow policy. |
 | Typed config + hot reload | Implemented | Current `code-review` schema is validated and hot-reloaded with last-known-good behavior. |
 | Issue tracker client boundary | Partial | GitHub issue selection exists, but there is no generic tracker protocol or Linear adapter yet. |
 | Workspace manager | Partial | Per-lane worktrees and lane-local files exist; generic lifecycle hooks are not first-class yet. |
@@ -29,9 +29,9 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 
 Daedalus currently differs from the Symphony draft in three material ways:
 
-1. The primary public workflow contract is still `config/workflow.yaml`.
-2. The first workflow is GitHub-backed `code-review`, not a Linear-backed generic scheduler.
-3. Runtime adapters are CLI-oriented today, not Codex app-server-native.
+1. The first workflow is GitHub-backed `code-review`, not a Linear-backed generic scheduler.
+2. Runtime adapters are CLI-oriented today, not Codex app-server-native.
+3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
 
 ## Recommended Next Gaps
 

--- a/tests/test_config_watcher.py
+++ b/tests/test_config_watcher.py
@@ -51,12 +51,7 @@ _VALID_YAML = textwrap.dedent("""\
 
 
 def _valid_workflow_markdown() -> str:
-    front_matter = textwrap.dedent(f"""\
-        daedalus:
-          prompt-role: coder
-          workflow-config:
-{textwrap.indent(_VALID_YAML, '            ')}
-    """)
+    front_matter = _VALID_YAML
     return f"---\n{front_matter}---\n\nYou are the workflow prompt.\n"
 
 
@@ -79,7 +74,7 @@ def test_parse_and_validate_accepts_workflow_markdown(tmp_path):
     snap = parse_and_validate(p)
 
     assert snap.config["workflow"] == "code-review"
-    assert snap.prompts["coder"] == "You are the workflow prompt."
+    assert snap.config["workflow-policy"] == "You are the workflow prompt."
 
 
 def test_parse_and_validate_raises_on_yaml_syntax_error(tmp_path):

--- a/tests/test_docs_public_workflow_template.py
+++ b/tests/test_docs_public_workflow_template.py
@@ -3,17 +3,19 @@ from pathlib import Path
 import jsonschema
 import yaml
 
+from workflows.contract import WORKFLOW_POLICY_KEY, load_workflow_contract_file
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-TEMPLATE_PATH = REPO_ROOT / "docs" / "examples" / "code-review.workflow.yaml"
+TEMPLATE_PATH = REPO_ROOT / "docs" / "examples" / "code-review.workflow.md"
 PAYLOAD_TEMPLATE_PATH = (
-    REPO_ROOT / "daedalus" / "workflows" / "code_review" / "workflow.template.yaml"
+    REPO_ROOT / "daedalus" / "workflows" / "code_review" / "workflow.template.md"
 )
 SCHEMA_PATH = REPO_ROOT / "daedalus" / "workflows" / "code_review" / "schema.yaml"
 
 
 def test_public_workflow_template_validates_against_schema():
-    template = yaml.safe_load(TEMPLATE_PATH.read_text(encoding="utf-8"))
+    template = load_workflow_contract_file(TEMPLATE_PATH).config
     schema = yaml.safe_load(SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(template, schema)
 
@@ -22,11 +24,15 @@ def test_public_workflow_template_uses_generic_placeholders():
     text = TEMPLATE_PATH.read_text(encoding="utf-8").lower()
     assert "yoyopod" not in text
     assert "your-org-your-repo-code-review" in text
+    assert "# workflow policy" in text
+
+
+def test_public_workflow_template_uses_markdown_body_for_shared_policy():
+    contract = load_workflow_contract_file(TEMPLATE_PATH)
+
+    assert contract.config[WORKFLOW_POLICY_KEY]
+    assert "keep scope narrow" in contract.config[WORKFLOW_POLICY_KEY].lower()
 
 
 def test_payload_workflow_template_matches_docs_copy():
-    assert PAYLOAD_TEMPLATE_PATH.read_text(encoding="utf-8") == TEMPLATE_PATH.read_text(encoding="utf-8").replace(
-        "# Public docs copy.\n# Canonical installable source:\n#   daedalus/workflows/code_review/workflow.template.yaml\n\n",
-        "",
-        1,
-    )
+    assert PAYLOAD_TEMPLATE_PATH.read_text(encoding="utf-8") == TEMPLATE_PATH.read_text(encoding="utf-8")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -25,7 +25,7 @@ def test_install_into_default_hermes_home_copies_plugin_tree(tmp_path):
     assert (plugin_dir / "runtime.py").exists()
     assert (plugin_dir / "alerts.py").exists()
     assert (plugin_dir / "workflows" / "code_review" / "status.py").exists()
-    assert (plugin_dir / "workflows" / "code_review" / "workflow.template.yaml").exists()
+    assert (plugin_dir / "workflows" / "code_review" / "workflow.template.md").exists()
     assert list((plugin_dir / "projects").glob("*/config/project.json"))
     assert (plugin_dir / "skills" / "operator" / "SKILL.md").exists()
 

--- a/tests/test_official_plugin_layout.py
+++ b/tests/test_official_plugin_layout.py
@@ -74,7 +74,7 @@ def test_repo_root_tools_wrapper_dispatches_scaffold(tmp_path):
     )
 
     assert "daedalus error:" not in out, out
-    assert (workflow_root / "config" / "workflow.yaml").exists()
+    assert (workflow_root / "WORKFLOW.md").exists()
 
 
 def test_repo_root_workflows_wrapper_exposes_code_review_submodules():

--- a/tests/test_pip_plugin_packaging.py
+++ b/tests/test_pip_plugin_packaging.py
@@ -78,7 +78,7 @@ def test_wheel_contains_runtime_loaded_plugin_payload(tmp_path):
         "daedalus/plugin.yaml",
         "daedalus/skills/operator/SKILL.md",
         "daedalus/workflows/code_review/schema.yaml",
-        "daedalus/workflows/code_review/workflow.template.yaml",
+        "daedalus/workflows/code_review/workflow.template.md",
         "daedalus/workflows/code_review/prompts/coder.md",
         "daedalus/projects/yoyopod_core/config/project.json",
     }
@@ -124,4 +124,4 @@ def test_wheel_extracts_to_working_plugin_package(tmp_path):
         f"scaffold-workflow --workflow-root {workflow_root} --github-slug attmous/daedalus"
     )
     assert "daedalus error:" not in out, out
-    assert (workflow_root / "config" / "workflow.yaml").exists()
+    assert (workflow_root / "WORKFLOW.md").exists()

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -81,6 +81,7 @@ def test_readme_quickstart_mentions_supported_public_path():
     assert "hermes plugins install attmous/daedalus --enable" in readme
     assert "hermes daedalus scaffold-workflow" in readme
     assert "scaffold-workflow" in readme
+    assert "WORKFLOW.md" in readme
     assert "service-install" in readme
     assert "docs/operator/installation.md" in readme
     assert "docs/public-contract.md" in readme

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -15,10 +15,11 @@ def _load_module(module_name: str, path: Path):
     return module
 
 
-def test_public_onboarding_path_install_scaffold_init_and_supervise(tmp_path, monkeypatch):
+def test_public_onboarding_path_install_bootstrap_and_service_up(tmp_path, monkeypatch):
     install = _load_module("daedalus_install_smoke", REPO_ROOT / "scripts" / "install.py")
     hermes_home = tmp_path / ".hermes"
     plugin_dir = install.install_plugin(repo_root=REPO_ROOT, hermes_home=hermes_home)
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     monkeypatch.syspath_prepend(str(plugin_dir))
     tools = _load_module("daedalus_tools_smoke", plugin_dir / "tools.py")
@@ -26,49 +27,50 @@ def test_public_onboarding_path_install_scaffold_init_and_supervise(tmp_path, mo
     systemd_user_dir = tmp_path / "systemd-user"
     monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_user_dir))
 
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:attmous/daedalus.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    monkeypatch.chdir(repo)
+
     captured_commands = []
+    real_run = subprocess.run
 
     def fake_run(cmd, **kwargs):
         captured_commands.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["systemctl", "--user"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, **kwargs)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(tools.subprocess, "run", fake_run)
 
     workflow_root = hermes_home / "workflows" / "attmous-daedalus-code-review"
 
-    scaffold_out = tools.execute_raw_args(
-        f"scaffold-workflow --workflow-root {workflow_root} --github-slug attmous/daedalus"
-    )
-    assert "scaffolded workflow root" in scaffold_out
+    bootstrap_out = tools.execute_raw_args("bootstrap")
+    assert "bootstrapped workflow root" in bootstrap_out
+    assert (repo / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root)
 
-    init_out = tools.execute_raw_args(f"init --workflow-root {workflow_root} --json")
-    init_payload = json.loads(init_out)
-    assert init_payload["ok"] is True
+    service_up_out = tools.execute_raw_args("service-up --json")
+    service_up_payload = json.loads(service_up_out)
+    assert service_up_payload["ok"] is True
+    assert service_up_payload["preflight"]["ok"] is True
+    assert service_up_payload["preflight"]["workflow"] == "code-review"
+    assert Path(service_up_payload["service_install"]["unit_path"]).exists()
+    assert service_up_payload["service_enable"]["ok"] is True
+    assert service_up_payload["service_start"]["ok"] is True
+    assert service_up_payload["service_status"]["service_name"] == "daedalus-active@attmous-daedalus-code-review.service"
 
-    status_out = tools.execute_raw_args(f"status --workflow-root {workflow_root} --format json")
+    status_out = tools.execute_raw_args("status --format json")
     status_payload = json.loads(status_out)
     assert status_payload["runtime_status"] == "initialized"
     assert status_payload["project_key"] == "attmous-daedalus-code-review"
-
-    install_out = tools.execute_raw_args(
-        f"service-install --workflow-root {workflow_root} --service-mode active --json"
-    )
-    install_payload = json.loads(install_out)
-    assert install_payload["installed"] is True
-    assert Path(install_payload["unit_path"]).exists()
-
-    enable_out = tools.execute_raw_args(
-        f"service-enable --workflow-root {workflow_root} --service-mode active --json"
-    )
-    enable_payload = json.loads(enable_out)
-    assert enable_payload["ok"] is True
-
-    start_out = tools.execute_raw_args(
-        f"service-start --workflow-root {workflow_root} --service-mode active --json"
-    )
-    start_payload = json.loads(start_out)
-    assert start_payload["ok"] is True
 
     assert ["systemctl", "--user", "daemon-reload"] in captured_commands
     assert ["systemctl", "--user", "enable", "daedalus-active@attmous-daedalus-code-review.service"] in captured_commands
@@ -79,10 +81,10 @@ def test_readme_quickstart_mentions_supported_public_path():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
     assert "hermes plugins install attmous/daedalus --enable" in readme
+    assert "hermes daedalus bootstrap" in readme
     assert "hermes daedalus scaffold-workflow" in readme
-    assert "scaffold-workflow" in readme
     assert "WORKFLOW.md" in readme
-    assert "service-install" in readme
+    assert "service-up" in readme
     assert "docs/operator/installation.md" in readme
     assert "docs/public-contract.md" in readme
     assert "python3 -m pip install ." in readme

--- a/tests/test_runtime_agnostic_phase_a.py
+++ b/tests/test_runtime_agnostic_phase_a.py
@@ -286,6 +286,33 @@ def test_dispatch_agent_prefers_inline_prompt_template_from_config(tmp_path):
     assert Path(prompt_files[0]).read_text() == "Inline contract prompt"
 
 
+def test_dispatch_agent_prepends_shared_workflow_policy(tmp_path):
+    from workflows.code_review.dispatch import dispatch_agent
+
+    fake_run = MagicMock(return_value=MagicMock(stdout="ok"))
+    agents = {
+        "coder": {
+            "default": {"name": "c", "model": "gpt-5", "runtime": "codex-acpx"},
+        },
+    }
+    ws = _make_workspace(tmp_path, agents, _runtimes_cfg(), fake_run)
+    ws.config["prompts"] = {"coder": "Role-specific instructions"}
+    ws.config["workflow-policy"] = "Never widen scope."
+
+    dispatch_agent(
+        workspace=ws, role="coder", tier="default",
+        prompt_kwargs={}, session_name="lane-10", worktree=tmp_path,
+    )
+
+    argv = fake_run.call_args[0][0]
+    prompt_files = [a for a in argv if a.endswith(".txt")]
+    assert len(prompt_files) == 1
+    text = Path(prompt_files[0]).read_text()
+    assert "# Shared Workflow Policy" in text
+    assert "Never widen scope." in text
+    assert "Role-specific instructions" in text
+
+
 def test_dispatch_agent_legacy_fallback_calls_run_prompt(tmp_path):
     """When neither agent nor runtime has command:, dispatcher calls runtime.run_prompt."""
     from workflows.code_review.dispatch import dispatch_agent

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -1,0 +1,109 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from workflows.contract import load_workflow_contract_file
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
+
+
+def load_module(module_name: str, relative_path: str):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tools():
+    return load_module("daedalus_tools_bootstrap_workflow_test", "tools.py")
+
+
+def _init_git_repo(path: Path, *, remote_url: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "remote", "add", "origin", remote_url], cwd=path, check=True, capture_output=True, text=True)
+
+
+def test_bootstrap_workflow_infers_repo_root_slug_and_default_root(tmp_path, monkeypatch):
+    tools = _tools()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@github.com:attmous/daedalus.git")
+    nested = repo_root / "src" / "pkg"
+    nested.mkdir(parents=True)
+
+    result = tools.bootstrap_workflow_root(
+        repo_path=nested,
+        workflow_name="code-review",
+        workflow_root=None,
+        github_slug=None,
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=False,
+    )
+
+    expected_root = home / ".hermes" / "workflows" / "attmous-daedalus-code-review"
+    contract_path = expected_root / "WORKFLOW.md"
+    pointer_path = repo_root / ".hermes" / "daedalus" / "workflow-root"
+    cfg = load_workflow_contract_file(contract_path).config
+
+    assert Path(result["workflow_root"]) == expected_root
+    assert result["detected_repo_root"] == str(repo_root.resolve())
+    assert result["repo_path"] == str(repo_root.resolve())
+    assert result["github_slug"] == "attmous/daedalus"
+    assert result["remote_url"] == "git@github.com:attmous/daedalus.git"
+    assert result["repo_pointer_path"] == str(pointer_path)
+    assert result["next_edit_path"] == str(contract_path)
+    assert result["next_command"] == "hermes daedalus service-up"
+    assert cfg["repository"]["local-path"] == str(repo_root.resolve())
+    assert pointer_path.read_text(encoding="utf-8").strip() == str(expected_root)
+
+
+def test_bootstrap_workflow_accepts_explicit_slug_for_non_github_remote(tmp_path):
+    tools = _tools()
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@example.com:team/project.git")
+    workflow_root = tmp_path / ".hermes" / "workflows" / "acme-widget-code-review"
+
+    result = tools.bootstrap_workflow_root(
+        repo_path=repo_root,
+        workflow_name="code-review",
+        workflow_root=workflow_root,
+        github_slug="acme/widget",
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=False,
+    )
+
+    cfg = load_workflow_contract_file(workflow_root / "WORKFLOW.md").config
+    assert result["github_slug"] == "acme/widget"
+    assert cfg["repository"]["github-slug"] == "acme/widget"
+    assert cfg["repository"]["local-path"] == str(repo_root.resolve())
+    assert (repo_root / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root.resolve())
+
+
+def test_bootstrap_workflow_requires_git_repo(tmp_path):
+    tools = _tools()
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+
+    with pytest.raises(tools.DaedalusCommandError) as exc:
+        tools.bootstrap_workflow_root(
+            repo_path=non_repo,
+            workflow_name="code-review",
+            workflow_root=None,
+            github_slug=None,
+            active_lane_label="active-lane",
+            engine_owner="hermes",
+            force=False,
+        )
+
+    assert "git repository" in str(exc.value)

--- a/tests/test_tools_new_command_dispatch.py
+++ b/tests/test_tools_new_command_dispatch.py
@@ -86,4 +86,4 @@ def test_scaffold_workflow_dispatched_not_falling_through_to_unknown(tmp_path):
     )
     assert "unknown daedalus command" not in out, out
     assert "scaffolded workflow root" in out
-    assert (root / "config" / "workflow.yaml").exists()
+    assert (root / "WORKFLOW.md").exists()

--- a/tests/test_tools_new_command_dispatch.py
+++ b/tests/test_tools_new_command_dispatch.py
@@ -10,6 +10,7 @@ These tests pin the dispatch routing so a future refactor can't silently
 re-break it.
 """
 import importlib.util
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -87,3 +88,25 @@ def test_scaffold_workflow_dispatched_not_falling_through_to_unknown(tmp_path):
     assert "unknown daedalus command" not in out, out
     assert "scaffolded workflow root" in out
     assert (root / "WORKFLOW.md").exists()
+
+
+def test_bootstrap_dispatched_not_falling_through_to_unknown(tmp_path, monkeypatch):
+    tools = _tools()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:attmous/daedalus.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    out = tools.execute_raw_args(f"bootstrap --repo-path {repo}")
+    assert "unknown daedalus command" not in out, out
+    assert "bootstrapped workflow root" in out
+    assert (home / ".hermes" / "workflows" / "attmous-daedalus-code-review" / "WORKFLOW.md").exists()

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -112,4 +112,4 @@ def test_run_cli_command_dispatches_scaffold_workflow(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "unknown daedalus command" not in out, out
     assert "scaffolded workflow root" in out
-    assert (root / "config" / "workflow.yaml").exists()
+    assert (root / "WORKFLOW.md").exists()

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -13,6 +13,7 @@ These tests pin ``run_cli_command`` so it dispatches the string-returning
 handlers directly.
 """
 import importlib.util
+import subprocess
 from pathlib import Path
 
 
@@ -113,3 +114,34 @@ def test_run_cli_command_dispatches_scaffold_workflow(tmp_path, capsys):
     assert "unknown daedalus command" not in out, out
     assert "scaffolded workflow root" in out
     assert (root / "WORKFLOW.md").exists()
+
+
+def test_run_cli_command_dispatches_bootstrap(tmp_path, capsys, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:attmous/daedalus.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    tools = _tools()
+    args = _parse(
+        tools,
+        [
+            "bootstrap",
+            "--repo-path",
+            str(repo),
+        ],
+    )
+    tools.run_cli_command(args)
+    out = capsys.readouterr().out
+    assert "unknown daedalus command" not in out, out
+    assert "bootstrapped workflow root" in out
+    assert (home / ".hermes" / "workflows" / "attmous-daedalus-code-review" / "WORKFLOW.md").exists()

--- a/tests/test_tools_scaffold_workflow.py
+++ b/tests/test_tools_scaffold_workflow.py
@@ -2,7 +2,8 @@ import importlib.util
 from pathlib import Path
 
 import pytest
-import yaml
+
+from workflows.contract import WORKFLOW_POLICY_KEY, load_workflow_contract_file
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
@@ -35,16 +36,17 @@ def test_scaffold_workflow_writes_config_and_layout(tmp_path):
         force=False,
     )
 
-    config_path = root / "config" / "workflow.yaml"
-    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    contract_path = root / "WORKFLOW.md"
+    cfg = load_workflow_contract_file(contract_path).config
 
-    assert result["config_path"] == str(config_path)
+    assert result["contract_path"] == str(contract_path)
     assert cfg["instance"]["name"] == "attmous-daedalus-code-review"
     assert cfg["instance"]["engine-owner"] == "hermes"
     assert cfg["repository"]["github-slug"] == "attmous/daedalus"
     assert cfg["repository"]["active-lane-label"] == "ready-for-daedalus"
     assert cfg["triggers"]["lane-selector"]["label"] == "ready-for-daedalus"
     assert cfg["repository"]["local-path"] == str(root / "workspace" / "repo")
+    assert cfg[WORKFLOW_POLICY_KEY]
     assert (root / "memory").is_dir()
     assert (root / "state" / "sessions").is_dir()
     assert (root / "runtime" / "state" / "daedalus").is_dir()
@@ -55,9 +57,9 @@ def test_scaffold_workflow_writes_config_and_layout(tmp_path):
 def test_scaffold_workflow_refuses_to_overwrite_without_force(tmp_path):
     tools = _tools()
     root = tmp_path / "attmous-daedalus-code-review"
-    config_path = root / "config" / "workflow.yaml"
-    config_path.parent.mkdir(parents=True)
-    config_path.write_text("workflow: code-review\n", encoding="utf-8")
+    contract_path = root / "WORKFLOW.md"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text("---\nworkflow: code-review\nschema-version: 1\n---\n", encoding="utf-8")
 
     try:
         tools.scaffold_workflow_root(
@@ -70,7 +72,7 @@ def test_scaffold_workflow_refuses_to_overwrite_without_force(tmp_path):
             force=False,
         )
     except tools.DaedalusCommandError as exc:
-        assert "refusing to overwrite existing config" in str(exc)
+        assert "refusing to overwrite existing workflow contract" in str(exc)
         return
     raise AssertionError("expected DaedalusCommandError when overwriting without --force")
 
@@ -78,9 +80,9 @@ def test_scaffold_workflow_refuses_to_overwrite_without_force(tmp_path):
 def test_scaffold_workflow_force_replaces_existing_config(tmp_path):
     tools = _tools()
     root = tmp_path / "attmous-daedalus-code-review"
-    config_path = root / "config" / "workflow.yaml"
-    config_path.parent.mkdir(parents=True)
-    config_path.write_text("workflow: old\n", encoding="utf-8")
+    contract_path = root / "WORKFLOW.md"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text("---\nworkflow: old\nschema-version: 1\n---\n", encoding="utf-8")
 
     tools.scaffold_workflow_root(
         workflow_root=root,
@@ -92,11 +94,32 @@ def test_scaffold_workflow_force_replaces_existing_config(tmp_path):
         force=True,
     )
 
-    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    cfg = load_workflow_contract_file(contract_path).config
     assert cfg["workflow"] == "code-review"
     assert cfg["instance"]["name"] == "attmous-daedalus-code-review"
     assert cfg["instance"]["engine-owner"] == "openclaw"
     assert cfg["repository"]["local-path"] == str(root / "workspace" / "checkout")
+
+
+def test_scaffold_workflow_force_retires_legacy_yaml_when_present(tmp_path):
+    tools = _tools()
+    root = tmp_path / "attmous-daedalus-code-review"
+    legacy_path = root / "config" / "workflow.yaml"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text("workflow: code-review\nschema-version: 1\n", encoding="utf-8")
+
+    tools.scaffold_workflow_root(
+        workflow_root=root,
+        workflow_name="code-review",
+        repo_path=None,
+        github_slug="attmous/daedalus",
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=True,
+    )
+
+    assert (root / "WORKFLOW.md").exists()
+    assert not legacy_path.exists()
 
 
 def test_scaffold_workflow_requires_owner_repo_workflow_root_name(tmp_path):

--- a/tests/test_workflow_contract_loader.py
+++ b/tests/test_workflow_contract_loader.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from workflows.contract import (
+    WORKFLOW_POLICY_KEY,
     WorkflowContractError,
     find_workflow_contract_path,
     load_workflow_contract,
@@ -38,14 +39,8 @@ def _native_config() -> dict:
 
 
 def _workflow_markdown(config: dict, *, prompt_role: str = "coder", body: str = "You are the workflow prompt.") -> str:
-    front_matter = {
-        "tracker": {"kind": "github-issues"},
-        "daedalus": {
-            "prompt-role": prompt_role,
-            "workflow-config": config,
-        },
-    }
-    return "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n"
+    del prompt_role
+    return "---\n" + yaml.safe_dump(config, sort_keys=False) + "---\n\n" + body + "\n"
 
 
 def test_load_workflow_contract_reads_yaml_mapping(tmp_path):
@@ -78,26 +73,38 @@ def test_load_workflow_contract_reads_markdown_and_injects_prompt(tmp_path):
 
     assert contract.source_path == path
     assert contract.config["workflow"] == "code-review"
-    assert contract.config["prompts"]["internal-reviewer"] == "Review the lane strictly."
+    assert contract.config[WORKFLOW_POLICY_KEY] == "Review the lane strictly."
     assert contract.prompt_template == "Review the lane strictly."
 
 
-def test_load_workflow_contract_markdown_requires_daedalus_workflow_config(tmp_path):
+def test_load_workflow_contract_markdown_body_becomes_workflow_policy(tmp_path):
     path = tmp_path / "WORKFLOW.md"
     path.write_text(
-        "---\ntracker:\n  kind: linear\n---\n\nPrompt body.\n",
+        _workflow_markdown(_native_config(), body="Prompt body."),
         encoding="utf-8",
     )
 
-    with pytest.raises(WorkflowContractError, match="daedalus.workflow-config"):
+    contract = load_workflow_contract_file(path)
+
+    assert contract.config[WORKFLOW_POLICY_KEY] == "Prompt body."
+
+
+def test_load_workflow_contract_markdown_rejects_duplicate_policy_sources(tmp_path):
+    payload = _native_config()
+    payload[WORKFLOW_POLICY_KEY] = "front matter policy"
+    path = tmp_path / "WORKFLOW.md"
+    path.write_text(_workflow_markdown(payload, body="body policy"), encoding="utf-8")
+
+    with pytest.raises(WorkflowContractError, match="workflow-policy"):
         load_workflow_contract_file(path)
 
 
-def test_find_workflow_contract_path_prefers_yaml_when_both_exist(tmp_path):
+def test_find_workflow_contract_path_prefers_markdown_when_both_exist(tmp_path):
     root = tmp_path / "wf"
     (root / "config").mkdir(parents=True)
     yaml_path = root / "config" / "workflow.yaml"
     yaml_path.write_text(yaml.safe_dump(_native_config()), encoding="utf-8")
-    (root / "WORKFLOW.md").write_text(_workflow_markdown(_native_config()), encoding="utf-8")
+    markdown_path = root / "WORKFLOW.md"
+    markdown_path.write_text(_workflow_markdown(_native_config()), encoding="utf-8")
 
-    assert find_workflow_contract_path(root) == yaml_path
+    assert find_workflow_contract_path(root) == markdown_path

--- a/tests/test_workflows_code_review_paths.py
+++ b/tests/test_workflows_code_review_paths.py
@@ -75,17 +75,7 @@ def _write_workflow_markdown(workflow_root: Path, *, instance_name: str = "bluep
     }
     workflow_root.mkdir(parents=True, exist_ok=True)
     (workflow_root / "WORKFLOW.md").write_text(
-        "---\n"
-        + yaml.safe_dump(
-            {
-                "daedalus": {
-                    "prompt-role": "coder",
-                    "workflow-config": config,
-                },
-            },
-            sort_keys=False,
-        )
-        + "---\n\nPrompt body\n",
+        "---\n" + yaml.safe_dump(config, sort_keys=False) + "---\n\nPrompt body\n",
         encoding="utf-8",
     )
 

--- a/tests/test_workflows_code_review_paths.py
+++ b/tests/test_workflows_code_review_paths.py
@@ -162,6 +162,30 @@ def test_resolve_default_workflow_root_detects_cwd_ancestor_with_workflow_markdo
     assert resolved == workflow_root.resolve()
 
 
+def test_resolve_default_workflow_root_follows_repo_local_pointer(tmp_path):
+    paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
+    workflow_root = tmp_path / ".hermes" / "workflows" / "owner-repo-code-review"
+    _write_workflow_markdown(workflow_root)
+    (workflow_root / "runtime").mkdir(parents=True, exist_ok=True)
+    (workflow_root / "memory").mkdir(parents=True, exist_ok=True)
+    (workflow_root / "state").mkdir(parents=True, exist_ok=True)
+
+    repo_root = tmp_path / "repo"
+    nested = repo_root / "src" / "pkg"
+    nested.mkdir(parents=True)
+    pointer_path = repo_root / ".hermes" / "daedalus" / "workflow-root"
+    pointer_path.parent.mkdir(parents=True)
+    pointer_path.write_text(str(workflow_root.resolve()) + "\n", encoding="utf-8")
+
+    resolved = paths_module.resolve_default_workflow_root(
+        plugin_dir=tmp_path / "plugin" / "daedalus",
+        env={},
+        cwd=nested,
+    )
+
+    assert resolved == workflow_root.resolve()
+
+
 def test_resolve_default_workflow_root_falls_back_to_cwd_when_no_config(tmp_path):
     paths_module = load_module("daedalus_workflows_code_review_paths_test", "workflows/code_review/paths.py")
     cwd = tmp_path / "scratch"

--- a/tests/test_workflows_code_review_prompts.py
+++ b/tests/test_workflows_code_review_prompts.py
@@ -53,6 +53,26 @@ def test_render_implementation_dispatch_prompt_includes_issue_summary_for_restar
     assert 'The local branch has already passed the Claude pre-publish gate.' in result
 
 
+def test_render_implementation_dispatch_prompt_prepends_shared_workflow_policy():
+    prompts_module = load_module("daedalus_workflows_code_review_prompts_test", "workflows/code_review/prompts.py")
+
+    result = prompts_module.render_implementation_dispatch_prompt(
+        issue={"number": 224, "title": "Issue 224", "url": "https://example.com/issues/224"},
+        issue_details={"body": "Body."},
+        worktree=Path('/tmp/issue-224'),
+        lane_memo_path=None,
+        lane_state_path=None,
+        open_pr=None,
+        action='restart-session',
+        workflow_state='implementing_local',
+        workflow_policy='Never widen scope.',
+    )
+
+    assert '# Shared Workflow Policy' in result
+    assert 'Never widen scope.' in result
+    assert '# Role-Specific Instructions' in result
+
+
 def test_render_claude_repair_handoff_prompt_includes_review_summary_and_fix_lists():
     prompts_module = load_module("daedalus_workflows_code_review_prompts_test", "workflows/code_review/prompts.py")
 
@@ -91,6 +111,23 @@ def test_render_external_reviewer_repair_handoff_prompt_includes_pr_url_and_guar
     assert 'External_Reviewer_Agent summary:' in result
     assert '- Tighten edge case' in result
     assert 'Do not publish .codex artifacts.' in result
+
+
+def test_render_inter_review_agent_prompt_can_prepend_shared_workflow_policy(tmp_path):
+    prompts_module = load_module("daedalus_workflows_code_review_prompts_test", "workflows/code_review/prompts.py")
+
+    result = prompts_module.render_inter_review_agent_prompt(
+        issue={"number": 224, "title": "Issue 224", "url": "https://example.com/issues/224"},
+        worktree=tmp_path,
+        lane_memo_path=None,
+        lane_state_path=None,
+        head_sha="abc123",
+        workflow_policy="Do not guess.",
+    )
+
+    assert '# Shared Workflow Policy' in result
+    assert 'Do not guess.' in result
+    assert 'Scope: local-prepublish only' in result
 
 
 def test_summarize_validation_and_render_lane_memo_capture_checks_progress_and_fix_lists():

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -91,6 +91,7 @@ def test_make_workspace_exposes_config_constants_and_primitives(tmp_path):
     assert ws.INTER_REVIEW_AGENT_MODEL == "claude-sonnet-4-6"
     assert ws.INTERNAL_REVIEWER_AGENT_NAME == "Internal_Reviewer_Agent"
     assert ws.LANE_FAILURE_RETRY_BUDGET == 3
+    assert ws.WORKFLOW_POLICY == ""
     # I/O primitives
     assert callable(ws._run)
     assert callable(ws._now_iso)
@@ -110,6 +111,28 @@ def test_workspace_engine_owner_selects_hermes_cron_jobs_path(tmp_path):
     config["engineOwner"] = "openclaw"
     ws2 = workspace_module.make_workspace(workspace_root=tmp_path, config=config)
     assert ws2._jobs_store_path() == Path(config["cronJobsPath"])
+
+
+def test_workspace_uses_workflow_policy_from_workflow_contract(tmp_path):
+    workspace_module = load_module("daedalus_workflows_code_review_workspace_test", "workflows/code_review/workspace.py")
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["workflow-policy"] = "Never widen scope."
+
+    ws = workspace_module.make_workspace(workspace_root=tmp_path, config=cfg)
+    prompt = ws._render_implementation_dispatch_prompt(
+        issue={"number": 224, "title": "Issue 224", "url": "https://example.test/issues/224"},
+        issue_details={"body": "Issue body"},
+        worktree=tmp_path / "repo",
+        lane_memo_path=None,
+        lane_state_path=None,
+        open_pr=None,
+        action="restart-session",
+        workflow_state="implementing_local",
+    )
+
+    assert ws.WORKFLOW_POLICY == "Never widen scope."
+    assert "# Shared Workflow Policy" in prompt
+    assert "Never widen scope." in prompt
 
 
 def test_workspace_audit_appends_jsonl(tmp_path):

--- a/tests/test_workflows_dispatcher.py
+++ b/tests/test_workflows_dispatcher.py
@@ -130,13 +130,8 @@ def _reset_workflows_module_cache():
 
 def _write_workflow_markdown(workspace_root: Path, *, workflow_name: str = "demo-wf", body: str = "Prompt body") -> None:
     front_matter = {
-        "daedalus": {
-            "prompt-role": "coder",
-            "workflow-config": {
-                "workflow": workflow_name,
-                "schema-version": 1,
-            },
-        },
+        "workflow": workflow_name,
+        "schema-version": 1,
     }
     (workspace_root / "WORKFLOW.md").write_text(
         "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n",

--- a/tests/test_workspace_yaml_loader.py
+++ b/tests/test_workspace_yaml_loader.py
@@ -84,13 +84,8 @@ def _yaml_config(repo_path: Path) -> dict:
 
 
 def _workflow_markdown(config: dict, *, prompt_role: str = "coder", body: str = "Contract prompt") -> str:
-    front_matter = {
-        "daedalus": {
-            "prompt-role": prompt_role,
-            "workflow-config": config,
-        },
-    }
-    return "---\n" + yaml.safe_dump(front_matter, sort_keys=False) + "---\n\n" + body + "\n"
+    del prompt_role
+    return "---\n" + yaml.safe_dump(config, sort_keys=False) + "---\n\n" + body + "\n"
 
 
 def test_load_workspace_from_config_prefers_workflow_yaml(tmp_path):
@@ -140,6 +135,7 @@ def test_load_workspace_from_config_accepts_explicit_markdown_path(tmp_path):
 
     assert ws.REPO_PATH == Path(tmp_path / "markdown-repo")
     assert ws.ENGINE_OWNER == "hermes"
+    assert ws.WORKFLOW_POLICY == "Contract prompt"
 
 
 def test_load_workspace_from_config_rejects_json_config_path(tmp_path):
@@ -164,6 +160,7 @@ def test_load_workspace_from_config_falls_back_to_workflow_markdown(tmp_path):
 
     assert ws.REPO_PATH == Path(tmp_path / "markdown-repo")
     assert ws.ENGINE_OWNER == "hermes"
+    assert ws.WORKFLOW_POLICY == "Contract prompt"
 
 
 def test_load_workspace_from_config_raises_when_no_config_present(tmp_path):


### PR DESCRIPTION
## Summary

This PR finishes the public workflow-contract flip and tightens the operator onboarding path around it.

- make `WORKFLOW.md` the primary public workflow contract and keep `config/workflow.yaml` as legacy load-only input
- treat the Markdown body as shared workflow policy prepended across role-specific prompts
- switch scaffolded output and shipped examples/templates from YAML files to Markdown workflow contracts
- add `hermes daedalus service-up` as the one-shot post-edit service command
- add `hermes daedalus bootstrap` to infer the repo root and GitHub slug from the current checkout
- persist a repo-local workflow pointer at `./.hermes/daedalus/workflow-root` so later `hermes daedalus ...` commands work from the repo root without `--workflow-root`
- update docs, onboarding, and tests so the supported public path is install -> bootstrap -> edit `WORKFLOW.md` -> `service-up`

## Why

The earlier direction change was to adopt `WORKFLOW.md` as the operator-facing contract because it is easier to read and review than a split config/prompt surface. After that shift, the remaining friction was onboarding: operators still had to think about workflow-root naming and pass `--workflow-root` back into every command.

This PR closes that gap. The common case now works from the repo checkout with one contract file and one bring-up command.

## Impact

- new workflow roots still live at `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
- operators edit exactly one file: `WORKFLOW.md`
- `bootstrap` writes a repo-local pointer so Daedalus can resolve the workflow root from the repo checkout
- `service-up` initializes, validates, installs, enables, and starts the service in one command
- `scaffold-workflow`, `init`, and the lower-level `service-*` commands remain available as explicit escape hatches
- legacy `config/workflow.yaml` still loads for older instances, but it is no longer the primary path in docs or scaffolding

## Validation

```bash
pytest tests/test_workflows_code_review_paths.py tests/test_tools_bootstrap_workflow.py tests/test_public_onboarding_smoke.py tests/test_tools_new_command_dispatch.py tests/test_tools_run_cli_command_dispatch.py tests/test_tools_scaffold_workflow.py tests/test_install.py tests/test_official_plugin_layout.py tests/test_pip_plugin_packaging.py
```

`46 passed`
