### PR TITLE
[codex] harden issue-runner codex app-server

### DIFF
--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -162,21 +162,23 @@ class _AppServerClient:
             on_message(message)
 
     def next_message(self, *, deadline: float) -> dict[str, Any]:
-        timeout = max(deadline - time.monotonic(), 0)
-        if timeout <= 0:
+        message = self.poll_message(deadline=deadline)
+        if message is None:
             raise CodexAppServerError(
                 "codex-app-server protocol response timed out",
                 stderr=self.stderr_text,
                 returncode=self.returncode,
             )
+        return message
+
+    def poll_message(self, *, deadline: float) -> dict[str, Any] | None:
+        timeout = max(deadline - time.monotonic(), 0)
+        if timeout <= 0:
+            return None
         try:
             message = self._messages.get(timeout=timeout)
-        except queue.Empty as exc:
-            raise CodexAppServerError(
-                "codex-app-server protocol response timed out",
-                stderr=self.stderr_text,
-                returncode=self.returncode,
-            ) from exc
+        except queue.Empty:
+            return None
         if message is self._EOF:
             raise CodexAppServerError(
                 "codex-app-server exited before completing the turn",
@@ -772,7 +774,9 @@ class CodexAppServerRuntime:
             read_deadline = min(deadline, now + self._read_timeout_s())
             if stall_timeout is not None and self._last_activity is not None:
                 read_deadline = min(read_deadline, self._last_activity + stall_timeout)
-            message = client.next_message(deadline=read_deadline)
+            message = client.poll_message(deadline=read_deadline)
+            if message is None:
+                continue
             if client._is_server_request(message):
                 self._consume_message(message, state=state)
                 client._reject_server_request(message)

--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import http.client
 import json
 import os
+import queue
 import shlex
+import socket
 import subprocess
+import threading
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from . import PromptRunResult, SessionHandle, SessionHealth, register
 
@@ -26,20 +34,406 @@ class CodexAppServerError(RuntimeError):
         self.returncode = returncode
 
 
+@dataclass
+class _RunState:
+    session_id: str | None = None
+    thread_id: str | None = None
+    turn_id: str | None = None
+    last_event: str | None = None
+    last_message: str | None = None
+    turn_count: int = 0
+    tokens: dict[str, int] = field(default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+    rate_limits: dict | None = None
+    output_parts: list[str] = field(default_factory=list)
+
+
+class _AppServerClient:
+    _EOF = object()
+
+    def __init__(
+        self,
+        *,
+        argv: list[str],
+        cwd: Path,
+        env: dict[str, str],
+        on_activity,
+    ):
+        self._next_request_id = 1
+        self._messages: queue.Queue[dict[str, Any] | object] = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._on_activity = on_activity
+        self._proc = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+        assert self._proc.stderr is not None
+        self._stdout_thread = threading.Thread(target=self._read_stdout, daemon=True)
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+
+    @property
+    def returncode(self) -> int | None:
+        return self._proc.poll()
+
+    @property
+    def stderr_text(self) -> str:
+        return "".join(self._stderr_lines)
+
+    def _read_stdout(self) -> None:
+        try:
+            assert self._proc.stdout is not None
+            for raw_line in self._proc.stdout:
+                self._on_activity()
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    self._messages.put({"method": "protocol/error", "params": {"message": f"non-JSON stdout: {line}"}})
+                    continue
+                if isinstance(payload, dict):
+                    self._messages.put(payload)
+                else:
+                    self._messages.put(
+                        {"method": "protocol/error", "params": {"message": f"non-object stdout: {line}"}}
+                    )
+        finally:
+            self._messages.put(self._EOF)
+
+    def _read_stderr(self) -> None:
+        assert self._proc.stderr is not None
+        for line in self._proc.stderr:
+            self._on_activity()
+            self._stderr_lines.append(line)
+
+    def send_request(self, method: str, params: dict[str, Any] | None = None) -> int:
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        payload = {
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        self._write(payload)
+        return request_id
+
+    def send_notification(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self._write({"method": method, "params": params or {}})
+
+    def send_response(self, request_id: Any, result: dict[str, Any]) -> None:
+        self._write({"id": request_id, "result": result})
+
+    def send_error_response(self, request_id: Any, message: str) -> None:
+        self._write({"id": request_id, "error": {"code": -32601, "message": message}})
+
+    def request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+        *,
+        timeout_s: float,
+        on_message,
+    ) -> dict[str, Any]:
+        request_id = self.send_request(method, params)
+        deadline = time.monotonic() + timeout_s
+        while True:
+            message = self.next_message(deadline=deadline)
+            if self._is_server_request(message):
+                on_message(message)
+                self._reject_server_request(message)
+                continue
+            if message.get("id") == request_id and ("result" in message or "error" in message):
+                if "error" in message:
+                    raise CodexAppServerError(self._jsonrpc_error_message(method=method, error=message.get("error")))
+                result = message.get("result")
+                if isinstance(result, dict):
+                    return result
+                return {}
+            on_message(message)
+
+    def next_message(self, *, deadline: float) -> dict[str, Any]:
+        timeout = max(deadline - time.monotonic(), 0)
+        if timeout <= 0:
+            raise CodexAppServerError(
+                "codex-app-server protocol response timed out",
+                stderr=self.stderr_text,
+                returncode=self.returncode,
+            )
+        try:
+            message = self._messages.get(timeout=timeout)
+        except queue.Empty as exc:
+            raise CodexAppServerError(
+                "codex-app-server protocol response timed out",
+                stderr=self.stderr_text,
+                returncode=self.returncode,
+            ) from exc
+        if message is self._EOF:
+            raise CodexAppServerError(
+                "codex-app-server exited before completing the turn",
+                stderr=self.stderr_text,
+                returncode=self.returncode,
+            )
+        assert isinstance(message, dict)
+        return message
+
+    def close(self) -> None:
+        if self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=2)
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        if self._proc.poll() is not None:
+            raise CodexAppServerError(
+                "codex-app-server exited before accepting protocol input",
+                stderr=self.stderr_text,
+                returncode=self.returncode,
+            )
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        self._proc.stdin.flush()
+        self._on_activity()
+
+    def _is_server_request(self, message: dict[str, Any]) -> bool:
+        return "id" in message and "method" in message and "result" not in message and "error" not in message
+
+    def _reject_server_request(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        method = str(message.get("method") or "")
+        if method in {"item/commandExecution/requestApproval", "item/fileChange/requestApproval"}:
+            self.send_response(request_id, {"decision": "cancel"})
+            return
+        self.send_error_response(request_id, f"Daedalus does not handle app-server request {method!r}")
+
+    def _jsonrpc_error_message(self, *, method: str, error: Any) -> str:
+        if isinstance(error, dict):
+            detail = error.get("message") or json.dumps(error, sort_keys=True)
+        else:
+            detail = str(error)
+        return f"codex-app-server request {method!r} failed: {detail}"
+
+
+class _WebSocketAppServerClient(_AppServerClient):
+    _WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        auth_token: str | None,
+        timeout_s: float,
+        on_activity,
+    ):
+        self._next_request_id = 1
+        self._messages: queue.Queue[dict[str, Any] | object] = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._on_activity = on_activity
+        self._closed = False
+        self._write_lock = threading.Lock()
+        self._socket = self._connect(endpoint=endpoint, auth_token=auth_token, timeout_s=timeout_s)
+        self._reader_thread = threading.Thread(target=self._read_websocket, daemon=True)
+        self._reader_thread.start()
+
+    @property
+    def returncode(self) -> int | None:
+        return None if not self._closed else 0
+
+    def close(self) -> None:
+        self._closed = True
+        try:
+            self._send_frame(opcode=0x8, payload=b"")
+        except OSError:
+            pass
+        try:
+            self._socket.close()
+        except OSError:
+            pass
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        if self._closed:
+            raise CodexAppServerError("codex-app-server websocket is closed", stderr=self.stderr_text)
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self._send_frame(opcode=0x1, payload=data)
+        self._on_activity()
+
+    def _connect(self, *, endpoint: str, auth_token: str | None, timeout_s: float) -> socket.socket:
+        parsed = urlparse(endpoint)
+        if parsed.scheme != "ws":
+            raise CodexAppServerError(f"external codex-app-server endpoint must use ws://, got {endpoint!r}")
+        if not parsed.hostname or not parsed.port:
+            raise CodexAppServerError(f"external codex-app-server endpoint requires host and port: {endpoint!r}")
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        sock = socket.create_connection((parsed.hostname, parsed.port), timeout=timeout_s)
+        sock.settimeout(timeout_s)
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        host = parsed.netloc
+        headers = [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+        ]
+        if auth_token:
+            headers.append(f"Authorization: Bearer {auth_token}")
+        request = "\r\n".join(headers) + "\r\n\r\n"
+        sock.sendall(request.encode("ascii"))
+        response = self._read_http_response(sock)
+        status_line = response.split("\r\n", 1)[0]
+        if " 101 " not in status_line:
+            raise CodexAppServerError(f"codex-app-server websocket handshake failed: {status_line}")
+        accept = base64.b64encode(hashlib.sha1((key + self._WS_GUID).encode("ascii")).digest()).decode("ascii")
+        response_headers = self._parse_http_headers(response)
+        if response_headers.get("sec-websocket-accept", "") != accept:
+            raise CodexAppServerError("codex-app-server websocket handshake returned an invalid accept key")
+        return sock
+
+    def _read_http_response(self, sock: socket.socket) -> str:
+        chunks: list[bytes] = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise CodexAppServerError("codex-app-server websocket closed during handshake")
+            chunks.append(chunk)
+            combined = b"".join(chunks)
+            if b"\r\n\r\n" in combined:
+                return combined.split(b"\r\n\r\n", 1)[0].decode("iso-8859-1")
+
+    def _parse_http_headers(self, response: str) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        for line in response.split("\r\n")[1:]:
+            if ":" not in line:
+                continue
+            name, value = line.split(":", 1)
+            headers[name.strip().lower()] = value.strip()
+        return headers
+
+    def _read_websocket(self) -> None:
+        text_parts: list[bytes] = []
+        try:
+            while not self._closed:
+                opcode, payload, fin = self._read_frame()
+                self._on_activity()
+                if opcode == 0x8:
+                    break
+                if opcode == 0x9:
+                    self._send_frame(opcode=0xA, payload=payload)
+                    continue
+                if opcode == 0xA:
+                    continue
+                if opcode == 0x1:
+                    text_parts = [payload]
+                elif opcode == 0x0 and text_parts:
+                    text_parts.append(payload)
+                else:
+                    continue
+                if not fin:
+                    continue
+                text = b"".join(text_parts).decode("utf-8")
+                text_parts = []
+                try:
+                    message = json.loads(text)
+                except json.JSONDecodeError:
+                    self._messages.put(
+                        {"method": "protocol/error", "params": {"message": f"non-JSON websocket frame: {text}"}}
+                    )
+                    continue
+                if isinstance(message, dict):
+                    self._messages.put(message)
+                else:
+                    self._messages.put(
+                        {"method": "protocol/error", "params": {"message": f"non-object websocket frame: {text}"}}
+                    )
+        except OSError as exc:
+            if not self._closed:
+                self._messages.put({"method": "protocol/error", "params": {"message": str(exc)}})
+        finally:
+            self._closed = True
+            self._messages.put(self._EOF)
+
+    def _read_frame(self) -> tuple[int, bytes, bool]:
+        header = self._recv_exact(2)
+        first, second = header[0], header[1]
+        fin = bool(first & 0x80)
+        opcode = first & 0x0F
+        masked = bool(second & 0x80)
+        length = second & 0x7F
+        if length == 126:
+            length = int.from_bytes(self._recv_exact(2), "big")
+        elif length == 127:
+            length = int.from_bytes(self._recv_exact(8), "big")
+        mask = self._recv_exact(4) if masked else b""
+        payload = self._recv_exact(length) if length else b""
+        if masked:
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        return opcode, payload, fin
+
+    def _send_frame(self, *, opcode: int, payload: bytes) -> None:
+        if len(payload) > 0x7FFFFFFFFFFFFFFF:
+            raise CodexAppServerError("websocket payload too large")
+        first = 0x80 | opcode
+        mask = os.urandom(4)
+        length = len(payload)
+        if length < 126:
+            header = bytes([first, 0x80 | length])
+        elif length <= 0xFFFF:
+            header = bytes([first, 0x80 | 126]) + length.to_bytes(2, "big")
+        else:
+            header = bytes([first, 0x80 | 127]) + length.to_bytes(8, "big")
+        masked_payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        with self._write_lock:
+            self._socket.sendall(header + mask + masked_payload)
+
+    def _recv_exact(self, size: int) -> bytes:
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = self._socket.recv(remaining)
+            if not chunk:
+                raise OSError("codex-app-server websocket closed")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+
 @register("codex-app-server")
 class CodexAppServerRuntime:
     def __init__(self, cfg: dict, *, run, run_json=None):
         del run, run_json
         self._cfg = cfg
         self._command = cfg.get("command") or "codex app-server"
+        self._mode = str(cfg.get("mode") or ("external" if cfg.get("endpoint") else "managed")).strip()
+        self._endpoint = str(cfg.get("endpoint") or "").strip() or None
+        self._healthcheck_path = str(cfg.get("healthcheck_path") or "/readyz").strip() or "/readyz"
+        self._ws_token = str(cfg.get("ws_token") or "").strip() or None
+        self._ws_token_env = str(cfg.get("ws_token_env") or "").strip() or None
+        self._ws_token_file = str(cfg.get("ws_token_file") or "").strip() or None
+        self._ephemeral = self._bool_config(cfg.get("ephemeral"), default=False)
         self._turn_timeout_ms = int(cfg.get("turn_timeout_ms") or 3600000)
         self._read_timeout_ms = int(cfg.get("read_timeout_ms") or 5000)
         self._stall_timeout_ms = int(cfg.get("stall_timeout_ms") or 300000)
-        self._approval_policy = str(cfg.get("approval_policy") or "").strip() or None
+        self._approval_policy = cfg.get("approval_policy")
         self._thread_sandbox = str(cfg.get("thread_sandbox") or "").strip() or None
-        self._turn_sandbox_policy = str(cfg.get("turn_sandbox_policy") or "").strip() or None
+        self._turn_sandbox_policy = cfg.get("turn_sandbox_policy")
         self._last_activity: float | None = None
         self._last_result: PromptRunResult | None = None
+        self._resume_thread_ids: dict[str, str] = {}
 
     def _record_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -58,7 +452,12 @@ class CodexAppServerRuntime:
         model: str,
         resume_session_id: str | None = None,
     ) -> SessionHandle:
-        del worktree, model, resume_session_id
+        del model
+        key = self._session_key(worktree=worktree, session_name=session_name)
+        if resume_session_id:
+            self._resume_thread_ids[key] = resume_session_id
+        else:
+            self._resume_thread_ids.pop(key, None)
         return SessionHandle(record_id=None, session_id=None, name=session_name)
 
     def run_prompt(
@@ -88,51 +487,64 @@ class CodexAppServerRuntime:
             "DAEDALUS_MODEL": model,
             "DAEDALUS_SESSION_NAME": session_name,
         }
-        if self._approval_policy:
-            env["DAEDALUS_APPROVAL_POLICY"] = self._approval_policy
+        approval_policy = self._approval_policy_value()
+        if approval_policy:
+            env["DAEDALUS_APPROVAL_POLICY"] = (
+                json.dumps(approval_policy) if isinstance(approval_policy, dict) else str(approval_policy)
+            )
         if self._thread_sandbox:
             env["DAEDALUS_THREAD_SANDBOX"] = self._thread_sandbox
         if self._turn_sandbox_policy:
-            env["DAEDALUS_TURN_SANDBOX_POLICY"] = self._turn_sandbox_policy
+            env["DAEDALUS_TURN_SANDBOX_POLICY"] = (
+                json.dumps(self._turn_sandbox_policy)
+                if isinstance(self._turn_sandbox_policy, dict)
+                else str(self._turn_sandbox_policy)
+            )
 
         self._record_activity()
-        argv = self._command_argv()
-        proc = subprocess.Popen(
-            argv,
-            cwd=str(worktree),
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env={**os.environ, **env},
-        )
-        assert proc.stdin is not None
-        assert proc.stdout is not None
-        assert proc.stderr is not None
+        client = self._build_client(worktree=worktree, env={**os.environ, **env})
+        state = _RunState()
         try:
-            stdout, stderr = proc.communicate(prompt, timeout=max(self._turn_timeout_ms / 1000, 1))
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            stdout, stderr = proc.communicate()
-            result = self._parse_event_stream(stdout, stderr=stderr)
+            self._initialize(client=client, state=state)
+            resume_thread_id = self._resume_thread_id(worktree=worktree, session_name=session_name)
+            if resume_thread_id:
+                state.thread_id = resume_thread_id
+                state.session_id = resume_thread_id
+                thread_result = client.request(
+                    "thread/resume",
+                    self._thread_resume_params(thread_id=resume_thread_id, worktree=worktree, model=model),
+                    timeout_s=self._read_timeout_s(),
+                    on_message=lambda message: self._consume_message(message, state=state),
+                )
+            else:
+                thread_result = client.request(
+                    "thread/start",
+                    self._thread_start_params(worktree=worktree, model=model),
+                    timeout_s=self._read_timeout_s(),
+                    on_message=lambda message: self._consume_message(message, state=state),
+                )
+            self._consume_thread_start_response(thread_result, state=state)
+            turn_result = client.request(
+                "turn/start",
+                self._turn_start_params(worktree=worktree, thread_id=state.thread_id, prompt=prompt, model=model),
+                timeout_s=self._read_timeout_s(),
+                on_message=lambda message: self._consume_message(message, state=state),
+            )
+            self._consume_turn_response(turn_result, state=state)
+            result = self._read_turn_to_completion(client=client, state=state)
             self._last_result = result
-            raise CodexAppServerError(
-                "codex-app-server turn timed out",
-                result=result,
-                stderr=stderr,
-                returncode=None,
-            )
-        self._record_activity()
-        result = self._parse_event_stream(stdout, stderr=stderr)
-        self._last_result = result
-        if proc.returncode != 0:
-            raise CodexAppServerError(
-                self._failure_detail(result=result, stderr=stderr, returncode=proc.returncode),
-                result=result,
-                stderr=stderr,
-                returncode=proc.returncode,
-            )
-        return result
+            return result
+        except CodexAppServerError as exc:
+            result = exc.result or self._result_from_state(state)
+            self._last_result = result
+            exc.result = result
+            if exc.stderr is None:
+                exc.stderr = client.stderr_text
+            if exc.returncode is None:
+                exc.returncode = client.returncode
+            raise
+        finally:
+            client.close()
 
     def _command_argv(self) -> list[str]:
         if isinstance(self._command, list):
@@ -143,71 +555,347 @@ class CodexAppServerRuntime:
             raise RuntimeError("codex-app-server runtime requires a non-empty command")
         return argv
 
-    def _parse_event_stream(self, stdout: str, *, stderr: str = "") -> PromptRunResult:
-        session_id = None
-        thread_id = None
-        turn_id = None
-        last_event = None
-        last_message = None
-        turn_count = 0
-        rate_limits = None
-        usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-        output_parts: list[str] = []
+    def _build_client(self, *, worktree: Path, env: dict[str, str]) -> _AppServerClient:
+        if self._mode == "managed":
+            return _AppServerClient(
+                argv=self._command_argv(),
+                cwd=worktree,
+                env=env,
+                on_activity=self._record_activity,
+            )
+        if self._mode == "external":
+            if not self._endpoint:
+                raise CodexAppServerError("external codex-app-server runtime requires endpoint: ws://HOST:PORT")
+            self._check_external_ready()
+            return _WebSocketAppServerClient(
+                endpoint=self._endpoint,
+                auth_token=self._resolve_ws_token(),
+                timeout_s=self._read_timeout_s(),
+                on_activity=self._record_activity,
+            )
+        raise CodexAppServerError("codex-app-server mode must be one of ['managed', 'external']")
 
-        for source_name, stream_text in (("stdout", stdout), ("stderr", stderr)):
-            for raw_line in stream_text.splitlines():
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    if source_name == "stdout":
-                        output_parts.append(raw_line)
-                    elif not last_message:
-                        last_message = line
-                    continue
-                if not isinstance(payload, dict):
-                    continue
-                event_type = str(payload.get("event") or payload.get("type") or "").strip()
-                if event_type:
-                    last_event = event_type
-                if event_type == "session_started":
-                    session_id = str(payload.get("session_id") or payload.get("sessionId") or session_id or "") or session_id
-                    thread_id = str(payload.get("thread_id") or payload.get("threadId") or thread_id or "") or thread_id
-                elif event_type in {"turn_started", "turn_completed", "turn_failed", "turn_input_required"}:
-                    turn_id = str(payload.get("turn_id") or payload.get("turnId") or turn_id or "") or turn_id
-                    if event_type == "turn_started":
-                        turn_count += 1
-                if "message" in payload and isinstance(payload.get("message"), str):
-                    last_message = payload["message"]
-                elif "error" in payload and isinstance(payload.get("error"), str):
-                    last_message = payload["error"]
-                if "text" in payload and isinstance(payload.get("text"), str):
-                    output_parts.append(payload["text"])
-                if "output" in payload and isinstance(payload.get("output"), str):
-                    output_parts.append(payload["output"])
-                usage_payload = payload.get("usage") or payload.get("token_usage")
-                if isinstance(usage_payload, dict):
-                    usage = self._coerce_usage(usage_payload, current=usage)
-                if isinstance(payload.get("rate_limits"), dict):
-                    rate_limits = payload.get("rate_limits")
-                elif isinstance(payload.get("rate_limits_snapshot"), dict):
-                    rate_limits = payload.get("rate_limits_snapshot")
-                elif isinstance(payload.get("rate_limit"), dict):
-                    rate_limits = payload.get("rate_limit")
+    def _session_key(self, *, worktree: Path, session_name: str) -> str:
+        return f"{worktree.expanduser().resolve(strict=False)}::{session_name}"
 
-        return PromptRunResult(
-            output="\n".join(part for part in output_parts if part).strip() + ("\n" if output_parts else ""),
-            session_id=session_id,
-            thread_id=thread_id,
-            turn_id=turn_id,
-            last_event=last_event,
-            last_message=last_message,
-            turn_count=turn_count,
-            tokens=usage,
-            rate_limits=rate_limits,
+    def _resume_thread_id(self, *, worktree: Path, session_name: str) -> str | None:
+        return self._resume_thread_ids.get(self._session_key(worktree=worktree, session_name=session_name))
+
+    def _resolve_ws_token(self) -> str | None:
+        if self._ws_token:
+            return self._ws_token
+        if self._ws_token_env:
+            return os.environ.get(self._ws_token_env, "").strip() or None
+        if self._ws_token_file:
+            return Path(self._ws_token_file).expanduser().read_text(encoding="utf-8").strip() or None
+        return None
+
+    def _check_external_ready(self) -> None:
+        if not self._endpoint:
+            return
+        ok, reason = self._external_healthcheck()
+        if not ok:
+            raise CodexAppServerError(f"external codex-app-server is not ready: {reason}")
+
+    def _external_healthcheck(self) -> tuple[bool, str | None]:
+        if not self._endpoint:
+            return False, "missing endpoint"
+        parsed = urlparse(self._endpoint)
+        if parsed.scheme != "ws":
+            return False, f"unsupported endpoint scheme {parsed.scheme!r}"
+        if not parsed.hostname or not parsed.port:
+            return False, "endpoint requires host and port"
+        connection = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=self._read_timeout_s())
+        try:
+            connection.request("GET", self._healthcheck_path)
+            response = connection.getresponse()
+            response.read()
+        except OSError as exc:
+            return False, str(exc)
+        finally:
+            connection.close()
+        if response.status == 200:
+            return True, None
+        return False, f"GET {self._healthcheck_path} returned HTTP {response.status}"
+
+    def _initialize(self, *, client: _AppServerClient, state: _RunState) -> None:
+        client.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "daedalus",
+                    "title": "Daedalus",
+                    "version": "0.1.0",
+                },
+            },
+            timeout_s=self._read_timeout_s(),
+            on_message=lambda message: self._consume_message(message, state=state),
         )
+        client.send_notification("initialized", {})
+
+    def _thread_start_params(self, *, worktree: Path, model: str) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "cwd": str(worktree),
+            "ephemeral": self._ephemeral,
+            "serviceName": "daedalus",
+        }
+        approval_policy = self._approval_policy_value()
+        if approval_policy is not None:
+            params["approvalPolicy"] = approval_policy
+        if self._thread_sandbox:
+            params["sandbox"] = self._thread_sandbox
+        if model:
+            params["model"] = model
+        return params
+
+    def _thread_resume_params(self, *, thread_id: str, worktree: Path, model: str) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "threadId": thread_id,
+            "cwd": str(worktree),
+            "serviceName": "daedalus",
+        }
+        approval_policy = self._approval_policy_value()
+        if approval_policy is not None:
+            params["approvalPolicy"] = approval_policy
+        if self._thread_sandbox:
+            params["sandbox"] = self._thread_sandbox
+        if model:
+            params["model"] = model
+        return params
+
+    def _turn_start_params(self, *, worktree: Path, thread_id: str | None, prompt: str, model: str) -> dict[str, Any]:
+        if not thread_id:
+            raise CodexAppServerError("codex-app-server did not return a thread id")
+        params: dict[str, Any] = {
+            "threadId": thread_id,
+            "cwd": str(worktree),
+            "input": [{"type": "text", "text": prompt}],
+        }
+        approval_policy = self._approval_policy_value()
+        if approval_policy is not None:
+            params["approvalPolicy"] = approval_policy
+        sandbox_policy = self._sandbox_policy(worktree=worktree)
+        if sandbox_policy is not None:
+            params["sandboxPolicy"] = sandbox_policy
+        if model:
+            params["model"] = model
+        return params
+
+    def _approval_policy_value(self) -> str | dict | None:
+        if self._approval_policy in (None, ""):
+            return None
+        if isinstance(self._approval_policy, dict):
+            return self._approval_policy
+        value = str(self._approval_policy).strip()
+        allowed = {"untrusted", "on-failure", "on-request", "never"}
+        if value not in allowed:
+            raise CodexAppServerError(
+                f"codex-app-server approval_policy must be one of {sorted(allowed)}, got {value!r}"
+            )
+        return value
+
+    def _bool_config(self, value: Any, *, default: bool) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "off"}:
+                return False
+        raise CodexAppServerError(f"expected boolean config value, got {value!r}")
+
+    def _sandbox_policy(self, *, worktree: Path) -> dict[str, Any] | None:
+        raw = self._turn_sandbox_policy
+        if raw in (None, "", "auto"):
+            return None
+        if isinstance(raw, dict):
+            return raw
+        value = str(raw).strip()
+        if value == "danger-full-access":
+            return {"type": "dangerFullAccess"}
+        if value == "read-only":
+            return {"type": "readOnly"}
+        if value == "workspace-write":
+            return {"type": "workspaceWrite", "writableRoots": [str(worktree)]}
+        raise CodexAppServerError(
+            "codex-app-server turn_sandbox_policy must be one of "
+            "['read-only', 'workspace-write', 'danger-full-access'] or a SandboxPolicy object"
+        )
+
+    def _consume_thread_start_response(self, payload: dict[str, Any], *, state: _RunState) -> None:
+        thread = payload.get("thread")
+        if isinstance(thread, dict):
+            state.thread_id = str(thread.get("id") or state.thread_id or "") or state.thread_id
+        state.thread_id = (
+            str(payload.get("threadId") or payload.get("thread_id") or state.thread_id or "") or state.thread_id
+        )
+        state.session_id = state.thread_id
+
+    def _consume_turn_response(self, payload: dict[str, Any], *, state: _RunState) -> None:
+        turn = payload.get("turn")
+        if isinstance(turn, dict):
+            state.turn_id = str(turn.get("id") or state.turn_id or "") or state.turn_id
+            self._record_turn_failure_if_present(turn, state=state)
+        state.turn_id = str(payload.get("turnId") or payload.get("turn_id") or state.turn_id or "") or state.turn_id
+
+    def _read_turn_to_completion(self, *, client: _AppServerClient, state: _RunState) -> PromptRunResult:
+        deadline = time.monotonic() + max(self._turn_timeout_ms / 1000, 1)
+        stall_timeout = self._stall_timeout_ms / 1000 if self._stall_timeout_ms > 0 else None
+        while True:
+            now = time.monotonic()
+            if now >= deadline:
+                self._interrupt_turn(client=client, state=state)
+                result = self._result_from_state(state)
+                raise CodexAppServerError(
+                    "codex-app-server turn timed out",
+                    result=result,
+                    stderr=client.stderr_text,
+                    returncode=client.returncode,
+                )
+            if (
+                stall_timeout is not None
+                and self._last_activity is not None
+                and now - self._last_activity >= stall_timeout
+            ):
+                self._interrupt_turn(client=client, state=state)
+                result = self._result_from_state(state)
+                raise CodexAppServerError(
+                    "codex-app-server turn stalled",
+                    result=result,
+                    stderr=client.stderr_text,
+                    returncode=client.returncode,
+                )
+
+            read_deadline = min(deadline, now + self._read_timeout_s())
+            if stall_timeout is not None and self._last_activity is not None:
+                read_deadline = min(read_deadline, self._last_activity + stall_timeout)
+            message = client.next_message(deadline=read_deadline)
+            if client._is_server_request(message):
+                self._consume_message(message, state=state)
+                client._reject_server_request(message)
+                continue
+            completed = self._consume_message(message, state=state)
+            if completed:
+                return self._result_from_state(state)
+
+    def _interrupt_turn(self, *, client: _AppServerClient, state: _RunState) -> None:
+        if not state.thread_id or not state.turn_id:
+            return
+        try:
+            client.request(
+                "turn/interrupt",
+                {"threadId": state.thread_id, "turnId": state.turn_id},
+                timeout_s=self._read_timeout_s(),
+                on_message=lambda message: self._consume_message(message, state=state),
+            )
+        except CodexAppServerError:
+            return
+
+    def _consume_message(self, message: dict[str, Any], *, state: _RunState) -> bool:
+        method = str(message.get("method") or "").strip()
+        if not method:
+            return False
+        params = message.get("params")
+        if not isinstance(params, dict):
+            params = {}
+        state.last_event = method
+
+        if method in {"protocol/error", "error"}:
+            detail = params.get("error")
+            if isinstance(detail, dict):
+                message_text = str(detail.get("message") or json.dumps(detail, sort_keys=True))
+            else:
+                message_text = str(params.get("message") or detail or "codex-app-server turn failed")
+            state.last_message = message_text
+            if method == "error" and params.get("willRetry") is True:
+                return False
+            raise CodexAppServerError(f"codex-app-server failed: {message_text}", result=self._result_from_state(state))
+
+        if method == "thread/started":
+            self._consume_thread_start_response(params, state=state)
+        elif method == "turn/started":
+            state.turn_count += 1
+            self._consume_turn_response(params, state=state)
+        elif method in {"agent/message_delta", "item/agentMessage/delta"}:
+            delta = params.get("delta")
+            if isinstance(delta, str):
+                state.output_parts.append(delta)
+                state.last_message = delta
+        elif method in {
+            "reasoning/text_delta",
+            "reasoning/summary_text_delta",
+            "plan/delta",
+            "item/reasoning/textDelta",
+            "item/reasoning/summaryTextDelta",
+            "item/plan/delta",
+        }:
+            delta = params.get("delta")
+            if isinstance(delta, str):
+                state.last_message = delta
+        elif method == "thread/tokenUsage/updated":
+            state.thread_id = str(params.get("threadId") or state.thread_id or "") or state.thread_id
+            state.turn_id = str(params.get("turnId") or state.turn_id or "") or state.turn_id
+            usage = params.get("tokenUsage")
+            if isinstance(usage, dict):
+                state.tokens = self._coerce_usage(usage, current=state.tokens)
+        elif method == "account/rateLimits/updated":
+            rate_limits = params.get("rateLimits")
+            if isinstance(rate_limits, dict):
+                state.rate_limits = rate_limits
+        elif method == "turn/completed":
+            self._consume_turn_response(params, state=state)
+            turn = params.get("turn")
+            if isinstance(turn, dict):
+                failure = self._turn_failure_message(turn)
+                if failure:
+                    state.last_message = failure
+                    raise CodexAppServerError(
+                        f"codex-app-server failed: {failure}",
+                        result=self._result_from_state(state),
+                    )
+            return True
+        elif self._is_request_notification(method):
+            state.last_message = f"unsupported app-server request: {method}"
+        return False
+
+    def _is_request_notification(self, method: str) -> bool:
+        return method.startswith("item/") or method.startswith("mcpServer/")
+
+    def _record_turn_failure_if_present(self, turn: dict[str, Any], *, state: _RunState) -> None:
+        failure = self._turn_failure_message(turn)
+        if failure:
+            state.last_message = failure
+
+    def _turn_failure_message(self, turn: dict[str, Any]) -> str | None:
+        error = turn.get("error")
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"])
+        status = str(turn.get("status") or "").strip().lower()
+        if status in {"failed", "interrupted", "cancelled", "canceled"}:
+            return f"turn status {status}"
+        return None
+
+    def _result_from_state(self, state: _RunState) -> PromptRunResult:
+        output = "".join(state.output_parts).strip()
+        if output:
+            output += "\n"
+        return PromptRunResult(
+            output=output,
+            session_id=state.session_id or state.thread_id,
+            thread_id=state.thread_id,
+            turn_id=state.turn_id,
+            last_event=state.last_event,
+            last_message=state.last_message,
+            turn_count=state.turn_count,
+            tokens=state.tokens,
+            rate_limits=state.rate_limits,
+        )
+
+    def _read_timeout_s(self) -> float:
+        return max(self._read_timeout_ms / 1000, 1)
 
     def _failure_detail(self, *, result: PromptRunResult, stderr: str, returncode: int) -> str:
         if result.last_message:
@@ -220,6 +908,11 @@ class CodexAppServerRuntime:
         return f"codex-app-server exited with code {returncode}"
 
     def _coerce_usage(self, payload: dict[str, Any], *, current: dict[str, int]) -> dict[str, int]:
+        if isinstance(payload.get("total"), dict):
+            payload = payload["total"]
+        elif isinstance(payload.get("last"), dict):
+            payload = payload["last"]
+
         input_tokens = payload.get("input_tokens")
         if input_tokens is None:
             input_tokens = payload.get("inputTokens")
@@ -259,6 +952,9 @@ class CodexAppServerRuntime:
         now_epoch: int | None = None,
     ) -> SessionHealth:
         del session_meta, worktree, now_epoch
+        if self._mode == "external":
+            ok, reason = self._external_healthcheck()
+            return SessionHealth(healthy=ok, reason=reason, last_used_at=None)
         return SessionHealth(healthy=True, reason=None, last_used_at=None)
 
     def close_session(self, *, worktree: Path, session_name: str) -> None:

--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -52,6 +52,8 @@ DAEDALUS_TEMPLATE_UNIT_FILENAMES = {
 }
 
 DAEDALUS_INSTANCE_ID_FORMAT = "daedalus-{mode}-{workspace}"
+CODEX_APP_SERVER_SERVICE_PREFIX = "daedalus-codex-app-server"
+DEFAULT_CODEX_APP_SERVER_LISTEN = "ws://127.0.0.1:4500"
 
 
 def _instance_id_for(*, service_mode: str, workspace: str) -> str:
@@ -262,6 +264,40 @@ def _render_template_unit(*, mode: str) -> str:
             f"--project-key %i --instance-id daedalus-{mode}-%i "
             f"--interval-seconds 30 --service-mode {mode} --json"
         ),
+        "Restart=always",
+        "RestartSec=5",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+        "",
+    ])
+
+
+def _codex_app_server_service_name(*, workflow_root: Path, service_name: str | None = None) -> str:
+    if service_name:
+        return service_name if service_name.endswith(".service") else f"{service_name}.service"
+    return f"{CODEX_APP_SERVER_SERVICE_PREFIX}@{workflow_root.name}.service"
+
+
+def _codex_app_server_unit_path(service_name: str) -> Path:
+    return _systemd_user_dir() / service_name
+
+
+def _render_codex_app_server_unit(*, listen: str, codex_command: str = "codex") -> str:
+    service_path = os.environ.get("PATH") or "/usr/local/bin:/usr/bin:/bin"
+    command_parts = shlex.split(str(codex_command).strip() or "codex")
+    exec_start = shlex.join(["/usr/bin/env", *command_parts, "app-server", "--listen", listen])
+    return "\n".join([
+        "[Unit]",
+        "Description=Daedalus Codex app-server (workspace=%i)",
+        "After=default.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        "WorkingDirectory=%h",
+        f"Environment=PATH={service_path}",
+        "Environment=PYTHONUNBUFFERED=1",
+        f"ExecStart={exec_start}",
         "Restart=always",
         "RestartSec=5",
         "",
@@ -539,6 +575,142 @@ def service_up(
         "service_enable": enable_result,
         "service_start": start_result,
         "service_status": service_status_result,
+    }
+
+
+def codex_app_server_install(
+    *,
+    workflow_root: Path,
+    listen: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
+    service_name: str | None = None,
+    codex_command: str = "codex",
+) -> dict[str, Any]:
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    unit_path = _codex_app_server_unit_path(resolved_service_name)
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(
+        _render_codex_app_server_unit(listen=listen, codex_command=codex_command),
+        encoding="utf-8",
+    )
+    reload_result = _run_systemctl("daemon-reload")
+    return {
+        "ok": reload_result.get("ok", False),
+        "action": "install",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "unit_path": str(unit_path),
+        "listen": listen,
+        "codex_command": codex_command,
+        "daemon_reload": reload_result,
+    }
+
+
+def codex_app_server_up(
+    *,
+    workflow_root: Path,
+    listen: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
+    service_name: str | None = None,
+    codex_command: str = "codex",
+) -> dict[str, Any]:
+    install_result = codex_app_server_install(
+        workflow_root=workflow_root,
+        listen=listen,
+        service_name=service_name,
+        codex_command=codex_command,
+    )
+    if not install_result.get("ok"):
+        daemon_reload = install_result.get("daemon_reload") or {}
+        raise DaedalusCommandError(
+            "unable to install codex-app-server service: "
+            f"{daemon_reload.get('stderr') or daemon_reload.get('stdout') or 'daemon-reload failed'}"
+        )
+    resolved_service_name = str(install_result["service_name"])
+    enable_result = _run_systemctl("enable", resolved_service_name)
+    if not enable_result.get("ok"):
+        raise DaedalusCommandError(
+            "unable to enable codex-app-server service: "
+            f"{enable_result.get('stderr') or enable_result.get('stdout') or enable_result.get('returncode')}"
+        )
+    start_result = _run_systemctl("start", resolved_service_name)
+    if not start_result.get("ok"):
+        raise DaedalusCommandError(
+            "unable to start codex-app-server service: "
+            f"{start_result.get('stderr') or start_result.get('stdout') or start_result.get('returncode')}"
+        )
+    return {
+        "ok": True,
+        "action": "up",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "listen": listen,
+        "install": install_result,
+        "enable": enable_result,
+        "start": start_result,
+        "status": codex_app_server_status(workflow_root=workflow_root, service_name=resolved_service_name),
+    }
+
+
+def codex_app_server_down(
+    *,
+    workflow_root: Path,
+    service_name: str | None = None,
+) -> dict[str, Any]:
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    stop_result = _run_systemctl("stop", resolved_service_name)
+    disable_result = _run_systemctl("disable", resolved_service_name)
+    return {
+        "ok": stop_result.get("ok", False) or disable_result.get("ok", False),
+        "action": "down",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "stop": stop_result,
+        "disable": disable_result,
+        "status": codex_app_server_status(workflow_root=workflow_root, service_name=resolved_service_name),
+    }
+
+
+def codex_app_server_status(
+    *,
+    workflow_root: Path,
+    service_name: str | None = None,
+) -> dict[str, Any]:
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    unit_path = _codex_app_server_unit_path(resolved_service_name)
+    active = _run_systemctl("is-active", resolved_service_name)
+    enabled = _run_systemctl("is-enabled", resolved_service_name)
+    show = _run_systemctl(
+        "show",
+        "--property=Id,Names,LoadState,ActiveState,SubState,UnitFileState,FragmentPath,ExecMainPID,ExecMainStatus,Result",
+        resolved_service_name,
+    )
+    props: dict[str, Any] = {}
+    if show.get("ok") and show.get("stdout"):
+        for line in show["stdout"].splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                props[key] = value
+    return {
+        "ok": active.get("ok", False),
+        "action": "status",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "unit_path": str(unit_path),
+        "installed": unit_path.exists(),
+        "active": active.get("stdout") or ("active" if active.get("ok") else "unknown"),
+        "enabled": enabled.get("stdout") or ("enabled" if enabled.get("ok") else "unknown"),
+        "properties": props,
+        "active_check": active,
+        "enabled_check": enabled,
+        "show": show,
     }
 
 
@@ -2153,6 +2325,47 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     bootstrap_cmd.add_argument("--json", action="store_true")
     bootstrap_cmd.set_defaults(handler=cmd_bootstrap_workflow, func=run_cli_command)
 
+    codex_cmd = sub.add_parser(
+        "codex-app-server",
+        help="Install and control the shared Codex app-server systemd user service.",
+    )
+    codex_sub = codex_cmd.add_subparsers(dest="codex_app_server_command")
+    codex_sub.required = True
+
+    codex_install_cmd = codex_sub.add_parser("install", help="Write the Codex app-server user unit.")
+    codex_install_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_install_cmd.add_argument("--listen", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
+    codex_install_cmd.add_argument("--service-name")
+    codex_install_cmd.add_argument("--codex-command", default="codex")
+    codex_install_cmd.add_argument("--json", action="store_true")
+    codex_install_cmd.set_defaults(func=run_cli_command)
+
+    codex_up_cmd = codex_sub.add_parser("up", help="Install, enable, and start the Codex app-server user unit.")
+    codex_up_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_up_cmd.add_argument("--listen", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
+    codex_up_cmd.add_argument("--service-name")
+    codex_up_cmd.add_argument("--codex-command", default="codex")
+    codex_up_cmd.add_argument("--json", action="store_true")
+    codex_up_cmd.set_defaults(func=run_cli_command)
+
+    codex_status_cmd = codex_sub.add_parser("status", help="Show Codex app-server user unit status.")
+    codex_status_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_status_cmd.add_argument("--service-name")
+    codex_status_cmd.add_argument("--json", action="store_true")
+    codex_status_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    codex_status_cmd.set_defaults(func=run_cli_command)
+
+    codex_down_cmd = codex_sub.add_parser("down", help="Stop and disable the Codex app-server user unit.")
+    codex_down_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_down_cmd.add_argument("--service-name")
+    codex_down_cmd.add_argument("--json", action="store_true")
+    codex_down_cmd.set_defaults(func=run_cli_command)
+
     return parser
 
 
@@ -2238,7 +2451,13 @@ def _resolve_format(format_arg: str | None, json_flag: bool | None) -> str:
 def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     workflow_root = Path(args.workflow_root).resolve() if hasattr(args, "workflow_root") else None
     daedalus = _load_daedalus_module(workflow_root) if workflow_root is not None else None
-    if workflow_root is not None and daedalus is not None and getattr(args, "daedalus_command", None):
+    eventless_commands = {"codex-app-server"}
+    if (
+        workflow_root is not None
+        and daedalus is not None
+        and getattr(args, "daedalus_command", None)
+        and args.daedalus_command not in eventless_commands
+    ):
         _record_operator_command_event(workflow_root=workflow_root, args=args, daedalus=daedalus)
     command = getattr(args, "daedalus_command", None)
     project_key_commands = {"init", "start", "service-install", "service-up", "service-loop", "run-shadow", "run-active"}
@@ -2361,6 +2580,33 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
             service_mode=args.service_mode,
             lines=args.lines,
         )
+    if args.daedalus_command == "codex-app-server":
+        action = args.codex_app_server_command
+        if action == "install":
+            return codex_app_server_install(
+                workflow_root=workflow_root,
+                listen=args.listen,
+                service_name=args.service_name,
+                codex_command=args.codex_command,
+            )
+        if action == "up":
+            return codex_app_server_up(
+                workflow_root=workflow_root,
+                listen=args.listen,
+                service_name=args.service_name,
+                codex_command=args.codex_command,
+            )
+        if action == "status":
+            return codex_app_server_status(
+                workflow_root=workflow_root,
+                service_name=args.service_name,
+            )
+        if action == "down":
+            return codex_app_server_down(
+                workflow_root=workflow_root,
+                service_name=args.service_name,
+            )
+        raise DaedalusCommandError(f"unknown codex-app-server command: {action}")
     if args.daedalus_command == "ingest-live":
         return daedalus.ingest_live_legacy_status(workflow_root=workflow_root)
     if args.daedalus_command == "heartbeat":
@@ -2518,6 +2764,30 @@ def render_result(
     if command == "service-logs":
         output = result.get("stdout") or result.get("stderr") or ""
         return output if output else f"no logs for {result.get('service_name')}"
+    if command == "codex-app-server":
+        action = result.get("action")
+        if action == "install":
+            return (
+                f"codex-app-server installed service={result.get('service_name')} "
+                f"listen={result.get('listen')} ok={result.get('ok')}"
+            )
+        if action == "up":
+            status = result.get("status") or {}
+            return (
+                f"codex-app-server up service={result.get('service_name')} "
+                f"listen={result.get('listen')} active={status.get('active')} enabled={status.get('enabled')}"
+            )
+        if action == "down":
+            status = result.get("status") or {}
+            return (
+                f"codex-app-server down service={result.get('service_name')} "
+                f"active={status.get('active')} enabled={status.get('enabled')}"
+            )
+        if action == "status":
+            return (
+                f"codex-app-server service={result.get('service_name')} "
+                f"installed={result.get('installed')} active={result.get('active')} enabled={result.get('enabled')}"
+            )
     if command == "ingest-live":
         return f"ingested lane={result.get('lane_id')} actor={result.get('actor_id')}"
     if command == "heartbeat":

--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -1,4 +1,5 @@
 import argparse
+import http.client
 import importlib.util
 import io
 import json
@@ -10,6 +11,7 @@ import subprocess
 from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -54,6 +56,7 @@ DAEDALUS_TEMPLATE_UNIT_FILENAMES = {
 DAEDALUS_INSTANCE_ID_FORMAT = "daedalus-{mode}-{workspace}"
 CODEX_APP_SERVER_SERVICE_PREFIX = "daedalus-codex-app-server"
 DEFAULT_CODEX_APP_SERVER_LISTEN = "ws://127.0.0.1:4500"
+DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH = "/readyz"
 
 
 def _instance_id_for(*, service_mode: str, workspace: str) -> str:
@@ -283,10 +286,87 @@ def _codex_app_server_unit_path(service_name: str) -> Path:
     return _systemd_user_dir() / service_name
 
 
-def _render_codex_app_server_unit(*, listen: str, codex_command: str = "codex") -> str:
+def _absolute_secret_path(value: str, *, flag_name: str) -> str:
+    path = Path(str(value or "")).expanduser()
+    if not path.is_absolute():
+        raise DaedalusCommandError(f"{flag_name} must be an absolute path")
+    return str(path)
+
+
+def _codex_app_server_ws_auth_args(
+    *,
+    ws_token_file: str | None = None,
+    ws_token_sha256: str | None = None,
+    ws_shared_secret_file: str | None = None,
+    ws_issuer: str | None = None,
+    ws_audience: str | None = None,
+    ws_max_clock_skew_seconds: int | None = None,
+) -> tuple[list[str], dict[str, Any] | None]:
+    token_file = str(ws_token_file or "").strip()
+    token_sha256 = str(ws_token_sha256 or "").strip()
+    shared_secret_file = str(ws_shared_secret_file or "").strip()
+    issuer = str(ws_issuer or "").strip()
+    audience = str(ws_audience or "").strip()
+
+    if token_file and token_sha256:
+        raise DaedalusCommandError("use either --ws-token-file or --ws-token-sha256, not both")
+    if (token_file or token_sha256) and shared_secret_file:
+        raise DaedalusCommandError("capability-token and signed-bearer-token auth modes are mutually exclusive")
+    if (issuer or audience or ws_max_clock_skew_seconds is not None) and not shared_secret_file:
+        raise DaedalusCommandError("--ws-issuer, --ws-audience, and --ws-max-clock-skew-seconds require --ws-shared-secret-file")
+    if ws_max_clock_skew_seconds is not None and ws_max_clock_skew_seconds < 0:
+        raise DaedalusCommandError("--ws-max-clock-skew-seconds must be non-negative")
+
+    if token_file:
+        path = _absolute_secret_path(token_file, flag_name="--ws-token-file")
+        return (
+            ["--ws-auth", "capability-token", "--ws-token-file", path],
+            {"mode": "capability-token", "token_file": path},
+        )
+    if token_sha256:
+        return (
+            ["--ws-auth", "capability-token", "--ws-token-sha256", token_sha256],
+            {"mode": "capability-token", "token_sha256": token_sha256},
+        )
+    if shared_secret_file:
+        path = _absolute_secret_path(shared_secret_file, flag_name="--ws-shared-secret-file")
+        args = ["--ws-auth", "signed-bearer-token", "--ws-shared-secret-file", path]
+        summary: dict[str, Any] = {"mode": "signed-bearer-token", "shared_secret_file": path}
+        if issuer:
+            args.extend(["--ws-issuer", issuer])
+            summary["issuer"] = issuer
+        if audience:
+            args.extend(["--ws-audience", audience])
+            summary["audience"] = audience
+        if ws_max_clock_skew_seconds is not None:
+            args.extend(["--ws-max-clock-skew-seconds", str(ws_max_clock_skew_seconds)])
+            summary["max_clock_skew_seconds"] = ws_max_clock_skew_seconds
+        return args, summary
+    return [], None
+
+
+def _render_codex_app_server_unit(
+    *,
+    listen: str,
+    codex_command: str = "codex",
+    ws_token_file: str | None = None,
+    ws_token_sha256: str | None = None,
+    ws_shared_secret_file: str | None = None,
+    ws_issuer: str | None = None,
+    ws_audience: str | None = None,
+    ws_max_clock_skew_seconds: int | None = None,
+) -> str:
     service_path = os.environ.get("PATH") or "/usr/local/bin:/usr/bin:/bin"
     command_parts = shlex.split(str(codex_command).strip() or "codex")
-    exec_start = shlex.join(["/usr/bin/env", *command_parts, "app-server", "--listen", listen])
+    auth_args, _auth_summary = _codex_app_server_ws_auth_args(
+        ws_token_file=ws_token_file,
+        ws_token_sha256=ws_token_sha256,
+        ws_shared_secret_file=ws_shared_secret_file,
+        ws_issuer=ws_issuer,
+        ws_audience=ws_audience,
+        ws_max_clock_skew_seconds=ws_max_clock_skew_seconds,
+    )
+    exec_start = shlex.join(["/usr/bin/env", *command_parts, "app-server", "--listen", listen, *auth_args])
     return "\n".join([
         "[Unit]",
         "Description=Daedalus Codex app-server (workspace=%i)",
@@ -584,15 +664,38 @@ def codex_app_server_install(
     listen: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
     service_name: str | None = None,
     codex_command: str = "codex",
+    ws_token_file: str | None = None,
+    ws_token_sha256: str | None = None,
+    ws_shared_secret_file: str | None = None,
+    ws_issuer: str | None = None,
+    ws_audience: str | None = None,
+    ws_max_clock_skew_seconds: int | None = None,
 ) -> dict[str, Any]:
     resolved_service_name = _codex_app_server_service_name(
         workflow_root=workflow_root,
         service_name=service_name,
     )
+    _auth_args, auth_summary = _codex_app_server_ws_auth_args(
+        ws_token_file=ws_token_file,
+        ws_token_sha256=ws_token_sha256,
+        ws_shared_secret_file=ws_shared_secret_file,
+        ws_issuer=ws_issuer,
+        ws_audience=ws_audience,
+        ws_max_clock_skew_seconds=ws_max_clock_skew_seconds,
+    )
     unit_path = _codex_app_server_unit_path(resolved_service_name)
     unit_path.parent.mkdir(parents=True, exist_ok=True)
     unit_path.write_text(
-        _render_codex_app_server_unit(listen=listen, codex_command=codex_command),
+        _render_codex_app_server_unit(
+            listen=listen,
+            codex_command=codex_command,
+            ws_token_file=ws_token_file,
+            ws_token_sha256=ws_token_sha256,
+            ws_shared_secret_file=ws_shared_secret_file,
+            ws_issuer=ws_issuer,
+            ws_audience=ws_audience,
+            ws_max_clock_skew_seconds=ws_max_clock_skew_seconds,
+        ),
         encoding="utf-8",
     )
     reload_result = _run_systemctl("daemon-reload")
@@ -604,6 +707,7 @@ def codex_app_server_install(
         "unit_path": str(unit_path),
         "listen": listen,
         "codex_command": codex_command,
+        "ws_auth": auth_summary,
         "daemon_reload": reload_result,
     }
 
@@ -614,12 +718,24 @@ def codex_app_server_up(
     listen: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
     service_name: str | None = None,
     codex_command: str = "codex",
+    ws_token_file: str | None = None,
+    ws_token_sha256: str | None = None,
+    ws_shared_secret_file: str | None = None,
+    ws_issuer: str | None = None,
+    ws_audience: str | None = None,
+    ws_max_clock_skew_seconds: int | None = None,
 ) -> dict[str, Any]:
     install_result = codex_app_server_install(
         workflow_root=workflow_root,
         listen=listen,
         service_name=service_name,
         codex_command=codex_command,
+        ws_token_file=ws_token_file,
+        ws_token_sha256=ws_token_sha256,
+        ws_shared_secret_file=ws_shared_secret_file,
+        ws_issuer=ws_issuer,
+        ws_audience=ws_audience,
+        ws_max_clock_skew_seconds=ws_max_clock_skew_seconds,
     )
     if not install_result.get("ok"):
         daemon_reload = install_result.get("daemon_reload") or {}
@@ -649,7 +765,11 @@ def codex_app_server_up(
         "install": install_result,
         "enable": enable_result,
         "start": start_result,
-        "status": codex_app_server_status(workflow_root=workflow_root, service_name=resolved_service_name),
+        "status": codex_app_server_status(
+            workflow_root=workflow_root,
+            service_name=resolved_service_name,
+            endpoint=listen,
+        ),
     }
 
 
@@ -675,10 +795,117 @@ def codex_app_server_down(
     }
 
 
+def codex_app_server_restart(
+    *,
+    workflow_root: Path,
+    service_name: str | None = None,
+    endpoint: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
+    healthcheck_path: str = DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH,
+) -> dict[str, Any]:
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    restart_result = _run_systemctl("restart", resolved_service_name)
+    return {
+        "ok": restart_result.get("ok", False),
+        "action": "restart",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "restart": restart_result,
+        "status": codex_app_server_status(
+            workflow_root=workflow_root,
+            service_name=resolved_service_name,
+            endpoint=endpoint,
+            healthcheck_path=healthcheck_path,
+        ),
+    }
+
+
+def codex_app_server_logs(
+    *,
+    workflow_root: Path,
+    service_name: str | None = None,
+    lines: int = 50,
+) -> dict[str, Any]:
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    completed = subprocess.run(
+        ["journalctl", "--user", "-u", resolved_service_name, "-n", str(lines), "--no-pager", "-o", "cat"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "ok": completed.returncode == 0,
+        "action": "logs",
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+        "lines": lines,
+    }
+
+
+def _codex_app_server_readyz(
+    *,
+    endpoint: str,
+    healthcheck_path: str = DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH,
+) -> dict[str, Any]:
+    parsed = urlparse(str(endpoint or ""))
+    path = str(healthcheck_path or DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH)
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if parsed.scheme != "ws":
+        return {
+            "ok": None,
+            "checked": False,
+            "endpoint": endpoint,
+            "path": path,
+            "reason": "readyz probe requires ws:// endpoint",
+        }
+    if not parsed.hostname or not parsed.port:
+        return {
+            "ok": False,
+            "checked": True,
+            "endpoint": endpoint,
+            "path": path,
+            "reason": "endpoint requires host and port",
+        }
+    connection = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=2)
+    try:
+        connection.request("GET", path)
+        response = connection.getresponse()
+        response.read()
+    except OSError as exc:
+        return {
+            "ok": False,
+            "checked": True,
+            "endpoint": endpoint,
+            "path": path,
+            "reason": str(exc),
+        }
+    finally:
+        connection.close()
+    return {
+        "ok": response.status == 200,
+        "checked": True,
+        "endpoint": endpoint,
+        "path": path,
+        "status": response.status,
+        "reason": None if response.status == 200 else f"HTTP {response.status}",
+    }
+
+
 def codex_app_server_status(
     *,
     workflow_root: Path,
     service_name: str | None = None,
+    endpoint: str = DEFAULT_CODEX_APP_SERVER_LISTEN,
+    healthcheck_path: str = DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH,
 ) -> dict[str, Any]:
     resolved_service_name = _codex_app_server_service_name(
         workflow_root=workflow_root,
@@ -707,6 +934,7 @@ def codex_app_server_status(
         "installed": unit_path.exists(),
         "active": active.get("stdout") or ("active" if active.get("ok") else "unknown"),
         "enabled": enabled.get("stdout") or ("enabled" if enabled.get("ok") else "unknown"),
+        "ready": _codex_app_server_readyz(endpoint=endpoint, healthcheck_path=healthcheck_path),
         "properties": props,
         "active_check": active,
         "enabled_check": enabled,
@@ -2332,11 +2560,20 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     codex_sub = codex_cmd.add_subparsers(dest="codex_app_server_command")
     codex_sub.required = True
 
+    def _add_codex_app_server_auth_args(cmd: argparse.ArgumentParser) -> None:
+        cmd.add_argument("--ws-token-file", help="Absolute token file for capability-token WebSocket auth.")
+        cmd.add_argument("--ws-token-sha256", help="SHA-256 verifier for capability-token WebSocket auth.")
+        cmd.add_argument("--ws-shared-secret-file", help="Absolute secret file for signed-bearer-token WebSocket auth.")
+        cmd.add_argument("--ws-issuer")
+        cmd.add_argument("--ws-audience")
+        cmd.add_argument("--ws-max-clock-skew-seconds", type=int)
+
     codex_install_cmd = codex_sub.add_parser("install", help="Write the Codex app-server user unit.")
     codex_install_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     codex_install_cmd.add_argument("--listen", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
     codex_install_cmd.add_argument("--service-name")
     codex_install_cmd.add_argument("--codex-command", default="codex")
+    _add_codex_app_server_auth_args(codex_install_cmd)
     codex_install_cmd.add_argument("--json", action="store_true")
     codex_install_cmd.set_defaults(func=run_cli_command)
 
@@ -2345,12 +2582,15 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     codex_up_cmd.add_argument("--listen", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
     codex_up_cmd.add_argument("--service-name")
     codex_up_cmd.add_argument("--codex-command", default="codex")
+    _add_codex_app_server_auth_args(codex_up_cmd)
     codex_up_cmd.add_argument("--json", action="store_true")
     codex_up_cmd.set_defaults(func=run_cli_command)
 
     codex_status_cmd = codex_sub.add_parser("status", help="Show Codex app-server user unit status.")
     codex_status_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     codex_status_cmd.add_argument("--service-name")
+    codex_status_cmd.add_argument("--endpoint", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
+    codex_status_cmd.add_argument("--healthcheck-path", default=DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH)
     codex_status_cmd.add_argument("--json", action="store_true")
     codex_status_cmd.add_argument(
         "--format",
@@ -2365,6 +2605,21 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     codex_down_cmd.add_argument("--service-name")
     codex_down_cmd.add_argument("--json", action="store_true")
     codex_down_cmd.set_defaults(func=run_cli_command)
+
+    codex_restart_cmd = codex_sub.add_parser("restart", help="Restart the Codex app-server user unit.")
+    codex_restart_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_restart_cmd.add_argument("--service-name")
+    codex_restart_cmd.add_argument("--endpoint", default=DEFAULT_CODEX_APP_SERVER_LISTEN)
+    codex_restart_cmd.add_argument("--healthcheck-path", default=DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH)
+    codex_restart_cmd.add_argument("--json", action="store_true")
+    codex_restart_cmd.set_defaults(func=run_cli_command)
+
+    codex_logs_cmd = codex_sub.add_parser("logs", help="Show recent logs for the Codex app-server user unit.")
+    codex_logs_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_logs_cmd.add_argument("--service-name")
+    codex_logs_cmd.add_argument("--lines", type=int, default=50)
+    codex_logs_cmd.add_argument("--json", action="store_true")
+    codex_logs_cmd.set_defaults(func=run_cli_command)
 
     return parser
 
@@ -2588,6 +2843,12 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
                 listen=args.listen,
                 service_name=args.service_name,
                 codex_command=args.codex_command,
+                ws_token_file=args.ws_token_file,
+                ws_token_sha256=args.ws_token_sha256,
+                ws_shared_secret_file=args.ws_shared_secret_file,
+                ws_issuer=args.ws_issuer,
+                ws_audience=args.ws_audience,
+                ws_max_clock_skew_seconds=args.ws_max_clock_skew_seconds,
             )
         if action == "up":
             return codex_app_server_up(
@@ -2595,16 +2856,37 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
                 listen=args.listen,
                 service_name=args.service_name,
                 codex_command=args.codex_command,
+                ws_token_file=args.ws_token_file,
+                ws_token_sha256=args.ws_token_sha256,
+                ws_shared_secret_file=args.ws_shared_secret_file,
+                ws_issuer=args.ws_issuer,
+                ws_audience=args.ws_audience,
+                ws_max_clock_skew_seconds=args.ws_max_clock_skew_seconds,
             )
         if action == "status":
             return codex_app_server_status(
                 workflow_root=workflow_root,
                 service_name=args.service_name,
+                endpoint=args.endpoint,
+                healthcheck_path=args.healthcheck_path,
             )
         if action == "down":
             return codex_app_server_down(
                 workflow_root=workflow_root,
                 service_name=args.service_name,
+            )
+        if action == "restart":
+            return codex_app_server_restart(
+                workflow_root=workflow_root,
+                service_name=args.service_name,
+                endpoint=args.endpoint,
+                healthcheck_path=args.healthcheck_path,
+            )
+        if action == "logs":
+            return codex_app_server_logs(
+                workflow_root=workflow_root,
+                service_name=args.service_name,
+                lines=args.lines,
             )
         raise DaedalusCommandError(f"unknown codex-app-server command: {action}")
     if args.daedalus_command == "ingest-live":
@@ -2775,7 +3057,8 @@ def render_result(
             status = result.get("status") or {}
             return (
                 f"codex-app-server up service={result.get('service_name')} "
-                f"listen={result.get('listen')} active={status.get('active')} enabled={status.get('enabled')}"
+                f"listen={result.get('listen')} active={status.get('active')} "
+                f"enabled={status.get('enabled')} ready={(status.get('ready') or {}).get('ok')}"
             )
         if action == "down":
             status = result.get("status") or {}
@@ -2783,10 +3066,22 @@ def render_result(
                 f"codex-app-server down service={result.get('service_name')} "
                 f"active={status.get('active')} enabled={status.get('enabled')}"
             )
+        if action == "restart":
+            status = result.get("status") or {}
+            return (
+                f"codex-app-server restart service={result.get('service_name')} "
+                f"ok={result.get('ok')} active={status.get('active')} "
+                f"ready={(status.get('ready') or {}).get('ok')}"
+            )
+        if action == "logs":
+            output = result.get("stdout") or result.get("stderr") or ""
+            return output if output else f"no logs for {result.get('service_name')}"
         if action == "status":
+            ready = result.get("ready") or {}
             return (
                 f"codex-app-server service={result.get('service_name')} "
-                f"installed={result.get('installed')} active={result.get('active')} enabled={result.get('enabled')}"
+                f"installed={result.get('installed')} active={result.get('active')} "
+                f"enabled={result.get('enabled')} ready={ready.get('ok')}"
             )
     if command == "ingest-live":
         return f"ingested lane={result.get('lane_id')} actor={result.get('actor_id')}"

--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -298,9 +298,9 @@ def extract_linear_blockers(payload: dict[str, Any]) -> list[dict[str, Any]]:
 def issue_priority_sort_key(issue: dict[str, Any]) -> tuple[int, str, str]:
     priority = issue.get("priority")
     priority_key = int(priority) if isinstance(priority, int) else 999999
-    updated_key = str(issue.get("updated_at") or issue.get("created_at") or "")
+    created_key = str(issue.get("created_at") or "")
     identifier = str(issue.get("identifier") or issue.get("id") or "")
-    return (priority_key, updated_key, identifier)
+    return (priority_key, created_key, identifier)
 
 
 def chunk(values: list[str], size: int) -> list[list[str]]:

--- a/daedalus/trackers/linear.py
+++ b/daedalus/trackers/linear.py
@@ -7,7 +7,6 @@ from . import (
     DEFAULT_ACTIVE_STATES,
     DEFAULT_TERMINAL_STATES,
     TrackerConfigError,
-    cfg_list,
     chunk,
     http_post_json,
     issue_priority_sort_key,
@@ -19,13 +18,21 @@ from . import (
 )
 
 
+def _configured_states(tracker_cfg: dict[str, Any], *keys: str, default: tuple[str, ...]) -> list[str]:
+    for key in keys:
+        if key in tracker_cfg:
+            value = tracker_cfg.get(key)
+            return list(value) if isinstance(value, list) else []
+    return list(default)
+
+
 LINEAR_ISSUES_BY_STATES_QUERY = """
 query IssueRunnerIssuesByStates($projectSlug: String!, $states: [String!], $after: String) {
   issues(
-    first: 100,
+    first: 50,
     after: $after,
     filter: {
-      project: { slug: { eq: $projectSlug } },
+      project: { slugId: { eq: $projectSlug } },
       state: { name: { in: $states } }
     }
   ) {
@@ -63,9 +70,9 @@ query IssueRunnerIssuesByStates($projectSlug: String!, $states: [String!], $afte
 """.strip()
 
 LINEAR_ISSUES_BY_IDS_QUERY = """
-query IssueRunnerIssuesByIds($ids: [String!], $after: String) {
+query IssueRunnerIssuesByIds($ids: [ID!], $after: String) {
   issues(
-    first: 100,
+    first: 50,
     after: $after,
     filter: {
       id: { in: $ids }
@@ -135,7 +142,12 @@ class LinearTrackerClient:
         from workflows.issue_runner.tracker import eligible_issues
 
         raw_issues = self._query_issues_by_states(
-            list(cfg_list(self._tracker_cfg, "active_states", "active-states") or DEFAULT_ACTIVE_STATES)
+            _configured_states(
+                self._tracker_cfg,
+                "active_states",
+                "active-states",
+                default=DEFAULT_ACTIVE_STATES,
+            )
         )
         return eligible_issues(
             tracker_cfg=self._tracker_cfg,
@@ -154,11 +166,21 @@ class LinearTrackerClient:
 
     def list_terminal(self) -> list[dict[str, Any]]:
         raw_issues = self._query_issues_by_states(
-            list(cfg_list(self._tracker_cfg, "terminal_states", "terminal-states") or DEFAULT_TERMINAL_STATES)
+            _configured_states(
+                self._tracker_cfg,
+                "terminal_states",
+                "terminal-states",
+                default=DEFAULT_TERMINAL_STATES,
+            )
         )
         terminal_states = {
             str(value).strip().lower()
-            for value in (cfg_list(self._tracker_cfg, "terminal_states", "terminal-states") or DEFAULT_TERMINAL_STATES)
+            for value in _configured_states(
+                self._tracker_cfg,
+                "terminal_states",
+                "terminal-states",
+                default=DEFAULT_TERMINAL_STATES,
+            )
             if str(value).strip()
         }
         out = []
@@ -169,6 +191,8 @@ class LinearTrackerClient:
         return out
 
     def _query_issues_by_states(self, states: list[str]) -> list[dict[str, Any]]:
+        if not states:
+            return []
         return self._paginate_query(
             LINEAR_ISSUES_BY_STATES_QUERY,
             lambda after: {
@@ -180,7 +204,7 @@ class LinearTrackerClient:
 
     def _query_issues_by_ids(self, issue_ids: list[str]) -> list[dict[str, Any]]:
         out: list[dict[str, Any]] = []
-        for batch in chunk(issue_ids, 100):
+        for batch in chunk(issue_ids, 50):
             out.extend(
                 self._paginate_query(
                     LINEAR_ISSUES_BY_IDS_QUERY,
@@ -219,5 +243,5 @@ class LinearTrackerClient:
                 break
             after = str(page_info.get("endCursor") or "").strip() or None
             if not after:
-                break
+                raise TrackerConfigError("Linear GraphQL pagination reported hasNextPage without endCursor")
         return nodes

--- a/daedalus/workflows/change_delivery/server/html.py
+++ b/daedalus/workflows/change_delivery/server/html.py
@@ -118,7 +118,7 @@ def render_dashboard(state: dict[str, Any]) -> str:
     running = state.get("running") or []
     retrying = state.get("retrying") or []
     events = state.get("recent_events") or []
-    totals = state.get("totals") or {}
+    totals = state.get("codex_totals") or {}
     rate_limits = state.get("rate_limits")
 
     parts: list[str] = [_PAGE_HEAD]

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -8,7 +8,7 @@ JSONL events log on disk per request.
 Shape conforms to Symphony §13.7 (spec §6.4):
 
 - ``state_view`` returns a snapshot of running + retrying work plus a
-  ``totals`` block. `change-delivery` keeps the legacy lane-backed model;
+  ``codex_totals`` block. `change-delivery` keeps the legacy lane-backed model;
   `issue-runner` projects from scheduler/status JSON files.
 - ``issue_view`` returns the per-lane shape, or ``None`` if the
   identifier is unknown.
@@ -317,7 +317,7 @@ def _issue_runner_state_view(workflow_root: Path, events_log_path: Path) -> dict
         "counts": {"running": len(running_rows), "retrying": len(retry_rows)},
         "running": running_rows,
         "retrying": retry_rows,
-        "totals": totals,
+        "codex_totals": totals,
         "rate_limits": rate_limits,
         "recent_events": recent_events,
     }
@@ -363,7 +363,7 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
         "counts": {"running": len(running), "retrying": 0},
         "running": running,
         "retrying": [],
-        "totals": {
+        "codex_totals": {
             "input_tokens": 0,
             "output_tokens": 0,
             "total_tokens": 0,

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -136,9 +136,27 @@ properties:
     type: object
     properties:
       command: {type: string}
-      approval_policy: {type: string}
-      thread_sandbox: {type: string}
-      turn_sandbox_policy: {type: string}
+      mode:
+        type: string
+        enum: [managed, external]
+      endpoint: {type: string}
+      healthcheck_path: {type: string}
+      ws_token_env: {type: string}
+      ws_token_file: {type: string}
+      ephemeral: {type: boolean}
+      approval_policy:
+        oneOf:
+          - type: string
+            enum: [untrusted, on-failure, on-request, never]
+          - type: object
+      thread_sandbox:
+        type: string
+        enum: [read-only, workspace-write, danger-full-access]
+      turn_sandbox_policy:
+        oneOf:
+          - type: string
+            enum: [read-only, workspace-write, danger-full-access]
+          - type: object
       turn_timeout_ms:
         type: integer
         minimum: 1
@@ -222,9 +240,27 @@ definitions:
           - type: array
             minItems: 1
             items: {type: string}
-      approval_policy: {type: string}
-      thread_sandbox: {type: string}
-      turn_sandbox_policy: {type: string}
+      mode:
+        type: string
+        enum: [managed, external]
+      endpoint: {type: string}
+      healthcheck_path: {type: string}
+      ws_token_env: {type: string}
+      ws_token_file: {type: string}
+      ephemeral: {type: boolean}
+      approval_policy:
+        oneOf:
+          - type: string
+            enum: [untrusted, on-failure, on-request, never]
+          - type: object
+      thread_sandbox:
+        type: string
+        enum: [read-only, workspace-write, danger-full-access]
+      turn_sandbox_policy:
+        oneOf:
+          - type: string
+            enum: [read-only, workspace-write, danger-full-access]
+          - type: object
       turn_timeout_ms:
         type: integer
         minimum: 1

--- a/daedalus/workflows/issue_runner/tracker.py
+++ b/daedalus/workflows/issue_runner/tracker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +20,7 @@ from trackers.linear import LinearTrackerClient
 from trackers.local_json import LocalJsonTrackerClient
 
 
-_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_WORKSPACE_KEY_ALLOWED = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
 
 
 def eligible_issues(*, tracker_cfg: dict[str, Any], issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -77,9 +76,10 @@ def select_issue(*, tracker_cfg: dict[str, Any], issues: list[dict[str, Any]]) -
 
 
 def issue_workspace_slug(issue: dict[str, Any]) -> str:
-    identifier = str(issue.get("identifier") or issue.get("id") or "issue").strip().lower()
+    identifier = str(issue.get("identifier") or issue.get("id") or "issue").strip()
     raw = identifier or "issue"
-    return _SLUG_RE.sub("-", raw).strip("-") or "issue"
+    sanitized = "".join(char if char in _WORKSPACE_KEY_ALLOWED else "_" for char in raw)
+    return sanitized or "issue"
 
 
 def issue_session_name(issue: dict[str, Any]) -> str:

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -39,9 +39,10 @@ agent:
 
 codex:
   command: codex app-server
-  approval_policy: auto
+  ephemeral: false
+  approval_policy: never
   thread_sandbox: workspace-write
-  turn_sandbox_policy: auto
+  turn_sandbox_policy: workspace-write
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -10,8 +10,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+import yaml
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+
 from runtimes import PromptRunResult, Runtime, build_runtimes
-from workflows.contract import WORKFLOW_POLICY_KEY, load_workflow_contract
+from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
 from workflows.issue_runner.tracker import (
     TrackerClient,
@@ -76,6 +80,43 @@ def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _schema_path() -> Path:
+    return Path(__file__).with_name("schema.yaml")
+
+
+def _validate_issue_runner_config(config: dict[str, Any]) -> None:
+    schema = yaml.safe_load(_schema_path().read_text(encoding="utf-8"))
+    Draft7Validator(schema).validate(config)
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_issue_workspace_path(workspace_root: Path, issue: dict[str, Any]) -> Path:
+    root = workspace_root.expanduser().resolve()
+    workspace_key = issue_workspace_slug(issue)
+    path = root / workspace_key
+    lexical_path = path.resolve(strict=False)
+    if lexical_path == root or not _is_relative_to(lexical_path, root):
+        raise RuntimeError(
+            f"invalid workspace path for issue {issue.get('identifier') or issue.get('id')!r}: "
+            f"{lexical_path} is not a child of {root}"
+        )
+    return path
+
+
+def _assert_workspace_inside_root(workspace_root: Path, issue_workspace: Path) -> None:
+    root = workspace_root.expanduser().resolve()
+    resolved = issue_workspace.expanduser().resolve()
+    if resolved == root or not _is_relative_to(resolved, root):
+        raise RuntimeError(f"invalid workspace path: {resolved} is not a child of {root}")
 
 
 def _retry_due_at(entry: dict[str, Any] | None, *, default: float | None = None) -> float:
@@ -164,6 +205,12 @@ def _runtime_profiles_from_config(config: dict[str, Any]) -> dict[str, dict[str,
             continue
         for key in (
             "command",
+            "mode",
+            "endpoint",
+            "healthcheck_path",
+            "ws_token_env",
+            "ws_token_file",
+            "ephemeral",
             "approval_policy",
             "thread_sandbox",
             "turn_sandbox_policy",
@@ -236,6 +283,7 @@ class IssueRunnerWorkspace:
     _run_json: Callable[..., dict[str, Any]]
     retry_entries: dict[str, dict[str, Any]]
     running_entries: dict[str, dict[str, Any]]
+    codex_threads: dict[str, dict[str, Any]]
     running_issue_id: str | None = None
     codex_totals: dict[str, Any] | None = None
 
@@ -307,6 +355,7 @@ class IssueRunnerWorkspace:
                 "running": self._running_snapshot(),
                 "retry_queue": self._retry_queue_snapshot(),
                 "codex_totals": dict(self.codex_totals or {}),
+                "codex_threads": self._codex_threads_snapshot(),
             },
             "selectedIssue": selected,
             "workspaceRoot": str(self.issue_workspace_root),
@@ -356,6 +405,7 @@ class IssueRunnerWorkspace:
                 "retry_queue": self._retry_queue_snapshot(),
                 "running": self._running_snapshot(),
                 "codex_totals": dict(self.codex_totals or {}),
+                "codex_threads": self._codex_threads_snapshot(),
             },
         )
 
@@ -398,6 +448,7 @@ class IssueRunnerWorkspace:
         self.retry_entries = retry_entries
         self.running_entries = {}
         self.codex_totals = dict(payload.get("codex_totals") or payload.get("codexTotals") or {})
+        self.codex_threads = self._restore_codex_threads(payload.get("codex_threads") or {})
         self.running_issue_id = None
 
         if recovered_running:
@@ -451,6 +502,65 @@ class IssueRunnerWorkspace:
         entries.sort(key=lambda item: (item["due_in_ms"], item["attempt"], item["identifier"] or item["issue_id"]))
         return entries
 
+    def _restore_codex_threads(self, raw: Any) -> dict[str, dict[str, Any]]:
+        if not isinstance(raw, dict):
+            return {}
+        restored: dict[str, dict[str, Any]] = {}
+        for issue_id, item in raw.items():
+            if not isinstance(item, dict):
+                continue
+            normalized_issue_id = str(item.get("issue_id") or issue_id or "").strip()
+            thread_id = str(item.get("thread_id") or "").strip()
+            if not normalized_issue_id or not thread_id:
+                continue
+            restored[normalized_issue_id] = {
+                "issue_id": normalized_issue_id,
+                "identifier": item.get("identifier"),
+                "session_name": item.get("session_name"),
+                "thread_id": thread_id,
+                "turn_id": item.get("turn_id"),
+                "updated_at": item.get("updated_at"),
+            }
+        return restored
+
+    def _codex_threads_snapshot(self) -> dict[str, dict[str, Any]]:
+        return {
+            issue_id: dict(entry)
+            for issue_id, entry in sorted(self.codex_threads.items(), key=lambda item: item[0])
+        }
+
+    def _codex_thread_for_issue(self, issue: dict[str, Any]) -> str | None:
+        issue_id = str(issue.get("id") or "").strip()
+        if not issue_id:
+            return None
+        entry = self.codex_threads.get(issue_id) or {}
+        thread_id = str(entry.get("thread_id") or "").strip()
+        return thread_id or None
+
+    def _record_codex_thread(
+        self,
+        *,
+        issue: dict[str, Any],
+        session_name: str,
+        metrics: dict[str, Any],
+    ) -> None:
+        issue_id = str(issue.get("id") or "").strip()
+        thread_id = str(metrics.get("thread_id") or "").strip()
+        if not issue_id or not thread_id:
+            return
+        self.codex_threads[issue_id] = {
+            "issue_id": issue_id,
+            "identifier": issue.get("identifier"),
+            "session_name": session_name,
+            "thread_id": thread_id,
+            "turn_id": metrics.get("turn_id"),
+            "updated_at": _now_iso(),
+        }
+
+    def _clear_codex_thread(self, issue_id: str | None) -> None:
+        if issue_id:
+            self.codex_threads.pop(issue_id, None)
+
     def _due_retry_issue(self, *, issues_by_id: dict[str, dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         now_epoch = _now_epoch()
         due_entries = sorted(
@@ -471,12 +581,21 @@ class IssueRunnerWorkspace:
             return issue, entry
         return None, None
 
-    def _schedule_retry(self, *, issue: dict[str, Any], error: str, current_attempt: int | None) -> dict[str, Any]:
-        scheduler = _scheduler_state_from_config(self.config)
+    def _schedule_retry(
+        self,
+        *,
+        issue: dict[str, Any],
+        error: str,
+        current_attempt: int | None,
+        delay_type: str = "failure",
+    ) -> dict[str, Any]:
         max_backoff_ms = int((self.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
-        retry_attempt = int((self.retry_entries.get(issue["id"]) or {}).get("attempt") or 0) + 1
-        base_delay_ms = max(int(scheduler["poll_interval_ms"]), 1000)
-        delay_ms = min(max_backoff_ms, base_delay_ms * (2 ** max(retry_attempt - 1, 0)))
+        if delay_type == "continuation":
+            retry_attempt = 1
+            delay_ms = 1000
+        else:
+            retry_attempt = int((self.retry_entries.get(issue["id"]) or {}).get("attempt") or 0) + 1
+            delay_ms = min(max_backoff_ms, 10000 * (2 ** max(retry_attempt - 1, 0)))
         due_at = _now_epoch() + (delay_ms / 1000.0)
         entry = {
             "issue_id": issue.get("id"),
@@ -485,6 +604,7 @@ class IssueRunnerWorkspace:
             "due_at_epoch": due_at,
             "error": error,
             "current_attempt": current_attempt,
+            "delay_type": delay_type,
         }
         self.retry_entries[str(issue.get("id"))] = entry
         self._emit_event(
@@ -494,6 +614,7 @@ class IssueRunnerWorkspace:
                 "identifier": issue.get("identifier"),
                 "retry_attempt": retry_attempt,
                 "delay_ms": delay_ms,
+                "delay_type": delay_type,
                 "error": error,
             },
         )
@@ -502,6 +623,7 @@ class IssueRunnerWorkspace:
             "identifier": issue.get("identifier"),
             "retry_attempt": retry_attempt,
             "delay_ms": delay_ms,
+            "delay_type": delay_type,
         }
 
     def _clear_retry(self, issue_id: str | None) -> None:
@@ -647,30 +769,37 @@ class IssueRunnerWorkspace:
         issue: dict[str, Any],
         retry_entry: dict[str, Any] | None,
     ) -> dict[str, Any]:
-        issue_workspace = self.issue_workspace_root / issue_workspace_slug(issue)
-        issue_workspace.mkdir(parents=True, exist_ok=True)
-        daemon_dir = issue_workspace / ".daedalus"
-        daemon_dir.mkdir(parents=True, exist_ok=True)
-        created_workspace = not (daemon_dir / "created.marker").exists()
-        if created_workspace:
-            (daemon_dir / "created.marker").write_text(_now_iso() + "\n", encoding="utf-8")
-
-        attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
-        prompt = _render_prompt(
-            prompt_template=self.prompt_template or str(self.config.get(WORKFLOW_POLICY_KEY) or ""),
-            issue=issue,
-            attempt=None if attempt <= 1 else attempt,
-        )
-        prompt_path = daemon_dir / "prompt.txt"
-        prompt_path.write_text(prompt, encoding="utf-8")
-        output_path = daemon_dir / "last-output.txt"
-        env = self._hook_env(issue=issue, issue_workspace=issue_workspace, prompt_path=prompt_path, output_path=output_path)
         hook_results: list[dict[str, Any]] = []
         runtime: Runtime | None = None
+        runtime_name: str | None = None
+        runtime_cfg: dict[str, Any] = {}
+        issue_workspace: Path | None = None
+        output_path: Path | None = None
+        env: dict[str, str] | None = None
+        created_workspace = False
+        attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
 
         try:
+            issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
+            issue_workspace.mkdir(parents=True, exist_ok=True)
+            _assert_workspace_inside_root(self.issue_workspace_root, issue_workspace)
+            daemon_dir = issue_workspace / ".daedalus"
+            daemon_dir.mkdir(parents=True, exist_ok=True)
+            created_marker = daemon_dir / "created.marker"
+            created_workspace = not created_marker.exists()
+
+            prompt = _render_prompt(
+                prompt_template=self.prompt_template or str(self.config.get(WORKFLOW_POLICY_KEY) or ""),
+                issue=issue,
+                attempt=None if attempt <= 1 else attempt,
+            )
+            prompt_path = daemon_dir / "prompt.txt"
+            prompt_path.write_text(prompt, encoding="utf-8")
+            output_path = daemon_dir / "last-output.txt"
+            env = self._hook_env(issue=issue, issue_workspace=issue_workspace, prompt_path=prompt_path, output_path=output_path)
             if created_workspace:
                 hook_results.append(self._run_hook("after_create", issue_workspace, env))
+                created_marker.write_text(_now_iso() + "\n", encoding="utf-8")
             hook_results.append(self._run_hook("before_run", issue_workspace, env))
 
             agent_cfg = self.config.get("agent") or {}
@@ -680,7 +809,15 @@ class IssueRunnerWorkspace:
             runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
             session_name = issue_session_name(issue)
             model = str(agent_cfg.get("model") or "")
-            runtime.ensure_session(worktree=issue_workspace, session_name=session_name, model=model)
+            resume_thread_id = None
+            if str(runtime_cfg.get("kind") or "").strip() == "codex-app-server":
+                resume_thread_id = self._codex_thread_for_issue(issue)
+            runtime.ensure_session(
+                worktree=issue_workspace,
+                session_name=session_name,
+                model=model,
+                resume_session_id=resume_thread_id,
+            )
 
             command = agent_cfg.get("command")
             if command is None:
@@ -718,19 +855,24 @@ class IssueRunnerWorkspace:
                 "hookResults": hook_results,
                 "outputPath": str(output_path),
                 "metrics": self._metrics_payload(run_result),
+                "runtime": runtime_name,
+                "runtimeKind": runtime_cfg.get("kind"),
             }
         except Exception as exc:
-            hook_results.append(self._run_hook("after_run", issue_workspace, env, ignore_failure=True))
+            if issue_workspace is not None and env is not None:
+                hook_results.append(self._run_hook("after_run", issue_workspace, env, ignore_failure=True))
             return {
                 "ok": False,
                 "issue": issue,
                 "attempt": attempt,
-                "workspace": str(issue_workspace),
+                "workspace": str(issue_workspace) if issue_workspace is not None else None,
                 "createdWorkspace": created_workspace,
                 "hookResults": hook_results,
-                "outputPath": str(output_path),
+                "outputPath": str(output_path) if output_path is not None else None,
                 "error": f"{type(exc).__name__}: {exc}",
                 "metrics": self._metrics_from_exception(exc, runtime=runtime),
+                "runtime": runtime_name if runtime is not None else None,
+                "runtimeKind": runtime_cfg.get("kind") if runtime is not None else None,
             }
 
     def tick(self) -> dict[str, Any]:
@@ -814,9 +956,22 @@ class IssueRunnerWorkspace:
                             rate_limits=metrics.get("rate_limits"),
                         )
                     )
+                    if result.get("runtimeKind") == "codex-app-server":
+                        self._record_codex_thread(
+                            issue=issue,
+                            session_name=issue_session_name(issue),
+                            metrics=recorded_metrics,
+                        )
                     tick_metrics.append(recorded_metrics)
                 if result.get("ok"):
                     self._clear_retry(issue_id)
+                    retry = self._schedule_retry(
+                        issue=issue,
+                        error="continuation",
+                        current_attempt=result.get("attempt"),
+                        delay_type="continuation",
+                    )
+                    result["retry"] = retry
                     self._emit_event(
                         "issue_runner.tick.completed",
                         {
@@ -824,6 +979,8 @@ class IssueRunnerWorkspace:
                             "attempt": result.get("attempt"),
                             "workspace": result.get("workspace"),
                             "output_path": result.get("outputPath"),
+                            "continuation_retry_attempt": retry.get("retry_attempt"),
+                            "continuation_retry_delay_ms": retry.get("delay_ms"),
                         },
                     )
                 else:
@@ -883,10 +1040,13 @@ class IssueRunnerWorkspace:
             state = str(issue.get("state") or "").strip().lower()
             if state not in terminal_states:
                 continue
-            self._clear_retry(str(issue.get("id") or ""))
-            issue_workspace = self.issue_workspace_root / issue_workspace_slug(issue)
+            issue_id = str(issue.get("id") or "")
+            self._clear_retry(issue_id)
+            self._clear_codex_thread(issue_id)
+            issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
             if not issue_workspace.exists():
                 continue
+            _assert_workspace_inside_root(self.issue_workspace_root, issue_workspace)
             daemon_dir = issue_workspace / ".daedalus"
             env = self._hook_env(
                 issue=issue,
@@ -1120,7 +1280,25 @@ class IssueRunnerWorkspace:
         }
 
     def reload_contract(self) -> None:
-        contract = load_workflow_contract(self.path)
+        try:
+            contract = load_workflow_contract(self.path)
+            _validate_issue_runner_config(dict(contract.config))
+        except (
+            FileNotFoundError,
+            WorkflowContractError,
+            JsonSchemaValidationError,
+            OSError,
+            UnicodeDecodeError,
+            yaml.YAMLError,
+        ) as exc:
+            self._emit_event(
+                "daedalus.config_reload_failed",
+                {
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "contract_path": str(self.contract_path),
+                },
+            )
+            return
         st = contract.source_path.stat()
         current = self.snapshot_ref.get()
         key = (st.st_mtime, st.st_size, str(contract.source_path))
@@ -1242,6 +1420,7 @@ def load_workspace_from_config(
         _run_json=runner_json,
         retry_entries={},
         running_entries={},
+        codex_threads={},
         codex_totals={},
     )
     workspace._restore_scheduler_state()

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -28,7 +28,7 @@ class Runtime(Protocol):
 |---|---|---|---|---|---|
 | Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot | ❌ one-turn protocol client |
 | `ensure_session` | no-op | `acpx codex sessions ensure` | no-op | no-op |
-| `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | requires `command:` override | stdio event stream to `codex app-server` |
+| `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | requires `command:` override | JSON-RPC over stdio to `codex app-server` |
 | `assess_health` | always healthy | freshness + grace window | always healthy | always healthy |
 | `close_session` | no-op | `acpx codex sessions close` | no-op | no-op |
 | Records `last_activity_ts` | yes (before + after `_run`) | yes | yes | yes |
@@ -74,10 +74,62 @@ Because it is one-shot, `assess_health` always returns healthy and `last_activit
 
 ### `codex-app-server` runtime
 
-The `codex-app-server` runtime speaks a first-pass stdio protocol to a local
-`codex app-server` command. It is currently used by `issue-runner` to move
-closer to the Symphony execution model and to capture per-run token and
-rate-limit data.
+The `codex-app-server` runtime speaks JSON-RPC to Codex app-server. In managed
+mode it starts `codex app-server` over stdio for one run. In external mode it
+connects to a long-running WebSocket listener. It sends `initialize`, starts or
+resumes a thread with `thread/start` or `thread/resume`, sends `turn/start`, and
+consumes notifications until `turn/completed`.
+
+```yaml
+runtimes:
+  codex:
+    kind: codex-app-server
+    command: codex app-server
+    ephemeral: false
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+```
+
+For a supervised long-running listener, install and start the Daedalus-managed
+user service:
+
+```bash
+hermes daedalus codex-app-server install
+hermes daedalus codex-app-server up
+hermes daedalus codex-app-server status
+```
+
+The default listener is `ws://127.0.0.1:4500`. The generated unit runs:
+
+```bash
+codex app-server --listen ws://127.0.0.1:4500
+```
+
+Then configure Daedalus for external mode:
+
+```yaml
+runtimes:
+  codex:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    healthcheck_path: /readyz
+    ephemeral: false
+    ws_token_env: CODEX_APP_SERVER_TOKEN  # only if the listener requires auth
+```
+
+External mode checks `GET /readyz` before connecting, then opens one JSON-RPC
+WebSocket connection for the run. `ephemeral: false` keeps Codex threads visible
+through app-server thread APIs. The default stdio transport cannot be shared:
+Daedalus can only attach to an already-started app-server when it exposes a
+socket transport.
+
+It maps `thread/tokenUsage/updated` into Daedalus token totals and
+`account/rateLimits/updated` into the latest rate-limit snapshot. It rejects
+non-interactive approval requests so an unattended service does not hang.
+`issue-runner` persists `issue_id -> thread_id` in scheduler state and resumes
+the existing Codex thread on later ticks instead of starting a fresh thread.
 
 ## Adding a new runtime
 

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -98,6 +98,7 @@ user service:
 hermes daedalus codex-app-server install
 hermes daedalus codex-app-server up
 hermes daedalus codex-app-server status
+hermes daedalus codex-app-server logs
 ```
 
 The default listener is `ws://127.0.0.1:4500`. The generated unit runs:
@@ -105,6 +106,26 @@ The default listener is `ws://127.0.0.1:4500`. The generated unit runs:
 ```bash
 codex app-server --listen ws://127.0.0.1:4500
 ```
+
+If you expose the WebSocket listener beyond loopback, configure auth when
+installing the service. Supported auth modes mirror Codex app-server:
+
+```bash
+hermes daedalus codex-app-server up \
+  --ws-token-file /absolute/path/to/codex-app-server.token
+
+hermes daedalus codex-app-server up \
+  --ws-token-sha256 <sha256-hex>
+
+hermes daedalus codex-app-server up \
+  --ws-shared-secret-file /absolute/path/to/shared-secret \
+  --ws-issuer daedalus \
+  --ws-audience codex-app-server
+```
+
+Client-side runtime config can then use `ws_token_file` or `ws_token_env` so
+Daedalus presents `Authorization: Bearer <token>` during the WebSocket
+handshake. `status` includes both systemd state and a `GET /readyz` probe.
 
 Then configure Daedalus for external mode:
 

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -39,9 +39,10 @@ agent:
 
 codex:
   command: codex app-server
-  approval_policy: auto
+  ephemeral: false
+  approval_policy: never
   thread_sandbox: workspace-write
-  turn_sandbox_policy: auto
+  turn_sandbox_policy: workspace-write
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -53,7 +53,7 @@ Conforms to Symphony §13.7 / Daedalus spec §6.4:
   "counts":   { "running": 3, "retrying": 0 },
   "running":  [ { "issue_id": "01HF…", "issue_identifier": "#42", "state": "coding_dispatched", "session_id": "claude-coder-1", "turn_count": 0, "last_event": "turn_started", "started_at": "…", "last_event_at": "…", "tokens": { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680 } } ],
   "retrying": [],
-  "totals":   { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680, "seconds_running": 43 },
+  "codex_totals": { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680, "seconds_running": 43 },
   "rate_limits": { "requests_remaining": 47 },
   "recent_events": [ /* up to 20, newest first */ ]
 }

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -165,6 +165,10 @@ hermes daedalus codex-app-server up
 ```
 
 Then point the workflow runtime at `ws://127.0.0.1:4500`.
+Use `hermes daedalus codex-app-server status`, `restart`, and `logs` for
+operator checks. If the listener is not loopback-only, pass one of the supported
+auth flags during `install` or `up`, for example
+`--ws-token-file /absolute/path/to/token`.
 
 ## Manual low-level path
 

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -157,6 +157,15 @@ Use `--service-mode shadow` if you want read-only parity validation first.
 That `shadow` mode applies to `change-delivery`. `issue-runner` supports
 `active` mode only.
 
+If your `issue-runner` contract uses `codex.mode: external`, bring up the
+shared Codex listener once:
+
+```bash
+hermes daedalus codex-app-server up
+```
+
+Then point the workflow runtime at `ws://127.0.0.1:4500`.
+
 ## Manual low-level path
 
 If you want to inspect or script each step separately, the lower-level commands

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -162,6 +162,10 @@ Daedalus service
 | `/daedalus service-disable` | Disable on boot |
 | `/daedalus service-status` | systemd status snapshot |
 | `/daedalus service-logs` | Last N journal entries |
+| `/daedalus codex-app-server install` | Write the shared Codex app-server user unit |
+| `/daedalus codex-app-server up` | Install, enable, and start the shared Codex app-server |
+| `/daedalus codex-app-server status` | Show Codex app-server unit status |
+| `/daedalus codex-app-server down` | Stop and disable Codex app-server |
 
 ### Cutover / migration (one-shot operator commands)
 

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -164,7 +164,9 @@ Daedalus service
 | `/daedalus service-logs` | Last N journal entries |
 | `/daedalus codex-app-server install` | Write the shared Codex app-server user unit |
 | `/daedalus codex-app-server up` | Install, enable, and start the shared Codex app-server |
-| `/daedalus codex-app-server status` | Show Codex app-server unit status |
+| `/daedalus codex-app-server status` | Show unit status plus `GET /readyz` readiness |
+| `/daedalus codex-app-server restart` | Restart the Codex app-server unit |
+| `/daedalus codex-app-server logs` | Last N Codex app-server journal entries |
 | `/daedalus codex-app-server down` | Stop and disable Codex app-server |
 
 ### Cutover / migration (one-shot operator commands)

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -15,13 +15,13 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | Symphony concept | Daedalus status | Notes |
 |---|---|---|
 | `WORKFLOW.md` loader | Partial | Supported as a repo-owned public contract. Front matter maps to the selected workflow schema; `issue-runner` is the closer generic reference surface, while `change-delivery` still carries richer GitHub-specific semantics. |
-| Typed config + hot reload | Implemented | Current `change-delivery` schema is validated and hot-reloaded with last-known-good behavior. |
-| Issue tracker client boundary | Partial | `issue-runner` now has a tracker client boundary with `local-json` and first-pass `linear` adapters, but the broader engine is still not tracker-agnostic end-to-end. |
-| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, managed long-running `issue-runner`, and persisted scheduler state now exist, but the scheduler policy is not yet fully spec-shaped. |
+| Typed config + hot reload | Implemented | Bundled workflows load repo-owned `WORKFLOW.md`; `issue-runner` now keeps last-known-good config on invalid reloads. |
+| Issue tracker client boundary | Partial | `issue-runner` has shared `local-json`, `github`, and Linear clients. The Linear query shape follows the Symphony baseline, but still needs real-service smoke validation. |
+| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, and persisted scheduler state now exist. |
 | Bounded concurrency | Partial | `issue-runner` now dispatches bounded batches and persists running-worker recovery, but the broader engine is still not uniformly scheduler-driven. |
-| Retry/backoff policy | Partial | Durable retry/backoff state now survives scheduler restarts, but the policy is still not exposed as a clean spec-native contract. |
-| Coding-agent protocol | Partial | CLI/session runtimes still exist, but `issue-runner` now ships a first-pass `codex-app-server` adapter. It is not yet a full spec-native session protocol. |
-| Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; `issue-runner` now records per-run token and rate-limit metrics, but broader operator surfaces still do not report them uniformly. |
+| Retry/backoff policy | Partial | `issue-runner` now uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff. The remaining gap is true async worker cancellation/reconciliation. |
+| Coding-agent protocol | Partial | `issue-runner` now ships a protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, and persisted thread resume. The remaining gap is in-flight worker cancellation/reconciliation. |
+| Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; `issue-runner` records per-run token/rate-limit metrics and exposes `codex_totals` plus Codex thread mappings. |
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
 
@@ -29,14 +29,15 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 
 Daedalus currently differs from the Symphony draft in three material ways:
 
-1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow and now has a first-pass Linear adapter, but the broader product story is still not Linear-first.
-2. Runtime adapters are still mixed: `issue-runner` now has a first-pass Codex app-server path, while the rest of Daedalus remains CLI/session-oriented.
+1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow and has a Linear adapter, but the broader product story is still not Linear-first.
+2. Runtime adapters are still mixed: `issue-runner` has a protocol-level Codex app-server path, while the rest of Daedalus remains CLI/session-oriented.
 3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
+4. `issue-runner` still executes worker turns synchronously inside a tick, so in-flight cancellation on tracker state changes is not fully Symphony-shaped yet.
 
 ## Recommended Next Gaps
 
-1. Promote the current tracker boundary into a fuller, repo-documented contract and harden the Linear adapter.
-2. Promote concurrency and retry policy into a fuller public scheduler contract.
-3. Promote the current Codex app-server path into a fuller spec-native protocol implementation.
+1. Move `issue-runner` from synchronous tick execution to true async worker supervision so reconciliation can stop active runs.
+2. Keep Codex app-server threads and loaded sessions alive across ticks instead of starting/resuming one connection per run.
+3. Add real Linear integration smoke tests and publish a stricter conformance checklist.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -15,7 +15,7 @@ For each eligible tracker issue:
 5. render the Markdown workflow body as the issue prompt template
 6. invoke the configured runtime/agent
 7. persist output and audit state
-8. persist scheduler state for retries, running workers, and token totals
+8. persist scheduler state for continuation retries, failure backoff, running-worker recovery, and token totals
 
 ## Use it when
 
@@ -35,7 +35,7 @@ For each eligible tracker issue:
 - `workspace`: per-issue workspace root
 - `hooks`: `after_create`, `before_run`, `after_run`, `before_remove`
 - `agent`: model/runtime plus scheduler-facing limits
-- `codex`: spec-shaped Codex runner settings
+- `codex`: spec-shaped Codex runner settings; set `mode: external` and `endpoint: ws://127.0.0.1:<port>` to connect to an already-running app-server, and keep `ephemeral: false` if you want Codex threads to remain inspectable
 - `daedalus.runtimes`: shared runtime backend profiles used by the current implementation when you are not using the top-level `codex` block
 
 Supported tracker kinds today:
@@ -48,8 +48,11 @@ Supported tracker kinds today:
 eligibility, ordering, retry, and workspace policy.
 
 Scheduler state is persisted under `storage.scheduler` (default:
-`memory/workflow-scheduler.json`) so retry queues, running-worker recovery, and
-aggregate Codex token totals survive loop restarts.
+`memory/workflow-scheduler.json`) so continuation retries, failure backoff,
+running-worker recovery, aggregate Codex token totals, and Codex
+`issue_id -> thread_id` mappings survive loop restarts. When a mapped thread
+exists, the Codex app-server adapter resumes it with `thread/resume` before
+starting the next turn.
 
 ## Operator path
 
@@ -102,9 +105,10 @@ tables.
 
 ## Current limitation
 
-- The Linear adapter is first-pass. It is useful for issue selection and reconciliation, but it has not been hardened against every Linear schema edge yet.
+- The Linear adapter follows the Symphony baseline query shape, but still needs real Linear integration smoke coverage before claiming production-grade Linear support.
 - Managed service mode is `active` only. `shadow` remains specific to `change-delivery`.
-- The bundled Codex app-server adapter now preserves partial metrics on failed turns, but it is still not a full spec-native session protocol yet.
+- The bundled Codex app-server adapter supports managed stdio and external WebSocket transports, including durable thread resume across ticks; full in-flight cancellation remains future work.
+- Worker execution is still synchronous inside each tick; full in-flight cancellation on tracker state changes is the next scheduler hardening step.
 
 ## Related docs
 

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -104,6 +104,49 @@ def _write_fake_resume_rejecting_app_server(path: Path, requests_path: Path) -> 
     )
 
 
+def _write_fake_quiet_turn_app_server(path: Path, requests_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                "import time",
+                f"requests_path = {str(requests_path)!r}",
+                "",
+                "def emit(payload):",
+                "    print(json.dumps(payload), flush=True)",
+                "",
+                "def record(payload):",
+                "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+                "        fh.write(json.dumps(payload) + '\\n')",
+                "",
+                "for line in sys.stdin:",
+                "    payload = json.loads(line)",
+                "    record(payload)",
+                "    method = payload.get('method')",
+                "    request_id = payload.get('id')",
+                "    if method == 'initialize':",
+                "        emit({'id': request_id, 'result': {'userAgent': 'fake-codex'}})",
+                "    elif method == 'initialized':",
+                "        continue",
+                "    elif method == 'thread/start':",
+                "        emit({'id': request_id, 'result': {'thread': {'id': 'thread-quiet'}}})",
+                "    elif method == 'turn/start':",
+                "        turn = {'id': 'turn-quiet', 'status': 'running', 'items': []}",
+                "        emit({'id': request_id, 'result': {'turn': turn}})",
+                "        time.sleep(1.2)",
+                "        item = {'threadId': 'thread-quiet', 'turnId': 'turn-quiet', 'itemId': 'item-1'}",
+                "        emit({'method': 'item/agentMessage/delta', 'params': {**item, 'delta': 'quiet ok'}})",
+                "        completed_turn = {'id': 'turn-quiet', 'status': 'completed', 'items': []}",
+                "        emit({'method': 'turn/completed', 'params': {'threadId': 'thread-quiet', 'turn': completed_turn}})",
+                "        break",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 class _FakeWebSocketAppServer:
     def __init__(self):
         self.requests: list[dict] = []
@@ -390,6 +433,38 @@ def test_codex_app_server_runtime_does_not_fallback_when_resume_fails(tmp_path):
     assert "thread/resume" in methods
     assert "thread/start" not in methods
     assert "turn/start" not in methods
+
+
+def test_codex_app_server_runtime_allows_quiet_period_longer_than_read_timeout(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_quiet_turn_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_quiet_turn_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 1000,
+            "stall_timeout_ms": 4000,
+        },
+        run=None,
+    )
+
+    result = runtime.run_prompt_result(
+        worktree=worktree,
+        session_name="ISSUE-QUIET",
+        prompt="Work quietly",
+        model="gpt-5.5",
+    )
+
+    assert result.output == "quiet ok\n"
+    assert result.thread_id == "thread-quiet"
+    assert result.turn_id == "turn-quiet"
 
 
 def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path):

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -66,6 +66,44 @@ def _write_fake_app_server(path: Path, requests_path: Path) -> None:
     )
 
 
+def _write_fake_resume_rejecting_app_server(path: Path, requests_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                f"requests_path = {str(requests_path)!r}",
+                "",
+                "def emit(payload):",
+                "    print(json.dumps(payload), flush=True)",
+                "",
+                "def record(payload):",
+                "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+                "        fh.write(json.dumps(payload) + '\\n')",
+                "",
+                "for line in sys.stdin:",
+                "    payload = json.loads(line)",
+                "    record(payload)",
+                "    method = payload.get('method')",
+                "    request_id = payload.get('id')",
+                "    if method == 'initialize':",
+                "        emit({'id': request_id, 'result': {'userAgent': 'fake-codex'}})",
+                "    elif method == 'initialized':",
+                "        continue",
+                "    elif method == 'thread/resume':",
+                "        error = {'code': -32000, 'message': 'thread not found'}",
+                "        emit({'id': request_id, 'error': error})",
+                "        break",
+                "    elif method == 'thread/start':",
+                "        emit({'id': request_id, 'result': {'thread': {'id': 'unexpected-thread'}}})",
+                "        break",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 class _FakeWebSocketAppServer:
     def __init__(self):
         self.requests: list[dict] = []
@@ -311,6 +349,47 @@ def test_codex_app_server_runtime_resumes_existing_thread(tmp_path):
     assert "thread/start" not in [item.get("method") for item in requests]
     thread_resume = next(item for item in requests if item.get("method") == "thread/resume")
     assert thread_resume["params"]["threadId"] == "thread-existing"
+
+
+def test_codex_app_server_runtime_does_not_fallback_when_resume_fails(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_resume_rejecting_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_resume_rejecting_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 1000,
+            "stall_timeout_ms": 5000,
+        },
+        run=None,
+    )
+    runtime.ensure_session(
+        worktree=worktree,
+        session_name="ISSUE-1",
+        model="gpt-5.5",
+        resume_session_id="missing-thread",
+    )
+
+    with pytest.raises(CodexAppServerError, match="thread/resume.*thread not found"):
+        runtime.run_prompt_result(
+            worktree=worktree,
+            session_name="ISSUE-1",
+            prompt="Continue",
+            model="gpt-5.5",
+        )
+
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    methods = [item.get("method") for item in requests]
+    assert "thread/resume" in methods
+    assert "thread/start" not in methods
+    assert "turn/start" not in methods
 
 
 def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path):

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -1,0 +1,375 @@
+import base64
+import hashlib
+import json
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+def _write_fake_app_server(path: Path, requests_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                f"requests_path = {str(requests_path)!r}",
+                "tid = 'thread-1'",
+                "trn = 'turn-1'",
+                "",
+                "def emit(payload):",
+                "    print(json.dumps(payload), flush=True)",
+                "",
+                "def record(payload):",
+                "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+                "        fh.write(json.dumps(payload) + '\\n')",
+                "",
+                "for line in sys.stdin:",
+                "    payload = json.loads(line)",
+                "    record(payload)",
+                "    method = payload.get('method')",
+                "    request_id = payload.get('id')",
+                "    if method == 'initialize':",
+                "        emit({'id': request_id, 'result': {'userAgent': 'fake-codex', 'codexHome': '/tmp/codex'}})",
+                "    elif method == 'initialized':",
+                "        continue",
+                "    elif method == 'thread/start':",
+                "        thread = {'id': tid, 'status': 'running', 'turns': []}",
+                "        emit({'id': request_id, 'result': {'thread': thread}})",
+                "    elif method == 'thread/resume':",
+                "        tid = payload.get('params', {}).get('threadId') or tid",
+                "        thread = {'id': tid, 'status': 'running', 'turns': []}",
+                "        emit({'id': request_id, 'result': {'thread': thread}})",
+                "    elif method == 'turn/start':",
+                "        running_turn = {'id': trn, 'status': 'running', 'items': []}",
+                "        emit({'id': request_id, 'result': {'turn': running_turn}})",
+                "        emit({'method': 'turn/started', 'params': {'threadId': tid, 'turn': running_turn}})",
+                "        item = {'threadId': tid, 'turnId': trn, 'itemId': 'item-1'}",
+                "        emit({'method': 'agent/message_delta', 'params': {**item, 'delta': 'hello '}})",
+                "        emit({'method': 'agent/message_delta', 'params': {**item, 'delta': 'world'}})",
+                "        usage_base = {'cachedInputTokens': 0, 'reasoningOutputTokens': 0}",
+                "        last_usage = dict(usage_base, inputTokens=2, outputTokens=3, totalTokens=5)",
+                "        total_usage = dict(usage_base, inputTokens=11, outputTokens=7, totalTokens=18)",
+                "        token_usage = {'last': last_usage, 'total': total_usage}",
+                "        emit({'method': 'thread/tokenUsage/updated', 'params': {**item, 'tokenUsage': token_usage}})",
+                "        rate_limits = {'limitName': 'primary', 'requests_remaining': 99}",
+                "        emit({'method': 'account/rateLimits/updated', 'params': {'rateLimits': rate_limits}})",
+                "        completed_turn = {'id': trn, 'status': 'completed', 'items': []}",
+                "        emit({'method': 'turn/completed', 'params': {'threadId': tid, 'turn': completed_turn}})",
+                "        break",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+class _FakeWebSocketAppServer:
+    def __init__(self):
+        self.requests: list[dict] = []
+        self._stop = threading.Event()
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen()
+        self.endpoint = f"ws://127.0.0.1:{self._sock.getsockname()[1]}"
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc):
+        self._stop.set()
+        try:
+            socket.create_connection(("127.0.0.1", self._sock.getsockname()[1]), timeout=0.2).close()
+        except OSError:
+            pass
+        self._sock.close()
+        self._thread.join(timeout=2)
+
+    def _serve(self):
+        while not self._stop.is_set():
+            try:
+                conn, _addr = self._sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle_connection, args=(conn,), daemon=True).start()
+
+    def _handle_connection(self, conn: socket.socket):
+        with conn:
+            request = self._read_http_request(conn)
+            if not request:
+                return
+            first_line = request.split("\r\n", 1)[0]
+            headers = self._headers(request)
+            if first_line.startswith("GET /readyz "):
+                conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK")
+                return
+            if headers.get("upgrade", "").lower() != "websocket":
+                conn.sendall(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+                return
+            key = headers["sec-websocket-key"]
+            accept = base64.b64encode(
+                hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("ascii")).digest()
+            ).decode("ascii")
+            response = (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            )
+            conn.sendall(response.encode("ascii"))
+            self._run_jsonrpc(conn)
+
+    def _run_jsonrpc(self, conn: socket.socket):
+        thread_id = "thread-ws"
+        while True:
+            payload = self._read_ws_text(conn)
+            if payload is None:
+                return
+            message = json.loads(payload)
+            self.requests.append(message)
+            method = message.get("method")
+            request_id = message.get("id")
+            if method == "initialize":
+                self._send_ws_json(conn, {"id": request_id, "result": {"userAgent": "fake-ws-codex"}})
+            elif method == "initialized":
+                continue
+            elif method == "thread/start":
+                thread = {"id": thread_id, "status": "running", "turns": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"thread": thread}})
+            elif method == "thread/resume":
+                thread_id = str((message.get("params") or {}).get("threadId") or thread_id)
+                thread = {"id": thread_id, "status": "running", "turns": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"thread": thread}})
+            elif method == "turn/start":
+                turn = {"id": "turn-ws", "status": "running", "items": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"turn": turn}})
+                self._send_ws_json(
+                    conn,
+                    {"method": "turn/started", "params": {"threadId": thread_id, "turn": turn}},
+                )
+                self._send_ws_json(
+                    conn,
+                    {
+                        "method": "agent/message_delta",
+                        "params": {"threadId": thread_id, "turnId": "turn-ws", "itemId": "item-1", "delta": "ws ok"},
+                    },
+                )
+                completed = {"id": "turn-ws", "status": "completed", "items": []}
+                self._send_ws_json(
+                    conn,
+                    {"method": "turn/completed", "params": {"threadId": thread_id, "turn": completed}},
+                )
+                return
+
+    def _read_http_request(self, conn: socket.socket) -> str:
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                return ""
+            data += chunk
+        return data.decode("iso-8859-1")
+
+    def _headers(self, request: str) -> dict[str, str]:
+        out = {}
+        for line in request.split("\r\n")[1:]:
+            if ":" not in line:
+                continue
+            name, value = line.split(":", 1)
+            out[name.strip().lower()] = value.strip()
+        return out
+
+    def _read_ws_text(self, conn: socket.socket) -> str | None:
+        header = self._recv_exact(conn, 2)
+        if not header:
+            return None
+        opcode = header[0] & 0x0F
+        if opcode == 0x8:
+            return None
+        length = header[1] & 0x7F
+        if length == 126:
+            length = int.from_bytes(self._recv_exact(conn, 2), "big")
+        elif length == 127:
+            length = int.from_bytes(self._recv_exact(conn, 8), "big")
+        mask = self._recv_exact(conn, 4)
+        data = self._recv_exact(conn, length)
+        return bytes(byte ^ mask[index % 4] for index, byte in enumerate(data)).decode("utf-8")
+
+    def _send_ws_json(self, conn: socket.socket, payload: dict) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        if len(data) < 126:
+            header = bytes([0x81, len(data)])
+        elif len(data) <= 0xFFFF:
+            header = bytes([0x81, 126]) + len(data).to_bytes(2, "big")
+        else:
+            header = bytes([0x81, 127]) + len(data).to_bytes(8, "big")
+        conn.sendall(header + data)
+
+    def _recv_exact(self, conn: socket.socket, size: int) -> bytes:
+        data = b""
+        while len(data) < size:
+            chunk = conn.recv(size - len(data))
+            if not chunk:
+                return b""
+            data += chunk
+        return data
+
+
+def test_codex_app_server_runtime_speaks_jsonrpc_and_maps_metrics(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "thread_sandbox": "workspace-write",
+            "turn_sandbox_policy": "workspace-write",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 1000,
+            "stall_timeout_ms": 5000,
+        },
+        run=None,
+    )
+
+    result = runtime.run_prompt_result(
+        worktree=worktree,
+        session_name="ISSUE-1",
+        prompt="Do the thing",
+        model="gpt-5.5",
+    )
+
+    assert result.output == "hello world\n"
+    assert result.session_id == "thread-1"
+    assert result.thread_id == "thread-1"
+    assert result.turn_id == "turn-1"
+    assert result.turn_count == 1
+    assert result.last_event == "turn/completed"
+    assert result.tokens == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+    assert result.rate_limits == {"limitName": "primary", "requests_remaining": 99}
+
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    assert all("jsonrpc" not in item for item in requests)
+    thread_start = next(item for item in requests if item.get("method") == "thread/start")
+    turn_start = next(item for item in requests if item.get("method") == "turn/start")
+    assert thread_start["params"]["approvalPolicy"] == "never"
+    assert thread_start["params"]["sandbox"] == "workspace-write"
+    assert thread_start["params"]["model"] == "gpt-5.5"
+    assert thread_start["params"]["ephemeral"] is False
+    assert turn_start["params"]["input"] == [{"type": "text", "text": "Do the thing"}]
+    assert turn_start["params"]["sandboxPolicy"] == {
+        "type": "workspaceWrite",
+        "writableRoots": [str(worktree)],
+    }
+
+
+def test_codex_app_server_runtime_resumes_existing_thread(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 1000,
+            "stall_timeout_ms": 5000,
+        },
+        run=None,
+    )
+    runtime.ensure_session(
+        worktree=worktree,
+        session_name="ISSUE-1",
+        model="gpt-5.5",
+        resume_session_id="thread-existing",
+    )
+
+    result = runtime.run_prompt_result(
+        worktree=worktree,
+        session_name="ISSUE-1",
+        prompt="Continue",
+        model="gpt-5.5",
+    )
+
+    assert result.thread_id == "thread-existing"
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    assert "thread/start" not in [item.get("method") for item in requests]
+    thread_resume = next(item for item in requests if item.get("method") == "thread/resume")
+    assert thread_resume["params"]["threadId"] == "thread-existing"
+
+
+def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
+
+    runtime = CodexAppServerRuntime(
+        {"command": [sys.executable, "-c", ""], "approval_policy": "auto"},
+        run=None,
+    )
+
+    with pytest.raises(CodexAppServerError, match="approval_policy"):
+        runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-1",
+            prompt="Do the thing",
+            model="gpt-5.5",
+        )
+
+
+def test_codex_app_server_runtime_connects_to_external_websocket(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakeWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "thread_sandbox": "workspace-write",
+                "turn_sandbox_policy": "workspace-write",
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+
+        health = runtime.assess_health({}, worktree=tmp_path)
+        result = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-1",
+            prompt="Do the thing",
+            model="gpt-5.5",
+        )
+
+    assert health.healthy is True
+    assert result.output == "ws ok\n"
+    assert result.thread_id == "thread-ws"
+    assert result.turn_id == "turn-ws"
+    assert [item.get("method") for item in server.requests] == [
+        "initialize",
+        "initialized",
+        "thread/start",
+        "turn/start",
+    ]
+    turn_start = next(item for item in server.requests if item.get("method") == "turn/start")
+    thread_start = next(item for item in server.requests if item.get("method") == "thread/start")
+    assert thread_start["params"]["ephemeral"] is False
+    assert turn_start["params"]["sandboxPolicy"] == {
+        "type": "workspaceWrite",
+        "writableRoots": [str(tmp_path)],
+    }

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -206,7 +206,7 @@ def test_state_view_empty_when_no_db(tmp_path: Path) -> None:
     assert view["counts"] == {"running": 0, "retrying": 0}
     assert view["running"] == []
     assert view["retrying"] == []
-    assert view["totals"]["total_tokens"] == 0
+    assert view["codex_totals"]["total_tokens"] == 0
     assert view["rate_limits"] is None
     assert "generated_at" in view
 
@@ -279,7 +279,7 @@ def test_issue_runner_state_view_reads_scheduler_and_audit_files(tmp_path: Path)
     assert view["counts"] == {"running": 1, "retrying": 1}
     assert view["running"][0]["issue_identifier"] == "#123"
     assert view["retrying"][0]["issue_identifier"] == "#124"
-    assert view["totals"]["total_tokens"] == 18
+    assert view["codex_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
     assert view["recent_events"][0]["event"] == "issue_runner.tick.completed"
 
@@ -373,7 +373,7 @@ def test_render_dashboard_escapes_html(tmp_path: Path) -> None:
             }
         ],
         "retrying": [],
-        "totals": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "seconds_running": 0},
+        "codex_totals": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "seconds_running": 0},
         "rate_limits": None,
         "recent_events": [],
     }

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 from pathlib import Path
 
@@ -46,6 +47,55 @@ def test_instance_unit_name():
     tools = load_tools()
     assert tools._instance_unit_name("active", "workflow") == "daedalus-active@workflow.service"
     assert tools._instance_unit_name("shadow", "blueprint") == "daedalus-shadow@blueprint.service"
+
+
+def test_codex_app_server_service_name_and_unit(tmp_path):
+    tools = load_tools()
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+
+    assert (
+        tools._codex_app_server_service_name(workflow_root=workflow_root)
+        == "daedalus-codex-app-server@attmous-daedalus-issue-runner.service"
+    )
+    rendered = tools._render_codex_app_server_unit(listen="ws://127.0.0.1:4500", codex_command="codex")
+    assert "Description=Daedalus Codex app-server" in rendered
+    assert "ExecStart=/usr/bin/env codex app-server --listen ws://127.0.0.1:4500" in rendered
+    assert "Restart=always" in rendered
+
+
+def test_codex_app_server_install_command_writes_user_unit(tmp_path, monkeypatch):
+    tools = load_tools()
+    systemd_dir = tmp_path / "systemd"
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_dir))
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    calls = []
+
+    def fake_systemctl(*args):
+        calls.append(args)
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "",
+            "command": ["systemctl", "--user", *args],
+        }
+
+    monkeypatch.setattr(tools, "_run_systemctl", fake_systemctl)
+
+    result = tools.execute_raw_args(
+        f"codex-app-server install --workflow-root {workflow_root} "
+        "--listen ws://127.0.0.1:4500 --json"
+    )
+
+    payload = json.loads(result)
+    assert payload["ok"] is True
+    assert payload["service_name"] == "daedalus-codex-app-server@attmous-daedalus-issue-runner.service"
+    unit_path = systemd_dir / payload["service_name"]
+    assert unit_path.exists()
+    assert "codex app-server --listen ws://127.0.0.1:4500" in unit_path.read_text(encoding="utf-8")
+    assert ("daemon-reload",) in calls
 
 
 def test_migrate_systemd_tolerant_of_missing_old_units(tmp_path, monkeypatch):

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -64,6 +64,47 @@ def test_codex_app_server_service_name_and_unit(tmp_path):
     assert "Restart=always" in rendered
 
 
+def test_codex_app_server_unit_supports_websocket_auth_flags(tmp_path):
+    tools = load_tools()
+    token_file = tmp_path / "codex-token"
+    shared_secret_file = tmp_path / "codex-shared-secret"
+
+    token_unit = tools._render_codex_app_server_unit(
+        listen="ws://127.0.0.1:4500",
+        codex_command="codex",
+        ws_token_file=str(token_file),
+    )
+    assert "--ws-auth capability-token --ws-token-file" in token_unit
+    assert str(token_file) in token_unit
+
+    signed_unit = tools._render_codex_app_server_unit(
+        listen="ws://127.0.0.1:4500",
+        codex_command="codex",
+        ws_shared_secret_file=str(shared_secret_file),
+        ws_issuer="daedalus",
+        ws_audience="codex-app-server",
+        ws_max_clock_skew_seconds=60,
+    )
+    assert "--ws-auth signed-bearer-token --ws-shared-secret-file" in signed_unit
+    assert "--ws-issuer daedalus" in signed_unit
+    assert "--ws-audience codex-app-server" in signed_unit
+    assert "--ws-max-clock-skew-seconds 60" in signed_unit
+
+    with pytest.raises(tools.DaedalusCommandError, match="absolute path"):
+        tools._render_codex_app_server_unit(
+            listen="ws://127.0.0.1:4500",
+            codex_command="codex",
+            ws_token_file="relative-token",
+        )
+    with pytest.raises(tools.DaedalusCommandError, match="mutually exclusive"):
+        tools._render_codex_app_server_unit(
+            listen="ws://127.0.0.1:4500",
+            codex_command="codex",
+            ws_token_file=str(token_file),
+            ws_shared_secret_file=str(shared_secret_file),
+        )
+
+
 def test_codex_app_server_install_command_writes_user_unit(tmp_path, monkeypatch):
     tools = load_tools()
     systemd_dir = tmp_path / "systemd"
@@ -96,6 +137,90 @@ def test_codex_app_server_install_command_writes_user_unit(tmp_path, monkeypatch
     assert unit_path.exists()
     assert "codex app-server --listen ws://127.0.0.1:4500" in unit_path.read_text(encoding="utf-8")
     assert ("daemon-reload",) in calls
+
+
+def test_codex_app_server_status_includes_ready_probe(tmp_path, monkeypatch):
+    tools = load_tools()
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+
+    def fake_systemctl(*args):
+        if args[0] == "is-active":
+            stdout = "active"
+        elif args[0] == "is-enabled":
+            stdout = "enabled"
+        elif args[0] == "show":
+            stdout = "ActiveState=active\nSubState=running"
+        else:
+            stdout = ""
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "command": ["systemctl", "--user", *args],
+        }
+
+    monkeypatch.setattr(tools, "_run_systemctl", fake_systemctl)
+    monkeypatch.setattr(
+        tools,
+        "_codex_app_server_readyz",
+        lambda **kwargs: {"ok": True, "checked": True, **kwargs},
+    )
+
+    result = tools.codex_app_server_status(
+        workflow_root=workflow_root,
+        endpoint="ws://127.0.0.1:4500",
+    )
+
+    assert result["active"] == "active"
+    assert result["enabled"] == "enabled"
+    assert result["ready"]["ok"] is True
+    assert result["ready"]["endpoint"] == "ws://127.0.0.1:4500"
+
+
+def test_codex_app_server_restart_and_logs(tmp_path, monkeypatch):
+    tools = load_tools()
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    systemctl_calls = []
+    journal_calls = []
+
+    def fake_systemctl(*args):
+        systemctl_calls.append(args)
+        stdout = ""
+        if args[0] == "is-active":
+            stdout = "active"
+        elif args[0] == "is-enabled":
+            stdout = "enabled"
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "command": ["systemctl", "--user", *args],
+        }
+
+    def fake_run(cmd, **kwargs):
+        journal_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "line 1\nline 2\n", "")
+
+    monkeypatch.setattr(tools, "_run_systemctl", fake_systemctl)
+    monkeypatch.setattr(tools, "_codex_app_server_readyz", lambda **kwargs: {"ok": True, **kwargs})
+    monkeypatch.setattr(tools.subprocess, "run", fake_run)
+
+    restart = tools.codex_app_server_restart(workflow_root=workflow_root)
+    logs = tools.codex_app_server_logs(workflow_root=workflow_root, lines=25)
+
+    assert restart["ok"] is True
+    assert ("restart", "daedalus-codex-app-server@attmous-daedalus-issue-runner.service") in systemctl_calls
+    assert logs["stdout"] == "line 1\nline 2"
+    assert journal_calls[0][:4] == [
+        "journalctl",
+        "--user",
+        "-u",
+        "daedalus-codex-app-server@attmous-daedalus-issue-runner.service",
+    ]
 
 
 def test_migrate_systemd_tolerant_of_missing_old_units(tmp_path, monkeypatch):

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -30,9 +30,10 @@ def _config() -> dict:
         },
         "codex": {
             "command": "codex app-server",
-            "approval_policy": "auto",
+            "ephemeral": False,
+            "approval_policy": "never",
             "thread_sandbox": "workspace-write",
-            "turn_sandbox_policy": "auto",
+            "turn_sandbox_policy": "workspace-write",
             "turn_timeout_ms": 3600000,
             "read_timeout_ms": 5000,
             "stall_timeout_ms": 300000,
@@ -93,12 +94,36 @@ def test_issue_runner_schema_accepts_linear_tracker_and_codex_runtime():
             "codex": {
                 "kind": "codex-app-server",
                 "command": "codex app-server",
-                "approval_policy": "auto",
+                "approval_policy": "never",
                 "thread_sandbox": "workspace-write",
-                "turn_sandbox_policy": "auto",
+                "turn_sandbox_policy": "workspace-write",
                 "turn_timeout_ms": 3600000,
                 "read_timeout_ms": 5000,
                 "stall_timeout_ms": 300000,
+            }
+        }
+    }
+    jsonschema.validate(cfg, schema)
+
+
+def test_issue_runner_schema_accepts_external_codex_app_server_runtime():
+    schema = yaml.safe_load(
+        (REPO_ROOT / "daedalus" / "workflows" / "issue_runner" / "schema.yaml").read_text(encoding="utf-8")
+    )
+    cfg = _config()
+    cfg["agent"]["runtime"] = "codex"
+    cfg["daedalus"] = {
+        "runtimes": {
+            "codex": {
+                "kind": "codex-app-server",
+                "mode": "external",
+                "endpoint": "ws://127.0.0.1:4500",
+                "healthcheck_path": "/readyz",
+                "ws_token_env": "CODEX_APP_SERVER_TOKEN",
+                "ephemeral": False,
+                "approval_policy": "never",
+                "thread_sandbox": "workspace-write",
+                "turn_sandbox_policy": "workspace-write",
             }
         }
     }

--- a/tests/test_workflows_issue_runner_tracker.py
+++ b/tests/test_workflows_issue_runner_tracker.py
@@ -63,6 +63,13 @@ def test_local_json_tracker_client_lists_candidates_terminal_and_refresh(tmp_pat
     assert refreshed["ISSUE-1"]["title"] == "Higher priority"
 
 
+def test_issue_workspace_slug_matches_symphony_sanitization():
+    from workflows.issue_runner.tracker import issue_workspace_slug
+
+    assert issue_workspace_slug({"identifier": "ABC-123"}) == "ABC-123"
+    assert issue_workspace_slug({"identifier": "ABC/123 needs work"}) == "ABC_123_needs_work"
+
+
 def test_linear_tracker_client_normalizes_graphql_payload(monkeypatch, tmp_path):
     from workflows.issue_runner.tracker import build_tracker_client
 
@@ -107,6 +114,7 @@ def test_linear_tracker_client_normalizes_graphql_payload(monkeypatch, tmp_path)
         assert endpoint == "https://api.linear.app/graphql"
         assert api_key == "linear-token"
         if "IssueRunnerIssuesByIds" in query:
+            assert "$ids: [ID!]" in query
             return {
                 "data": {
                     "issues": {
@@ -115,6 +123,7 @@ def test_linear_tracker_client_normalizes_graphql_payload(monkeypatch, tmp_path)
                     }
                 }
             }
+        assert "project: { slugId: { eq: $projectSlug } }" in query
         states = {state.lower() for state in (variables.get("states") or [])}
         nodes = [active_issue] if "in progress" in states else [terminal_issue]
         return {
@@ -148,6 +157,61 @@ def test_linear_tracker_client_normalizes_graphql_payload(monkeypatch, tmp_path)
     assert candidates[0]["blocked_by"][0]["identifier"] == "ABC-122"
     assert terminals[0]["state"] == "Done"
     assert refreshed["lin-1"]["branch_name"] == "abc-123-important-work"
+
+
+def test_linear_tracker_client_empty_state_fetch_does_not_call_api(monkeypatch, tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    monkeypatch.setenv("LINEAR_API_KEY", "linear-token")
+
+    def fail_post_json(*args, **kwargs):
+        raise AssertionError("empty state fetch should not call Linear")
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "linear",
+            "api_key": "$LINEAR_API_KEY",
+            "project_slug": "core",
+            "active_states": [],
+            "terminal_states": [],
+        },
+        post_json=fail_post_json,
+    )
+
+    assert client.list_candidates() == []
+    assert client.list_terminal() == []
+
+
+def test_linear_tracker_client_errors_when_pagination_cursor_missing(monkeypatch, tmp_path):
+    from workflows.issue_runner.tracker import TrackerConfigError, build_tracker_client
+
+    monkeypatch.setenv("LINEAR_API_KEY", "linear-token")
+
+    def fake_post_json(endpoint, *, query, variables, api_key):
+        del endpoint, query, variables, api_key
+        return {
+            "data": {
+                "issues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": True, "endCursor": None},
+                }
+            }
+        }
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "linear",
+            "api_key": "$LINEAR_API_KEY",
+            "project_slug": "core",
+            "active_states": ["Todo"],
+        },
+        post_json=fake_post_json,
+    )
+
+    with pytest.raises(TrackerConfigError, match="endCursor"):
+        client.list_candidates()
 
 
 def test_linear_tracker_client_requires_api_key(monkeypatch, tmp_path):

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -34,9 +34,10 @@ def _config(tmp_path: Path) -> dict:
         },
         "codex": {
             "command": "codex app-server",
-            "approval_policy": "auto",
+            "ephemeral": False,
+            "approval_policy": "never",
             "thread_sandbox": "workspace-write",
-            "turn_sandbox_policy": "auto",
+            "turn_sandbox_policy": "workspace-write",
             "turn_timeout_ms": 3600000,
             "read_timeout_ms": 5000,
             "stall_timeout_ms": 300000,
@@ -55,6 +56,71 @@ def _config(tmp_path: Path) -> dict:
             "audit-log": "memory/workflow-audit.jsonl",
         },
     }
+
+
+def _write_fake_codex_app_server(path: Path, *, requests_path: Path, fail: bool = False) -> None:
+    thread_id = "thread-2" if fail else "thread-1"
+    turn_id = "turn-2" if fail else "turn-1"
+    input_tokens = 5 if fail else 11
+    output_tokens = 2 if fail else 7
+    total_tokens = input_tokens + output_tokens
+    requests_remaining = 88 if fail else 99
+    message_delta = "" if fail else "handled prompt"
+    script = [
+        "import json",
+        "import sys",
+        f"requests_path = {str(requests_path)!r}",
+        f"thread_id = {thread_id!r}",
+        f"turn_id = {turn_id!r}",
+        f"input_tokens = {input_tokens!r}",
+        f"output_tokens = {output_tokens!r}",
+        f"total_tokens = {total_tokens!r}",
+        f"requests_remaining = {requests_remaining!r}",
+        f"message_delta = {message_delta!r}",
+        "",
+        "def emit(payload):",
+        "    print(json.dumps(payload), flush=True)",
+        "",
+        "def record(payload):",
+        "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+        "        fh.write(json.dumps(payload) + '\\n')",
+        "",
+        "for line in sys.stdin:",
+        "    payload = json.loads(line)",
+        "    record(payload)",
+        "    method = payload.get('method')",
+        "    request_id = payload.get('id')",
+        "    if method == 'initialize':",
+        "        emit({'id': request_id, 'result': {'userAgent': 'fake-codex', 'codexHome': '/tmp/codex'}})",
+        "    elif method == 'initialized':",
+        "        continue",
+        "    elif method == 'thread/start':",
+        "        emit({'id': request_id, 'result': {'thread': {'id': thread_id, 'status': 'running', 'turns': []}}})",
+        "    elif method == 'thread/resume':",
+        "        thread_id = payload.get('params', {}).get('threadId') or thread_id",
+        "        emit({'id': request_id, 'result': {'thread': {'id': thread_id, 'status': 'running', 'turns': []}}})",
+        "    elif method == 'turn/start':",
+        "        turn = {'id': turn_id, 'status': 'running', 'items': []}",
+        "        usage_base = {'cachedInputTokens': 0, 'reasoningOutputTokens': 0}",
+        "        usage = dict(usage_base)",
+        "        usage.update(inputTokens=input_tokens, outputTokens=output_tokens, totalTokens=total_tokens)",
+        "        item = {'threadId': thread_id, 'turnId': turn_id, 'itemId': 'item-1'}",
+        "        emit({'id': request_id, 'result': {'turn': turn}})",
+        "        emit({'method': 'turn/started', 'params': {'threadId': thread_id, 'turn': turn}})",
+        "        token_usage = {'last': usage, 'total': usage}",
+        "        emit({'method': 'thread/tokenUsage/updated', 'params': {**item, 'tokenUsage': token_usage}})",
+        "        rate_limits = {'requests_remaining': requests_remaining}",
+        "        emit({'method': 'account/rateLimits/updated', 'params': {'rateLimits': rate_limits}})",
+        "        if message_delta:",
+        "            emit({'method': 'agent/message_delta', 'params': {**item, 'delta': message_delta}})",
+        "            completed_turn = {'id': turn_id, 'status': 'completed', 'items': []}",
+        "            emit({'method': 'turn/completed', 'params': {'threadId': thread_id, 'turn': completed_turn}})",
+        "            break",
+        "        error = {'message': 'tool call rejected'}",
+        "        emit({'method': 'error', 'params': {**item, 'willRetry': False, 'error': error}})",
+        "        raise SystemExit(1)",
+    ]
+    path.write_text("\n".join(script) + "\n", encoding="utf-8")
 
 
 def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
@@ -109,7 +175,7 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
         ),
         encoding="utf-8",
     )
-    stale_terminal_workspace = workflow_root / "workspace" / "issues" / "issue-2"
+    stale_terminal_workspace = workflow_root / "workspace" / "issues" / "ISSUE-2"
     stale_terminal_workspace.mkdir(parents=True)
     (stale_terminal_workspace / "stale.txt").write_text("stale\n", encoding="utf-8")
 
@@ -142,6 +208,8 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
 
     assert result["ok"] is True
     assert result["selectedIssue"]["id"] == "ISSUE-1"
+    assert result["results"][0]["retry"]["delay_type"] == "continuation"
+    assert result["results"][0]["retry"]["delay_ms"] == 1000
     output_path = Path(result["outputPath"])
     assert output_path.exists()
     assert output_path.read_text(encoding="utf-8") == "agent finished\n"
@@ -153,10 +221,11 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     assert (issue_workspace / "created.txt").exists()
     assert (issue_workspace / "before.txt").exists()
     assert (issue_workspace / "after.txt").exists()
-    assert not (workflow_root / "workspace" / "issues" / "issue-2").exists()
+    assert not (workflow_root / "workspace" / "issues" / "ISSUE-2").exists()
     status = workspace.build_status()
     assert status["selectedIssue"]["id"] == "ISSUE-1"
     assert status["tracker"]["eligibleCount"] == 1
+    assert status["scheduler"]["retry_queue"][0]["error"] == "continuation"
 
 
 def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
@@ -167,21 +236,8 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     cfg.pop("daedalus", None)
 
     runtime_script = tmp_path / "fake_codex_app_server.py"
-    runtime_script.write_text(
-        "\n".join(
-            [
-                "import json",
-                "import sys",
-                "prompt = sys.stdin.read()",
-                'print(json.dumps({"event": "session_started", "session_id": "sess-1", "thread_id": "thread-1"}))',
-                'print(json.dumps({"event": "turn_started", "turn_id": "turn-1"}))',
-                'print(json.dumps({"text": "handled prompt", "message": "handled prompt"}))',
-                'print(json.dumps({"event": "turn_completed", "turn_id": "turn-1", "usage": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}, "rate_limits": {"requests_remaining": 99, "tokens_remaining": 9000}}))',
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    requests_path = tmp_path / "fake_codex_requests.jsonl"
+    _write_fake_codex_app_server(runtime_script, requests_path=requests_path)
     cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
 
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
@@ -220,7 +276,7 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     result = workspace.tick()
 
     assert result["ok"] is True
-    assert result["metrics"]["session_id"] == "sess-1"
+    assert result["metrics"]["session_id"] == "thread-1"
     assert result["metrics"]["thread_id"] == "thread-1"
     assert result["metrics"]["turn_id"] == "turn-1"
     assert result["metrics"]["tokens"] == {
@@ -230,13 +286,84 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     }
     assert result["metrics"]["rate_limits"] == {
         "requests_remaining": 99,
-        "tokens_remaining": 9000,
     }
     assert Path(result["outputPath"]).read_text(encoding="utf-8") == "handled prompt\n"
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    turn_start = next(item for item in requests if item.get("method") == "turn/start")
+    assert turn_start["params"]["input"] == [{"type": "text", "text": "Issue: ISSUE-1\nAttempt:\n"}]
+    assert turn_start["params"]["sandboxPolicy"] == {
+        "type": "workspaceWrite",
+        "writableRoots": [str(workflow_root / "workspace" / "issues" / "ISSUE-1")],
+    }
 
     status = workspace.build_status()
     assert status["metrics"]["tokens"]["total_tokens"] == 18
     assert status["metrics"]["rate_limits"]["requests_remaining"] == 99
+    assert status["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+
+
+def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    cfg["agent"].pop("runtime", None)
+    cfg.pop("daedalus", None)
+
+    runtime_script = tmp_path / "fake_codex_app_server.py"
+    requests_path = tmp_path / "fake_codex_requests.jsonl"
+    _write_fake_codex_app_server(runtime_script, requests_path=requests_path)
+    cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
+
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    (workflow_root / "config").mkdir()
+    (workflow_root / "config" / "issues.json").write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "id": "ISSUE-1",
+                        "identifier": "ISSUE-1",
+                        "title": "First issue",
+                        "description": "Do the thing.",
+                        "priority": 1,
+                        "state": "todo",
+                        "branch_name": "issue-1-first-issue",
+                        "url": "https://tracker.example/issues/ISSUE-1",
+                        "labels": ["sample"],
+                        "blocked_by": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config=cfg,
+            prompt_template="Issue: {{ issue.identifier }}\nAttempt: {{ attempt }}",
+        ),
+        encoding="utf-8",
+    )
+
+    first_workspace = load_workspace_from_config(workspace_root=workflow_root)
+    first = first_workspace.tick()
+    assert first["ok"] is True
+    assert first_workspace.build_status()["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+
+    reloaded = load_workspace_from_config(workspace_root=workflow_root)
+    assert reloaded.build_status()["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    reloaded.retry_entries["ISSUE-1"]["due_at_epoch"] = 0.0
+
+    second = reloaded.tick()
+    assert second["ok"] is True
+
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    methods = [item.get("method") for item in requests]
+    assert methods.count("thread/start") == 1
+    assert methods.count("thread/resume") == 1
+    thread_resume = next(item for item in requests if item.get("method") == "thread/resume")
+    assert thread_resume["params"]["threadId"] == "thread-1"
 
 
 def test_issue_runner_retry_queue_retries_failed_issue_on_next_due_tick(tmp_path):
@@ -306,13 +433,16 @@ def test_issue_runner_retry_queue_retries_failed_issue_on_next_due_tick(tmp_path
     failed = workspace.tick()
     assert failed["ok"] is False
     assert failed["retry"]["retry_attempt"] == 1
+    assert failed["retry"]["delay_ms"] == 10000
     assert workspace.build_status()["scheduler"]["retry_queue"]
 
     workspace.retry_entries["ISSUE-1"]["due_at_monotonic"] = 0.0
     recovered = workspace.tick()
     assert recovered["ok"] is True
     assert recovered["selectedIssue"]["id"] == "ISSUE-1"
-    assert workspace.build_status()["scheduler"]["retry_queue"] == []
+    retry_queue = workspace.build_status()["scheduler"]["retry_queue"]
+    assert retry_queue[0]["attempt"] == 1
+    assert retry_queue[0]["error"] == "continuation"
     assert workspace.build_status()["scheduler"]["codex_totals"]["total_tokens"] == 0
 
 
@@ -392,7 +522,9 @@ def test_issue_runner_retry_queue_persists_across_workspace_reload(tmp_path):
     reloaded.retry_entries["ISSUE-1"]["due_at_epoch"] = 0.0
     recovered = reloaded.tick()
     assert recovered["ok"] is True
-    assert reloaded.build_status()["scheduler"]["retry_queue"] == []
+    retry_queue = reloaded.build_status()["scheduler"]["retry_queue"]
+    assert retry_queue[0]["attempt"] == 1
+    assert retry_queue[0]["error"] == "continuation"
 
 
 def test_issue_runner_tick_dispatches_batch_up_to_max_concurrent_agents(tmp_path):
@@ -481,19 +613,8 @@ def test_issue_runner_codex_failure_preserves_partial_metrics(tmp_path):
     cfg.pop("daedalus", None)
 
     runtime_script = tmp_path / "fake_codex_app_server_fail.py"
-    runtime_script.write_text(
-        "\n".join(
-            [
-                "import json",
-                'print(json.dumps({"event": "session_started", "session_id": "sess-2", "thread_id": "thread-2"}))',
-                'print(json.dumps({"event": "turn_started", "turn_id": "turn-2"}))',
-                'print(json.dumps({"event": "turn_failed", "turn_id": "turn-2", "message": "tool call rejected", "usage": {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7}, "rate_limits": {"requests_remaining": 88}}))',
-                "raise SystemExit(1)",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    requests_path = tmp_path / "fake_codex_fail_requests.jsonl"
+    _write_fake_codex_app_server(runtime_script, requests_path=requests_path, fail=True)
     cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
 
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
@@ -532,3 +653,114 @@ def test_issue_runner_codex_failure_preserves_partial_metrics(tmp_path):
     assert result["metrics"]["tokens"]["total_tokens"] == 7
     assert result["metrics"]["rate_limits"]["requests_remaining"] == 88
     assert workspace.build_status()["scheduler"]["codex_totals"]["total_tokens"] == 7
+
+
+def test_issue_runner_run_loop_keeps_last_known_good_on_invalid_reload(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    (workflow_root / "config").mkdir()
+    (workflow_root / "config" / "issues.json").write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "id": "ISSUE-1",
+                        "identifier": "ISSUE-1",
+                        "title": "First issue",
+                        "description": "Do the thing.",
+                        "priority": 1,
+                        "state": "todo",
+                        "labels": [],
+                        "blocked_by": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    workflow_file = workflow_root / "WORKFLOW.md"
+    workflow_file.write_text(
+        render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command[:2] == ["bash", "-lc"]:
+            class HookResult:
+                stdout = ""
+                stderr = ""
+                returncode = 0
+
+            return HookResult()
+
+        class Result:
+            stdout = "agent finished\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+    workflow_file.write_text("---\nworkflow: [unclosed\n", encoding="utf-8")
+
+    result = workspace.run_loop(interval_seconds=1, max_iterations=1, sleep_fn=lambda _seconds: None)
+
+    assert result["loop_status"] == "completed"
+    assert result["last_result"]["ok"] is True
+    events = (workflow_root / "memory" / "workflow-audit.jsonl").read_text(encoding="utf-8")
+    assert "daedalus.config_reload_failed" in events
+
+
+def test_issue_runner_rejects_workspace_symlink_escape(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    (workflow_root / "config").mkdir()
+    (workflow_root / "config" / "issues.json").write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "id": "ISSUE-1",
+                        "identifier": "ISSUE-1",
+                        "title": "Escape issue",
+                        "description": "Should not run outside root.",
+                        "priority": 1,
+                        "state": "todo",
+                        "labels": [],
+                        "blocked_by": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    issue_root = workflow_root / "workspace" / "issues"
+    issue_root.mkdir(parents=True)
+    (issue_root / "ISSUE-1").symlink_to(outside, target_is_directory=True)
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=lambda *args, **kwargs: None,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    result = workspace.tick()
+
+    assert result["ok"] is False
+    assert "not a child" in result["error"]


### PR DESCRIPTION
## Summary

Hardens the generic `issue-runner` workflow and Codex app-server integration toward the Symphony-aligned execution model.

- Adds a real Codex app-server JSON-RPC runtime with managed stdio and external WebSocket modes.
- Adds `hermes daedalus codex-app-server install|up|status|restart|logs|down` for a shared managed Codex app-server user service.
- Supports managed WebSocket auth flags for capability tokens and signed bearer tokens.
- Persists `issue_id -> thread_id` scheduler state and resumes existing Codex threads with `thread/resume` instead of always starting fresh threads.
- Fails visibly when `thread/resume` fails instead of falling back to `thread/start`.
- Treats `read_timeout_ms` as active-turn polling cadence; `stall_timeout_ms` and `turn_timeout_ms` remain the abort thresholds.
- Adds `/readyz` probing to app-server status.
- Tightens issue-runner scheduler persistence, retry/backoff, workspace safety, Linear tracker handling, status/HTTP visibility, and documentation.

## Validation

- `pytest -q` -> `771 passed, 6 skipped`
- `git diff --check` -> clean
