### PR TITLE
[codex] tighten project-pack boundary and trim README install flow

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include README.md
 include LICENSE
-recursive-include daedalus *.yaml *.md *.json
+include daedalus/plugin.yaml
+recursive-include daedalus/skills *.md
+recursive-include daedalus/workflows *.yaml *.md *.json
+prune daedalus/projects

--- a/README.md
+++ b/README.md
@@ -78,68 +78,22 @@ If you want the exact operator contract we support, read [docs/public-contract.m
 ## Install & quick start
 
 ```bash
-# 1. Make sure host python has the runtime deps
-# Debian/Ubuntu example:
 sudo apt install python3-yaml python3-jsonschema
-
-# 2. Install and enable the plugin
 hermes plugins install attmous/daedalus --enable
-
-# 3. Bootstrap one workflow instance from your repo checkout
 cd /path/to/your/repo
 hermes daedalus bootstrap
 ```
 
-`bootstrap` infers the git repo root, derives `github-slug` from `origin`, and
-creates:
-
-```text
-~/.hermes/workflows/<owner>-<repo>-<workflow-type>
-```
-
-It also writes a repo-local pointer at:
-
-```text
-./.hermes/daedalus/workflow-root
-```
-
-So later `hermes daedalus ...` commands can resolve the workflow root directly
-from the repo checkout.
-
-If you need explicit control, the lower-level command is still available:
+Edit the generated workflow contract:
 
 ```bash
-hermes daedalus scaffold-workflow \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
-  --github-slug your-org/your-repo
+$EDITOR ~/.hermes/workflows/your-org-your-repo-code-review/WORKFLOW.md
 ```
 
-Edit `~/.hermes/workflows/your-org-your-repo-code-review/WORKFLOW.md` before starting the engine:
-
-- set `repository.local-path`
-- confirm the runtime kinds you actually have installed
-- tune agents/models/gates for your repo
-
-The YAML front matter is the machine config. The Markdown body below it is the
-shared workflow policy Daedalus applies across its role-specific prompts.
-
-Then initialize, verify, and supervise it:
+Then bring it up:
 
 ```bash
 hermes daedalus service-up
-```
-
-`service-up` initializes the runtime, validates `WORKFLOW.md`, installs the
-user systemd unit, enables it, and starts it. If you want to inspect before
-starting, the lower-level commands still exist:
-
-```bash
-hermes daedalus init \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review
-
-hermes daedalus doctor \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-code-review \
-  --format json
 ```
 
 Start Hermes in your repo:
@@ -149,43 +103,22 @@ cd /path/to/your/repo
 hermes
 ```
 
-Daedalus resolves the workflow root from the repo-local pointer written by
-`bootstrap`. `DAEDALUS_WORKFLOW_ROOT` remains available when you need to
-override it explicitly.
+`bootstrap` infers the repo root and GitHub slug, creates
+`~/.hermes/workflows/<owner>-<repo>-<workflow-type>/WORKFLOW.md`, and wires the
+repo checkout to that workflow root. The YAML front matter is the machine
+config; the Markdown body is the shared workflow policy.
 
 Inside Hermes:
 
 ```text
-
 /daedalus status
 /daedalus doctor
 /workflow code-review status
 ```
 
-The full supported install path is documented in [docs/operator/installation.md](docs/operator/installation.md).
-
-Daedalus also ships a standard Hermes pip entry point. From a local checkout or
-published package, Hermes can discover it through `hermes_agent.plugins`:
-
-```bash
-python3 -m pip install .
-hermes plugins enable daedalus
-```
-
-The Git install path above remains the primary community path because it is the
-most direct operator story and handles install + enable in one command.
-
-Need a local-dev fallback instead of `hermes plugins install`?
-
-```bash
-git clone https://github.com/attmous/daedalus.git
-cd daedalus
-./scripts/install.sh --hermes-home /path/to/hermes-home    # custom Hermes home
-./scripts/install.sh --destination /tmp/daedalus           # arbitrary destination
-hermes plugins enable daedalus
-```
-
-`HERMES_ENABLE_PROJECT_PLUGINS=true` is only for project-local plugins under `./.hermes/plugins/`. It is not required for the supported global install path above.
+For manual scaffold paths, pip installs, local-dev installation, service modes,
+and every lower-level command, read
+[docs/operator/installation.md](docs/operator/installation.md).
 
 The full operator surface is in the [cheat sheet](docs/operator/cheat-sheet.md); every slash command is catalogued in [slash-commands.md](docs/operator/slash-commands.md).
 

--- a/daedalus/projects/README.md
+++ b/daedalus/projects/README.md
@@ -1,46 +1,48 @@
 # Daedalus projects
 
-Each subdirectory under `projects/` is one **project pack** — optional
-playground material for a specific repository or operator setup.
+Each subdirectory under `projects/` is source-repo **playground material** for
+one specific repository or operator environment.
 
-Project packs are not the public workflow contract. The engine is
-configured from `<workflow-root>/WORKFLOW.md`; `projects/` is
-where you keep project-specific docs, helper skills, and local metadata
-that you do not want in the generic plugin surface.
+This tree is **not** part of the public plugin contract and is **not shipped**
+in the install payload. The public engine is configured from
+`<workflow-root>/WORKFLOW.md`, and the canonical repo checkout is the one the
+operator bootstraps from.
 
-The published repo keeps `yoyopod_core/` here as an example pack and
-local playground, not as an engine default.
+That means:
 
-## Layout
+- agents should work against the user's real repo checkout recorded in
+  `repository.local-path`
+- workflow instance state lives under
+  `~/.hermes/workflows/<owner>-<repo>-<workflow-type>/`
+- `projects/` is only for source-controlled notes, legacy skills, and local
+  playground reference material
 
-```
-projects/
-├── README.md                # this file
-└── <project-slug>/          # one directory per project pack
-    ├── config/              # project metadata
-    │   └── project.json     # {projectSlug, displayName, workspaceRepoName}
-    ├── docs/                # project-scoped runbooks and specs
-    ├── runtime/             # mutable runtime state (gitignored)
-    │   ├── memory/          # event log, alert state, status projections
-    │   ├── state/           # sqlite + durable runtime state
-    │   └── logs/            # local runtime/service logs
-    ├── skills/              # project-only skills kept out of the public root
-    └── workspace/           # cloned source repo (gitignored)
-        └── <repo-name>/     # the actual git checkout the agents work in
-```
+The repo currently keeps `yoyopod_core/` here as historical/example material.
+Treat it as archived playground content, not as a recommended deployment model.
 
-`runtime/` and `workspace/` are excluded from git — only the README
-stubs inside them are tracked, so the directory shape is preserved on a
-fresh clone.
+## What belongs here
 
-## Adding a new project pack
+Keep only source-controlled reference material:
 
-1. Create `projects/<your-slug>/config/project.json` with the three
-   keys: `projectSlug`, `displayName`, `workspaceRepoName`.
-2. Add `projects/<your-slug>/runtime/README.md` and
-   `projects/<your-slug>/workspace/README.md` placeholders.
-3. Add `projects/<your-slug>/docs/` and `projects/<your-slug>/skills/`
-   if you need project-only runbooks or automations.
-4. Point your real workflow root's `WORKFLOW.md` at the repo
-   and policy for that project. Daedalus selects work by
-   `--workflow-root`, not by project-pack slug.
+- project-specific docs or migration notes
+- local-only skills that should not appear in the public plugin root
+- archived example metadata if it helps explain older layouts
+
+Do not treat `projects/` as:
+
+- the canonical product checkout
+- the default place where agents edit code
+- a packaged plugin runtime surface
+- a loader contract the engine resolves at runtime
+
+## Current model
+
+The supported public model is:
+
+1. clone or open the real product repo
+2. run `hermes daedalus bootstrap` from that checkout
+3. edit the generated workflow root's `WORKFLOW.md`
+4. run `hermes daedalus service-up`
+
+If a project pack is useful, it should help humans understand or migrate that
+project. It should not replace the workflow root or the user checkout.

--- a/daedalus/projects/yoyopod_core/docs/README.md
+++ b/daedalus/projects/yoyopod_core/docs/README.md
@@ -1,5 +1,12 @@
 # yoyopod_core project-local docs
 
-This directory is for project-scoped docs and runbooks that belong to the
-hosted `yoyopod-core` project inside this repo rather than to generic Daedalus
-operator docs.
+This directory is archived playground/reference material for the historical
+`yoyopod-core` example pack.
+
+It is not part of the public plugin payload and it is not the recommended
+operator model. The supported public path is:
+
+- real repo checkout
+- `hermes daedalus bootstrap`
+- workflow root under `~/.hermes/workflows/...`
+- `WORKFLOW.md` as the contract

--- a/daedalus/projects/yoyopod_core/docs/model1-implementation-spec.md
+++ b/daedalus/projects/yoyopod_core/docs/model1-implementation-spec.md
@@ -1,5 +1,11 @@
 # `yoyopod-core` Model 1 implementation spec
 
+> **Historical note:** This document describes an earlier Model 1 layout where
+> project-local runtime data and cloned workspace state lived under
+> `daedalus/projects/yoyopod_core/`. That is no longer the supported public
+> model. Public installs now use the operator's real repo checkout plus a
+> workflow instance root under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>/`.
+>
 > **Goal:** Move the `yoyopod-core` workflow brain into the `daedalus` plugin repo with a hard internal boundary between generic Daedalus engine code, project adapter code, and project runtime assets.
 
 ## 1. Scope

--- a/daedalus/projects/yoyopod_core/runtime/README.md
+++ b/daedalus/projects/yoyopod_core/runtime/README.md
@@ -1,6 +1,13 @@
 # yoyopod_core runtime data
 
-This directory is the live mutable home for `yoyopod-core` runtime state.
+This directory documents the older project-pack layout and is kept only as
+historical playground material.
+
+It is not part of the shipped plugin payload, and it is not the supported home
+for public workflow-instance runtime state. Public runtime state lives under
+the real workflow root:
+
+- `~/.hermes/workflows/<owner>-<repo>-<workflow-type>/runtime/`
 
 Expected contents over time:
 

--- a/daedalus/projects/yoyopod_core/skills/daedalus-model1-project-layout/SKILL.md
+++ b/daedalus/projects/yoyopod_core/skills/daedalus-model1-project-layout/SKILL.md
@@ -11,6 +11,14 @@ metadata:
 
 # Daedalus Model 1 Project Layout
 
+Historical note: this skill captures an older Model 1 repo layout where
+`projects/<project>/runtime/` and `projects/<project>/workspace/` were treated
+as the default project-local homes. The supported public model is now:
+
+- real repo checkout as the canonical codebase
+- `WORKFLOW.md` under the workflow instance root as the contract
+- runtime state under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>/`
+
 Use this when reorganizing Daedalus before a full two-plugin split.
 
 ## Goal

--- a/daedalus/projects/yoyopod_core/workspace/README.md
+++ b/daedalus/projects/yoyopod_core/workspace/README.md
@@ -1,9 +1,14 @@
 # yoyopod_core workspace
 
-This directory is for the live cloned product repository used by the adapter.
+This directory documents the older project-pack layout and is kept only as
+historical playground material.
 
-Expected primary clone path:
+It is not part of the shipped plugin payload, and it is not the supported home
+for the canonical product checkout. In the supported public model:
 
-- `yoyopod-core/`
+- the operator works from the real repo checkout they bootstrapped from
+- `repository.local-path` in `WORKFLOW.md` points at that checkout
+- Daedalus creates any runtime-managed workspaces or worktrees from there
 
-This is mutable workspace data and should not be version-controlled.
+So this directory is reference-only. It should not be treated as the default
+place where agents edit code.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,8 +36,10 @@ pytest tests/test_pip_plugin_packaging.py -v
 ```
 
 If you touch files loaded at runtime via `Path(__file__).parent` — prompts,
-skills, workflow templates, project packs, or `plugin.yaml` — keep the package
-metadata in `pyproject.toml` / `MANIFEST.in` and the packaging test green.
+skills, workflow templates, or `plugin.yaml` — keep the package metadata in
+`pyproject.toml` / `MANIFEST.in` and the packaging test green. `daedalus/projects/**`
+is source-repo playground material and is intentionally not shipped in the
+public plugin payload.
 
 ---
 

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -29,7 +29,8 @@ These are not public compatibility promises yet:
 - SQLite schema details in `runtime/state/daedalus/daedalus.db`
 - event payload internals beyond documented operator output
 - archived design/spec material under `docs/superpowers/`
-- playground project packs under `daedalus/projects/**`
+- source-repo playground material under `daedalus/projects/**` (not shipped in
+  the public plugin payload)
 - experimental skills and local migration helpers
 
 We can refactor those freely as long as the stable surfaces above keep working.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,8 @@ daedalus = "daedalus"
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.exclude-package-data]
+daedalus = ["projects/*", "projects/**/*"]
+
 [tool.setuptools.packages.find]
 include = ["daedalus*"]

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -25,7 +25,6 @@ PAYLOAD_ITEMS = [
     "watch.py",
     "watch_sources.py",
     "workflows",
-    "projects",
     "skills",
 ]
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -26,7 +26,7 @@ def test_install_into_default_hermes_home_copies_plugin_tree(tmp_path):
     assert (plugin_dir / "alerts.py").exists()
     assert (plugin_dir / "workflows" / "code_review" / "status.py").exists()
     assert (plugin_dir / "workflows" / "code_review" / "workflow.template.md").exists()
-    assert list((plugin_dir / "projects").glob("*/config/project.json"))
+    assert not (plugin_dir / "projects").exists()
     assert (plugin_dir / "skills" / "operator" / "SKILL.md").exists()
 
 
@@ -41,7 +41,7 @@ def test_install_into_explicit_destination_uses_given_path(tmp_path):
     assert (target / "plugin.yaml").exists()
     assert (target / "tools.py").exists()
     assert (target / "workflows" / "code_review" / "workflow.py").exists()
-    assert list((target / "projects").glob("*/workspace/README.md"))
+    assert not (target / "projects").exists()
 
 
 def test_install_replaces_legacy_symlink_destination_with_real_directory(tmp_path):

--- a/tests/test_pip_plugin_packaging.py
+++ b/tests/test_pip_plugin_packaging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import subprocess
 import sys
 import zipfile
@@ -22,6 +23,9 @@ def _load_module(module_name: str, path: Path):
 
 
 def _build_wheel(tmp_path: Path) -> Path:
+    shutil.rmtree(REPO_ROOT / "build", ignore_errors=True)
+    for egg_info in REPO_ROOT.glob("*.egg-info"):
+        shutil.rmtree(egg_info, ignore_errors=True)
     dist_dir = tmp_path / "dist"
     completed = subprocess.run(
         [
@@ -80,10 +84,12 @@ def test_wheel_contains_runtime_loaded_plugin_payload(tmp_path):
         "daedalus/workflows/code_review/schema.yaml",
         "daedalus/workflows/code_review/workflow.template.md",
         "daedalus/workflows/code_review/prompts/coder.md",
-        "daedalus/projects/yoyopod_core/config/project.json",
     }
     missing = sorted(path for path in expected if path not in names)
     assert not missing, f"wheel missing runtime payload files: {missing}"
+    assert not any(name.startswith("daedalus/projects/") for name in names), (
+        "wheel should not ship source-only project packs"
+    )
 
 
 def test_wheel_extracts_to_working_plugin_package(tmp_path):

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -82,12 +82,9 @@ def test_readme_quickstart_mentions_supported_public_path():
 
     assert "hermes plugins install attmous/daedalus --enable" in readme
     assert "hermes daedalus bootstrap" in readme
-    assert "hermes daedalus scaffold-workflow" in readme
     assert "WORKFLOW.md" in readme
     assert "service-up" in readme
     assert "docs/operator/installation.md" in readme
     assert "docs/public-contract.md" in readme
-    assert "python3 -m pip install ." in readme
-    assert "hermes plugins enable daedalus" in readme
-    assert "HERMES_ENABLE_PROJECT_PLUGINS=true" in readme
-    assert "project-local plugins" in readme
+    assert "manual scaffold paths" in readme.lower()
+    assert "lower-level command" in readme.lower()


### PR DESCRIPTION
## What changed

This PR tightens the boundary around `daedalus/projects/**` and simplifies the repo landing page install flow.

- stop shipping `daedalus/projects/**` in the install payload and wheel
- update packaging and install tests to enforce that boundary
- reframe the Yoyopod project pack as archived playground/reference material instead of a live runtime surface
- shorten the README quick-start to the default happy path and push detailed installation variants into `docs/operator/installation.md`

## Why

`daedalus/projects/**` had become ambiguous: it looked like a supported runtime surface even though the public model is now the user's real repo checkout plus a workflow instance root under `~/.hermes/workflows/...`.

The README also carried too much operator detail for a repo landing page. The default path is now clearer, and the full install guide remains the source of truth for manual scaffold paths, pip installs, local-dev installation, and lower-level commands.

## Impact

- public plugin artifacts are cleaner and no longer ship source-only project packs
- archived Yoyopod material stays in the repo for reference without competing with the supported deployment model
- the landing page install flow is shorter and easier to scan

## Validation

- `pytest tests/test_install.py tests/test_pip_plugin_packaging.py tests/test_public_onboarding_smoke.py tests/test_official_plugin_layout.py`
- `pytest tests/test_workflows_code_review_paths.py tests/test_tools_bootstrap_workflow.py tests/test_tools_new_command_dispatch.py tests/test_tools_run_cli_command_dispatch.py`
