### PR TITLE
Supervise issue-runner workers

### DIFF
--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -436,6 +436,7 @@ class CodexAppServerRuntime:
         self._last_activity: float | None = None
         self._last_result: PromptRunResult | None = None
         self._resume_thread_ids: dict[str, str] = {}
+        self._cancel_event: threading.Event | None = None
 
     def _record_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -445,6 +446,9 @@ class CodexAppServerRuntime:
 
     def last_result(self) -> PromptRunResult | None:
         return self._last_result
+
+    def set_cancel_event(self, event: threading.Event | None) -> None:
+        self._cancel_event = event
 
     def ensure_session(
         self,
@@ -748,6 +752,15 @@ class CodexAppServerRuntime:
         stall_timeout = self._stall_timeout_ms / 1000 if self._stall_timeout_ms > 0 else None
         while True:
             now = time.monotonic()
+            if self._cancel_event is not None and self._cancel_event.is_set():
+                self._interrupt_turn(client=client, state=state)
+                result = self._result_from_state(state)
+                raise CodexAppServerError(
+                    "codex-app-server turn canceled",
+                    result=result,
+                    stderr=client.stderr_text,
+                    returncode=client.returncode,
+                )
             if now >= deadline:
                 self._interrupt_turn(client=client, state=state)
                 result = self._result_from_state(state)

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -5,8 +5,9 @@ import json
 import os
 import shutil
 import subprocess
+import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
@@ -286,6 +287,9 @@ class IssueRunnerWorkspace:
     codex_threads: dict[str, dict[str, Any]]
     running_issue_id: str | None = None
     codex_totals: dict[str, Any] | None = None
+    _supervisor_executor: concurrent.futures.ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
+    _supervisor_futures: dict[str, concurrent.futures.Future] = field(default_factory=dict, init=False, repr=False)
+    _supervisor_cancel_events: dict[str, threading.Event] = field(default_factory=dict, init=False, repr=False)
 
     def runtime(self, name: str) -> Runtime:
         return self.runtimes[name]
@@ -437,10 +441,21 @@ class IssueRunnerWorkspace:
                 continue
             entry = {
                 "issue_id": issue_id,
+                "worker_id": item.get("worker_id") or item.get("workerId") or f"worker:{issue_id}:recovered",
                 "identifier": item.get("identifier"),
                 "attempt": int(item.get("attempt") or 0),
                 "state": item.get("state"),
+                "worker_status": item.get("worker_status") or item.get("workerStatus") or "recovered",
                 "started_at_epoch": float(item.get("started_at_epoch") or item.get("startedAtEpoch") or _now_epoch()),
+                "heartbeat_at_epoch": float(
+                    item.get("heartbeat_at_epoch")
+                    or item.get("heartbeatAtEpoch")
+                    or item.get("started_at_epoch")
+                    or item.get("startedAtEpoch")
+                    or _now_epoch()
+                ),
+                "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
+                "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
             }
             running_entries[issue_id] = entry
             recovered_running.append(entry)
@@ -471,14 +486,23 @@ class IssueRunnerWorkspace:
         running = []
         for issue_id, entry in self.running_entries.items():
             started_at_epoch = float(entry.get("started_at_epoch") or now_epoch)
+            heartbeat_at_epoch = float(entry.get("heartbeat_at_epoch") or started_at_epoch)
             running.append(
                 {
                     "issue_id": issue_id,
+                    "worker_id": entry.get("worker_id"),
                     "identifier": entry.get("identifier"),
                     "attempt": int(entry.get("attempt") or 0),
                     "state": entry.get("state"),
+                    "worker_status": entry.get("worker_status") or "running",
                     "started_at_epoch": started_at_epoch,
+                    "heartbeat_at_epoch": heartbeat_at_epoch,
                     "running_for_ms": max(int((now_epoch - started_at_epoch) * 1000), 0),
+                    "heartbeat_age_ms": max(int((now_epoch - heartbeat_at_epoch) * 1000), 0),
+                    "cancel_requested": bool(entry.get("cancel_requested") or False),
+                    "cancel_reason": entry.get("cancel_reason"),
+                    "thread_id": entry.get("thread_id"),
+                    "turn_id": entry.get("turn_id"),
                 }
             )
         running.sort(key=lambda item: (item["state"] or "", item["identifier"] or item["issue_id"]))
@@ -734,17 +758,24 @@ class IssueRunnerWorkspace:
 
     def _mark_running(self, selections: list[tuple[dict[str, Any], dict[str, Any] | None]]) -> None:
         now_epoch = _now_epoch()
-        self.running_entries = {
-            str(issue.get("id") or ""): {
-                "issue_id": str(issue.get("id") or ""),
+        entries = dict(self.running_entries)
+        for issue, retry_entry in selections:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id:
+                continue
+            entries[issue_id] = {
+                "issue_id": issue_id,
+                "worker_id": f"worker:{issue_id}:{int(now_epoch * 1000)}",
                 "identifier": issue.get("identifier"),
                 "attempt": self._issue_attempt(issue=issue, retry_entry=retry_entry),
                 "state": issue.get("state"),
+                "worker_status": "running",
                 "started_at_epoch": now_epoch,
+                "heartbeat_at_epoch": now_epoch,
+                "cancel_requested": False,
+                "cancel_reason": None,
             }
-            for issue, retry_entry in selections
-            if str(issue.get("id") or "").strip()
-        }
+        self.running_entries = entries
         self.running_issue_id = next(iter(self.running_entries), None)
         self._persist_scheduler_state()
 
@@ -763,11 +794,37 @@ class IssueRunnerWorkspace:
             return self._metrics_payload(result)
         return {}
 
+    def _cancel_result(
+        self,
+        *,
+        issue: dict[str, Any],
+        attempt: int,
+        reason: str,
+        workspace: Path | None = None,
+        output_path: Path | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "canceled": True,
+            "suppressRetry": reason == "terminal-state",
+            "issue": issue,
+            "attempt": attempt,
+            "workspace": str(workspace) if workspace is not None else None,
+            "createdWorkspace": False,
+            "hookResults": [],
+            "outputPath": str(output_path) if output_path is not None else None,
+            "error": f"worker canceled: {reason}",
+            "metrics": {},
+            "runtime": None,
+            "runtimeKind": None,
+        }
+
     def _execute_issue(
         self,
         *,
         issue: dict[str, Any],
         retry_entry: dict[str, Any] | None,
+        cancel_event: threading.Event | None = None,
     ) -> dict[str, Any]:
         hook_results: list[dict[str, Any]] = []
         runtime: Runtime | None = None
@@ -780,6 +837,12 @@ class IssueRunnerWorkspace:
         attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
 
         try:
+            if cancel_event is not None and cancel_event.is_set():
+                return self._cancel_result(
+                    issue=issue,
+                    attempt=attempt,
+                    reason="requested-before-start",
+                )
             issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
             issue_workspace.mkdir(parents=True, exist_ok=True)
             _assert_workspace_inside_root(self.issue_workspace_root, issue_workspace)
@@ -797,6 +860,14 @@ class IssueRunnerWorkspace:
             prompt_path.write_text(prompt, encoding="utf-8")
             output_path = daemon_dir / "last-output.txt"
             env = self._hook_env(issue=issue, issue_workspace=issue_workspace, prompt_path=prompt_path, output_path=output_path)
+            if cancel_event is not None and cancel_event.is_set():
+                return self._cancel_result(
+                    issue=issue,
+                    attempt=attempt,
+                    reason="requested-before-run",
+                    workspace=issue_workspace,
+                    output_path=output_path,
+                )
             if created_workspace:
                 hook_results.append(self._run_hook("after_create", issue_workspace, env))
                 created_marker.write_text(_now_iso() + "\n", encoding="utf-8")
@@ -807,6 +878,9 @@ class IssueRunnerWorkspace:
             runtime_profiles = _runtime_profiles_from_config(self.config)
             runtime_cfg = runtime_profiles.get(runtime_name) or {}
             runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
+            set_cancel_event = getattr(runtime, "set_cancel_event", None)
+            if callable(set_cancel_event) and cancel_event is not None:
+                set_cancel_event(cancel_event)
             session_name = issue_session_name(issue)
             model = str(agent_cfg.get("model") or "")
             resume_thread_id = None
@@ -875,6 +949,375 @@ class IssueRunnerWorkspace:
                 "runtimeKind": runtime_cfg.get("kind") if runtime is not None else None,
             }
 
+    def _apply_issue_results(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        applied: list[dict[str, Any]] = []
+        for result in results:
+            issue = result.get("issue") or {}
+            issue_id = str(issue.get("id") or "")
+            metrics = result.get("metrics") or {}
+            if metrics:
+                recorded_metrics = self._record_metrics(
+                    PromptRunResult(
+                        output="",
+                        session_id=metrics.get("session_id"),
+                        thread_id=metrics.get("thread_id"),
+                        turn_id=metrics.get("turn_id"),
+                        last_event=metrics.get("last_event"),
+                        last_message=metrics.get("last_message"),
+                        turn_count=int(metrics.get("turn_count") or 0),
+                        tokens=metrics.get("tokens"),
+                        rate_limits=metrics.get("rate_limits"),
+                    )
+                )
+                if result.get("runtimeKind") == "codex-app-server":
+                    self._record_codex_thread(
+                        issue=issue,
+                        session_name=issue_session_name(issue),
+                        metrics=recorded_metrics,
+                    )
+                result["metrics"] = recorded_metrics
+
+            if result.get("ok"):
+                self._clear_retry(issue_id)
+                if result.get("suppressRetry"):
+                    result["retry"] = None
+                else:
+                    retry = self._schedule_retry(
+                        issue=issue,
+                        error="continuation",
+                        current_attempt=result.get("attempt"),
+                        delay_type="continuation",
+                    )
+                    result["retry"] = retry
+                self._emit_event(
+                    "issue_runner.tick.completed",
+                    {
+                        "issue_id": issue.get("id"),
+                        "attempt": result.get("attempt"),
+                        "workspace": result.get("workspace"),
+                        "output_path": result.get("outputPath"),
+                        "continuation_retry_attempt": (result.get("retry") or {}).get("retry_attempt"),
+                        "continuation_retry_delay_ms": (result.get("retry") or {}).get("delay_ms"),
+                    },
+                )
+            else:
+                if result.get("suppressRetry"):
+                    result["retry"] = None
+                    self._emit_event(
+                        "issue_runner.tick.canceled",
+                        {
+                            "issue_id": issue.get("id"),
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "error": result.get("error"),
+                            "retry_suppressed": True,
+                        },
+                    )
+                else:
+                    retry = self._schedule_retry(
+                        issue=issue,
+                        error=str(result.get("error") or "issue execution failed"),
+                        current_attempt=result.get("attempt"),
+                    )
+                    result["retry"] = retry
+                    self._emit_event(
+                        "issue_runner.tick.failed",
+                        {
+                            "issue_id": issue.get("id"),
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "error": result.get("error"),
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "retry_delay_ms": retry.get("delay_ms"),
+                        },
+                    )
+            applied.append(result)
+        return applied
+
+    def _status_from_results(
+        self,
+        *,
+        base_status: dict[str, Any],
+        results: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        results.sort(key=lambda item: str(((item.get("issue") or {}).get("identifier")) or ((item.get("issue") or {}).get("id")) or ""))
+        applied = self._apply_issue_results(results)
+        tick_metrics = [result.get("metrics") or {} for result in applied if result.get("metrics")]
+        first = applied[0] if applied else {}
+        base_status.update(
+            {
+                "ok": all(result.get("ok") or result.get("suppressRetry") for result in applied),
+                "attempt": first.get("attempt"),
+                "outputPath": first.get("outputPath"),
+                "workspace": first.get("workspace"),
+                "createdWorkspace": first.get("createdWorkspace"),
+                "hookResults": first.get("hookResults"),
+                "results": applied,
+                "metrics": self._aggregate_metrics(tick_metrics),
+            }
+        )
+        failed = next((result for result in applied if not result.get("ok") and not result.get("suppressRetry")), None)
+        if failed:
+            base_status["error"] = failed.get("error")
+            base_status["retry"] = failed.get("retry")
+        return base_status
+
+    def _supervisor_max_workers(self) -> int:
+        scheduler = _scheduler_state_from_config(self.config)
+        return max(int(scheduler["max_concurrent_agents"]), 1)
+
+    def _ensure_supervisor_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        if self._supervisor_executor is None:
+            self._supervisor_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=self._supervisor_max_workers(),
+                thread_name_prefix="daedalus-issue-runner",
+            )
+        return self._supervisor_executor
+
+    def _request_supervised_cancel(self, issue_id: str, *, reason: str) -> bool:
+        if not issue_id or issue_id not in self.running_entries:
+            return False
+        entry = self.running_entries[issue_id]
+        if entry.get("cancel_requested"):
+            return False
+        entry["cancel_requested"] = True
+        entry["cancel_reason"] = reason
+        entry["worker_status"] = "canceling"
+        entry["heartbeat_at_epoch"] = _now_epoch()
+        event = self._supervisor_cancel_events.get(issue_id)
+        if event is not None:
+            event.set()
+        future = self._supervisor_futures.get(issue_id)
+        if future is not None:
+            future.cancel()
+        self._emit_event(
+            "issue_runner.worker.cancel_requested",
+            {
+                "issue_id": issue_id,
+                "identifier": entry.get("identifier"),
+                "reason": reason,
+                "worker_id": entry.get("worker_id"),
+            },
+        )
+        self._persist_scheduler_state()
+        return True
+
+    def _request_terminal_cancellations(self, terminal_issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        requested = []
+        for issue in terminal_issues:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id or issue_id not in self.running_entries:
+                continue
+            if self._request_supervised_cancel(issue_id, reason="terminal-state"):
+                requested.append(
+                    {
+                        "issue_id": issue_id,
+                        "identifier": issue.get("identifier"),
+                        "reason": "terminal-state",
+                    }
+                )
+        return requested
+
+    def _reconcile_supervised_workers(self) -> list[dict[str, Any]]:
+        completed: list[dict[str, Any]] = []
+        for issue_id, future in list(self._supervisor_futures.items()):
+            if not future.done():
+                entry = self.running_entries.get(issue_id)
+                if entry is not None:
+                    entry["heartbeat_at_epoch"] = _now_epoch()
+                continue
+            self._supervisor_futures.pop(issue_id, None)
+            self._supervisor_cancel_events.pop(issue_id, None)
+            entry = self.running_entries.get(issue_id) or {}
+            if future.cancelled():
+                result = self._cancel_result(
+                    issue={
+                        "id": issue_id,
+                        "identifier": entry.get("identifier"),
+                        "state": entry.get("state"),
+                    },
+                    attempt=int(entry.get("attempt") or 0),
+                    reason=str(entry.get("cancel_reason") or "canceled"),
+                )
+            else:
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    result = {
+                        "ok": False,
+                        "issue": {
+                            "id": issue_id,
+                            "identifier": entry.get("identifier"),
+                            "state": entry.get("state"),
+                        },
+                        "attempt": int(entry.get("attempt") or 0),
+                        "workspace": None,
+                        "createdWorkspace": False,
+                        "hookResults": [],
+                        "outputPath": None,
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "metrics": {},
+                        "runtime": None,
+                        "runtimeKind": None,
+                    }
+            if entry.get("cancel_requested"):
+                result["cancelRequested"] = True
+                result["cancelReason"] = entry.get("cancel_reason")
+                if entry.get("cancel_reason") == "terminal-state":
+                    result["suppressRetry"] = True
+            metrics = result.get("metrics") or {}
+            if metrics.get("thread_id"):
+                entry["thread_id"] = metrics.get("thread_id")
+            if metrics.get("turn_id"):
+                entry["turn_id"] = metrics.get("turn_id")
+            entry["worker_status"] = "completed" if result.get("ok") else ("canceled" if result.get("canceled") else "failed")
+            entry["heartbeat_at_epoch"] = _now_epoch()
+            self._clear_running([issue_id])
+            completed.append(result)
+            self._emit_event(
+                "issue_runner.worker.completed",
+                {
+                    "issue_id": issue_id,
+                    "identifier": (result.get("issue") or {}).get("identifier") or entry.get("identifier"),
+                    "worker_id": entry.get("worker_id"),
+                    "ok": result.get("ok"),
+                    "canceled": result.get("canceled"),
+                    "error": result.get("error"),
+                },
+            )
+        if completed:
+            self._persist_scheduler_state()
+        return completed
+
+    def _dispatch_supervised_workers(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+    ) -> list[dict[str, Any]]:
+        if not selections:
+            return []
+        executor = self._ensure_supervisor_executor()
+        self._mark_running(selections)
+        dispatched: list[dict[str, Any]] = []
+        for issue, retry_entry in selections:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id:
+                continue
+            cancel_event = threading.Event()
+            self._supervisor_cancel_events[issue_id] = cancel_event
+            future = executor.submit(
+                self._execute_issue,
+                issue=issue,
+                retry_entry=retry_entry,
+                cancel_event=cancel_event,
+            )
+            self._supervisor_futures[issue_id] = future
+            entry = self.running_entries.get(issue_id) or {}
+            resume_thread_id = self._codex_thread_for_issue(issue)
+            if resume_thread_id:
+                entry["thread_id"] = resume_thread_id
+            dispatched.append(dict(entry))
+            self._emit_event(
+                "issue_runner.worker.dispatched",
+                {
+                    "issue_id": issue_id,
+                    "identifier": issue.get("identifier"),
+                    "worker_id": entry.get("worker_id"),
+                    "attempt": entry.get("attempt"),
+                    "state": issue.get("state"),
+                },
+            )
+        self._persist_scheduler_state()
+        return dispatched
+
+    def supervise_once(self) -> dict[str, Any]:
+        status = {
+            "ok": True,
+            "workflow": "issue-runner",
+            "mode": "supervised",
+            "updatedAt": _now_iso(),
+            "selectedIssue": None,
+            "selectedIssues": [],
+            "attempt": None,
+            "outputPath": None,
+            "metrics": {},
+            "results": [],
+            "completedResults": [],
+            "dispatchedWorkers": [],
+            "cancellationRequests": [],
+        }
+        try:
+            issues = self.tracker_client.list_all()
+            terminal_issues = self.tracker_client.list_terminal()
+        except Exception as exc:
+            status["ok"] = False
+            status["error"] = f"{type(exc).__name__}: {exc}"
+            self._write_status(status, health="error")
+            self._emit_event(
+                "issue_runner.tick.failed",
+                {
+                    "error": status["error"],
+                    "reason": "tracker-load-failed",
+                },
+            )
+            return status
+
+        status["cancellationRequests"] = self._request_terminal_cancellations(terminal_issues)
+        completed = self._reconcile_supervised_workers()
+        if completed:
+            status = self._status_from_results(base_status=status, results=completed)
+            status["completedResults"] = status.get("results") or []
+        cleanup = self._cleanup_terminal_workspaces(terminal_issues)
+        status["cleanup"] = cleanup
+
+        issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
+        selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
+        refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+        for selected, retry_entry in selections:
+            issue_id = str(selected.get("id") or "").strip()
+            if issue_id:
+                selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
+            refreshed_selections.append((selected, retry_entry))
+        selections = refreshed_selections
+        status["selectedIssues"] = [issue for issue, _retry_entry in selections]
+        status["selectedIssue"] = selections[0][0] if selections else None
+        dispatched = self._dispatch_supervised_workers(selections)
+        status["dispatchedWorkers"] = dispatched
+        if not completed and not dispatched:
+            status["message"] = "no dispatchable issues"
+            self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
+
+        if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
+            status["ok"] = False
+        self._write_status(status, health="healthy" if status["ok"] else "error")
+        self._persist_scheduler_state()
+        return status
+
+    def _reconcile_before_loop_exit(self, last_result: dict[str, Any] | None) -> dict[str, Any] | None:
+        completed = self._reconcile_supervised_workers()
+        if not completed:
+            self._persist_scheduler_state()
+            return last_result
+        status = {
+            "ok": True,
+            "workflow": "issue-runner",
+            "mode": "supervised-exit-reconcile",
+            "updatedAt": _now_iso(),
+            "selectedIssue": None,
+            "selectedIssues": [],
+            "attempt": None,
+            "outputPath": None,
+            "metrics": {},
+            "results": [],
+            "completedResults": [],
+            "dispatchedWorkers": [],
+            "cancellationRequests": [],
+        }
+        status = self._status_from_results(base_status=status, results=completed)
+        status["completedResults"] = status.get("results") or []
+        self._write_status(status, health="healthy" if status["ok"] else "error")
+        self._persist_scheduler_state()
+        return status
+
     def tick(self) -> dict[str, Any]:
         status = {
             "ok": False,
@@ -923,7 +1366,6 @@ class IssueRunnerWorkspace:
 
         self._mark_running(selections)
         results: list[dict[str, Any]] = []
-        tick_metrics: list[dict[str, Any]] = []
         try:
             if len(selections) == 1:
                 issue, retry_entry = selections[0]
@@ -937,88 +1379,7 @@ class IssueRunnerWorkspace:
                     for future in concurrent.futures.as_completed(future_map):
                         results.append(future.result())
 
-            results.sort(key=lambda item: str(((item.get("issue") or {}).get("identifier")) or ((item.get("issue") or {}).get("id")) or ""))
-            for result in results:
-                issue = result.get("issue") or {}
-                issue_id = str(issue.get("id") or "")
-                metrics = result.get("metrics") or {}
-                if metrics:
-                    recorded_metrics = self._record_metrics(
-                        PromptRunResult(
-                            output="",
-                            session_id=metrics.get("session_id"),
-                            thread_id=metrics.get("thread_id"),
-                            turn_id=metrics.get("turn_id"),
-                            last_event=metrics.get("last_event"),
-                            last_message=metrics.get("last_message"),
-                            turn_count=int(metrics.get("turn_count") or 0),
-                            tokens=metrics.get("tokens"),
-                            rate_limits=metrics.get("rate_limits"),
-                        )
-                    )
-                    if result.get("runtimeKind") == "codex-app-server":
-                        self._record_codex_thread(
-                            issue=issue,
-                            session_name=issue_session_name(issue),
-                            metrics=recorded_metrics,
-                        )
-                    tick_metrics.append(recorded_metrics)
-                if result.get("ok"):
-                    self._clear_retry(issue_id)
-                    retry = self._schedule_retry(
-                        issue=issue,
-                        error="continuation",
-                        current_attempt=result.get("attempt"),
-                        delay_type="continuation",
-                    )
-                    result["retry"] = retry
-                    self._emit_event(
-                        "issue_runner.tick.completed",
-                        {
-                            "issue_id": issue.get("id"),
-                            "attempt": result.get("attempt"),
-                            "workspace": result.get("workspace"),
-                            "output_path": result.get("outputPath"),
-                            "continuation_retry_attempt": retry.get("retry_attempt"),
-                            "continuation_retry_delay_ms": retry.get("delay_ms"),
-                        },
-                    )
-                else:
-                    retry = self._schedule_retry(
-                        issue=issue,
-                        error=str(result.get("error") or "issue execution failed"),
-                        current_attempt=result.get("attempt"),
-                    )
-                    result["retry"] = retry
-                    self._emit_event(
-                        "issue_runner.tick.failed",
-                        {
-                            "issue_id": issue.get("id"),
-                            "attempt": result.get("attempt"),
-                            "workspace": result.get("workspace"),
-                            "error": result.get("error"),
-                            "retry_attempt": retry.get("retry_attempt"),
-                            "retry_delay_ms": retry.get("delay_ms"),
-                        },
-                    )
-
-            first = results[0]
-            status.update(
-                {
-                    "ok": all(result.get("ok") for result in results),
-                    "attempt": first.get("attempt"),
-                    "outputPath": first.get("outputPath"),
-                    "workspace": first.get("workspace"),
-                    "createdWorkspace": first.get("createdWorkspace"),
-                    "hookResults": first.get("hookResults"),
-                    "results": results,
-                    "metrics": self._aggregate_metrics(tick_metrics),
-                }
-            )
-            failed = next((result for result in results if not result.get("ok")), None)
-            if failed:
-                status["error"] = failed.get("error")
-                status["retry"] = failed.get("retry")
+            status = self._status_from_results(base_status=status, results=results)
             self._write_status(status, health="healthy" if status["ok"] else "error")
             return status
         finally:
@@ -1041,6 +1402,18 @@ class IssueRunnerWorkspace:
             if state not in terminal_states:
                 continue
             issue_id = str(issue.get("id") or "")
+            if issue_id in self.running_entries:
+                self._request_supervised_cancel(issue_id, reason="terminal-state")
+                cleaned.append(
+                    {
+                        "issue_id": issue.get("id"),
+                        "identifier": issue.get("identifier"),
+                        "workspace": None,
+                        "deferred": True,
+                        "reason": "worker-running",
+                    }
+                )
+                continue
             self._clear_retry(issue_id)
             self._clear_codex_thread(issue_id)
             issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
@@ -1075,16 +1448,20 @@ class IssueRunnerWorkspace:
         return cleaned
 
     def _write_status(self, tick_result: dict[str, Any], *, health: str) -> None:
+        results = tick_result.get("results") or tick_result.get("completedResults") or []
+        result_issues = [result.get("issue") for result in results if result.get("issue")]
+        selected_issue = result_issues[0] if result_issues else tick_result.get("selectedIssue")
+        selected_issues = result_issues or tick_result.get("selectedIssues") or ([selected_issue] if selected_issue else [])
         payload = {
             "workflow": "issue-runner",
             "health": health,
             "lastRun": {
                 "ok": tick_result.get("ok"),
-                "issue": tick_result.get("selectedIssue"),
-                "issues": tick_result.get("selectedIssues") or ([tick_result.get("selectedIssue")] if tick_result.get("selectedIssue") else []),
+                "issue": selected_issue,
+                "issues": selected_issues,
                 "attempt": tick_result.get("attempt"),
                 "outputPath": tick_result.get("outputPath"),
-                "results": tick_result.get("results") or [],
+                "results": results,
                 "updatedAt": tick_result.get("updatedAt") or _now_iso(),
             },
             "metrics": tick_result.get("metrics") or {},
@@ -1262,17 +1639,19 @@ class IssueRunnerWorkspace:
         try:
             while True:
                 self.reload_contract()
-                last_result = self.tick()
+                last_result = self.supervise_once()
                 iterations += 1
                 if max_iterations is not None and iterations >= max_iterations:
                     break
                 sleep_fn(self._poll_interval_seconds(interval_seconds))
         except KeyboardInterrupt:
+            last_result = self._reconcile_before_loop_exit(last_result)
             return {
                 "loop_status": "interrupted",
                 "iterations": iterations,
                 "last_result": last_result,
             }
+        last_result = self._reconcile_before_loop_exit(last_result)
         return {
             "loop_status": "completed",
             "iterations": iterations,

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -151,6 +151,9 @@ It maps `thread/tokenUsage/updated` into Daedalus token totals and
 non-interactive approval requests so an unattended service does not hang.
 `issue-runner` persists `issue_id -> thread_id` in scheduler state and resumes
 the existing Codex thread on later ticks instead of starting a fresh thread.
+In the supervised `issue-runner run` loop, terminal tracker transitions request
+cooperative cancellation; the Codex adapter sends `turn/interrupt` for the
+active turn before surfacing the cancellation result to the scheduler.
 
 ## Adding a new runtime
 

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -221,8 +221,8 @@ This is the bundled generic tracker-driven workflow.
 |---|---|---|
 || `/workflow issue-runner status` | Selected issue + last run summary |
 || `/workflow issue-runner doctor` | Validate tracker, workspace, and runtime references |
-|| `/workflow issue-runner tick` | Run one issue-runner dispatch tick |
-|| `/workflow issue-runner run` | Run the long-lived issue-runner polling loop |
+|| `/workflow issue-runner tick` | Run one synchronous issue-runner dispatch tick |
+|| `/workflow issue-runner run` | Run the supervised long-lived issue-runner polling loop |
 || `/workflow issue-runner serve` | Run the optional localhost HTTP status server |
 
 ### Webhook commands

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -17,10 +17,10 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | `WORKFLOW.md` loader | Partial | Supported as a repo-owned public contract. Front matter maps to the selected workflow schema; `issue-runner` is the closer generic reference surface, while `change-delivery` still carries richer GitHub-specific semantics. |
 | Typed config + hot reload | Implemented | Bundled workflows load repo-owned `WORKFLOW.md`; `issue-runner` now keeps last-known-good config on invalid reloads. |
 | Issue tracker client boundary | Partial | `issue-runner` has shared `local-json`, `github`, and Linear clients. The Linear query shape follows the Symphony baseline, but still needs real-service smoke validation. |
-| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, and persisted scheduler state now exist. |
-| Bounded concurrency | Partial | `issue-runner` now dispatches bounded batches and persists running-worker recovery, but the broader engine is still not uniformly scheduler-driven. |
-| Retry/backoff policy | Partial | `issue-runner` now uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff. The remaining gap is true async worker cancellation/reconciliation. |
-| Coding-agent protocol | Partial | `issue-runner` now ships a protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, and persisted thread resume. The remaining gap is in-flight worker cancellation/reconciliation. |
+| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised worker dispatch/reconciliation, and persisted scheduler state now exist. |
+| Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery, but the broader engine is still not uniformly scheduler-driven. |
+| Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
+| Coding-agent protocol | Partial | `issue-runner` ships a protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, and cooperative turn interruption. |
 | Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; `issue-runner` records per-run token/rate-limit metrics and exposes `codex_totals` plus Codex thread mappings. |
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
@@ -32,12 +32,12 @@ Daedalus currently differs from the Symphony draft in three material ways:
 1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow and has a Linear adapter, but the broader product story is still not Linear-first.
 2. Runtime adapters are still mixed: `issue-runner` has a protocol-level Codex app-server path, while the rest of Daedalus remains CLI/session-oriented.
 3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
-4. `issue-runner` still executes worker turns synchronously inside a tick, so in-flight cancellation on tracker state changes is not fully Symphony-shaped yet.
+4. `issue-runner` has async supervision in the long-running `run` path, but manual `tick` remains synchronous and command-style runtimes still have limited cancellation semantics.
 
 ## Recommended Next Gaps
 
-1. Move `issue-runner` from synchronous tick execution to true async worker supervision so reconciliation can stop active runs.
-2. Keep Codex app-server threads and loaded sessions alive across ticks instead of starting/resuming one connection per run.
+1. Keep Codex app-server sessions warm across worker turns instead of opening a connection per run.
+2. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
 3. Add real Linear integration smoke tests and publish a stricter conformance checklist.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -15,7 +15,7 @@ For each eligible tracker issue:
 5. render the Markdown workflow body as the issue prompt template
 6. invoke the configured runtime/agent
 7. persist output and audit state
-8. persist scheduler state for continuation retries, failure backoff, running-worker recovery, and token totals
+8. persist scheduler state for running workers, continuation retries, failure backoff, recovery, and token totals
 
 ## Use it when
 
@@ -46,6 +46,11 @@ Supported tracker kinds today:
 
 `issue-runner` composes the shared `trackers/` clients with workflow-specific
 eligibility, ordering, retry, and workspace policy.
+
+`tick` is the manual/debug path: it selects a batch and runs it synchronously
+before returning. `run` is the service path: it dispatches eligible workers,
+returns to the polling loop, reconciles completed workers on later iterations,
+and requests cancellation when a running issue enters a terminal tracker state.
 
 Scheduler state is persisted under `storage.scheduler` (default:
 `memory/workflow-scheduler.json`) so continuation retries, failure backoff,
@@ -107,8 +112,8 @@ tables.
 
 - The Linear adapter follows the Symphony baseline query shape, but still needs real Linear integration smoke coverage before claiming production-grade Linear support.
 - Managed service mode is `active` only. `shadow` remains specific to `change-delivery`.
-- The bundled Codex app-server adapter supports managed stdio and external WebSocket transports, including durable thread resume across ticks; full in-flight cancellation remains future work.
-- Worker execution is still synchronous inside each tick; full in-flight cancellation on tracker state changes is the next scheduler hardening step.
+- The bundled Codex app-server adapter supports managed stdio and external WebSocket transports, durable thread resume across ticks, and cooperative in-flight cancellation in the supervised `run` loop.
+- Cancellation is cooperative. Codex app-server turns are interrupted when Daedalus requests cancellation; command-style runtimes may only observe cancellation before they start or after they exit.
 
 ## Related docs
 

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -4,6 +4,7 @@ import json
 import socket
 import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -139,6 +140,46 @@ def _write_fake_quiet_turn_app_server(path: Path, requests_path: Path) -> None:
                 "        emit({'method': 'item/agentMessage/delta', 'params': {**item, 'delta': 'quiet ok'}})",
                 "        completed_turn = {'id': 'turn-quiet', 'status': 'completed', 'items': []}",
                 "        emit({'method': 'turn/completed', 'params': {'threadId': 'thread-quiet', 'turn': completed_turn}})",
+                "        break",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_fake_cancellable_app_server(path: Path, requests_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                f"requests_path = {str(requests_path)!r}",
+                "",
+                "def emit(payload):",
+                "    print(json.dumps(payload), flush=True)",
+                "",
+                "def record(payload):",
+                "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+                "        fh.write(json.dumps(payload) + '\\n')",
+                "",
+                "for line in sys.stdin:",
+                "    payload = json.loads(line)",
+                "    record(payload)",
+                "    method = payload.get('method')",
+                "    request_id = payload.get('id')",
+                "    if method == 'initialize':",
+                "        emit({'id': request_id, 'result': {'userAgent': 'fake-codex'}})",
+                "    elif method == 'initialized':",
+                "        continue",
+                "    elif method == 'thread/start':",
+                "        emit({'id': request_id, 'result': {'thread': {'id': 'thread-cancel'}}})",
+                "    elif method == 'turn/start':",
+                "        turn = {'id': 'turn-cancel', 'status': 'running', 'items': []}",
+                "        emit({'id': request_id, 'result': {'turn': turn}})",
+                "        emit({'method': 'turn/started', 'params': {'threadId': 'thread-cancel', 'turn': turn}})",
+                "    elif method == 'turn/interrupt':",
+                "        emit({'id': request_id, 'result': {}})",
                 "        break",
             ]
         )
@@ -465,6 +506,66 @@ def test_codex_app_server_runtime_allows_quiet_period_longer_than_read_timeout(t
     assert result.output == "quiet ok\n"
     assert result.thread_id == "thread-quiet"
     assert result.turn_id == "turn-quiet"
+
+
+def test_codex_app_server_runtime_cancellation_interrupts_active_turn(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_cancellable_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_cancellable_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 100,
+            "stall_timeout_ms": 5000,
+        },
+        run=None,
+    )
+    cancel_event = threading.Event()
+    runtime.set_cancel_event(cancel_event)
+    errors: list[Exception] = []
+
+    def run_turn():
+        try:
+            runtime.run_prompt_result(
+                worktree=worktree,
+                session_name="ISSUE-CANCEL",
+                prompt="Work until canceled",
+                model="gpt-5.5",
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_turn)
+    thread.start()
+    try:
+        for _ in range(30):
+            if requests_path.exists():
+                methods = [json.loads(line).get("method") for line in requests_path.read_text(encoding="utf-8").splitlines()]
+                if "turn/start" in methods:
+                    break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("turn/start was not sent")
+
+        cancel_event.set()
+        thread.join(timeout=3)
+    finally:
+        cancel_event.set()
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], CodexAppServerError)
+    assert "turn canceled" in str(errors[0])
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    interrupt = next(item for item in requests if item.get("method") == "turn/interrupt")
+    assert interrupt["params"] == {"threadId": "thread-cancel", "turnId": "turn-cancel"}
 
 
 def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path):

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -1,6 +1,8 @@
 import json
 import shlex
 import sys
+import threading
+import time
 from pathlib import Path
 
 from workflows.contract import render_workflow_markdown
@@ -121,6 +123,33 @@ def _write_fake_codex_app_server(path: Path, *, requests_path: Path, fail: bool 
         "        raise SystemExit(1)",
     ]
     path.write_text("\n".join(script) + "\n", encoding="utf-8")
+
+
+def _write_issue_runner_contract(
+    *,
+    workflow_root: Path,
+    cfg: dict,
+    issues: list[dict],
+    prompt_template: str = "Issue: {{ issue.identifier }}",
+) -> Path:
+    (workflow_root / "config").mkdir(parents=True, exist_ok=True)
+    issues_path = workflow_root / "config" / "issues.json"
+    issues_path.write_text(json.dumps({"issues": issues}), encoding="utf-8")
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template=prompt_template),
+        encoding="utf-8",
+    )
+    return issues_path
+
+
+def _wait_for_supervised_futures(workspace, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        futures = list(workspace._supervisor_futures.values())
+        if futures and all(future.done() for future in futures):
+            return
+        time.sleep(0.01)
+    raise AssertionError("supervised futures did not finish")
 
 
 def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
@@ -603,6 +632,301 @@ def test_issue_runner_tick_dispatches_batch_up_to_max_concurrent_agents(tmp_path
     identifiers = {item["issue"]["identifier"] for item in result["results"]}
     assert identifiers == {"ISSUE-1", "ISSUE-2"}
     assert workspace.build_status()["scheduler"]["running"] == []
+
+
+def test_issue_runner_supervise_once_dispatches_and_reconciles_worker(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Async issue",
+                "description": "Run under supervisor.",
+                "priority": 1,
+                "state": "todo",
+                "labels": [],
+                "blocked_by": [],
+            }
+        ],
+    )
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command[:2] == ["bash", "-lc"]:
+            class HookResult:
+                stdout = ""
+                stderr = ""
+                returncode = 0
+
+            return HookResult()
+
+        started.set()
+        assert release.wait(timeout=2)
+
+        class Result:
+            stdout = "agent finished under supervision\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    dispatched = workspace.supervise_once()
+
+    assert dispatched["ok"] is True
+    assert dispatched["mode"] == "supervised"
+    assert dispatched["dispatchedWorkers"][0]["issue_id"] == "ISSUE-1"
+    assert started.wait(timeout=2)
+    running = workspace.build_status()["scheduler"]["running"]
+    assert running[0]["issue_id"] == "ISSUE-1"
+    assert running[0]["worker_status"] == "running"
+
+    release.set()
+    completed = None
+    for _ in range(20):
+        candidate = workspace.supervise_once()
+        if candidate.get("completedResults"):
+            completed = candidate
+            break
+        time.sleep(0.01)
+
+    assert completed is not None
+    assert completed["completedResults"][0]["ok"] is True
+    assert workspace.build_status()["scheduler"]["running"] == []
+    assert workspace.build_status()["scheduler"]["retry_queue"][0]["error"] == "continuation"
+    assert Path(completed["completedResults"][0]["outputPath"]).read_text(encoding="utf-8") == "agent finished under supervision\n"
+
+
+def test_issue_runner_run_loop_reconciles_completed_worker_before_bounded_exit(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Fast issue",
+                "description": "Finish before bounded loop exits.",
+                "priority": 1,
+                "state": "todo",
+                "labels": [],
+                "blocked_by": [],
+            }
+        ],
+    )
+
+    finished = threading.Event()
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command[:2] == ["bash", "-lc"]:
+            class HookResult:
+                stdout = ""
+                stderr = ""
+                returncode = 0
+
+            return HookResult()
+
+        class Result:
+            stdout = "agent finished fast\n"
+            stderr = ""
+            returncode = 0
+
+        finished.set()
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+    original_supervise_once = workspace.supervise_once
+
+    def supervise_and_wait():
+        result = original_supervise_once()
+        assert finished.wait(timeout=2)
+        _wait_for_supervised_futures(workspace)
+        return result
+
+    workspace.supervise_once = supervise_and_wait
+
+    result = workspace.run_loop(interval_seconds=1, max_iterations=1, sleep_fn=lambda _seconds: None)
+
+    assert result["loop_status"] == "completed"
+    assert result["last_result"]["mode"] == "supervised-exit-reconcile"
+    assert result["last_result"]["completedResults"][0]["ok"] is True
+    status = workspace.build_status()
+    assert status["scheduler"]["running"] == []
+    assert status["scheduler"]["retry_queue"][0]["error"] == "continuation"
+    scheduler = json.loads((workflow_root / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
+    assert scheduler["running"] == []
+
+
+def test_issue_runner_run_loop_reconciles_completed_worker_before_interrupt_exit(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Interrupted issue",
+                "description": "Finish before operator interrupt.",
+                "priority": 1,
+                "state": "todo",
+                "labels": [],
+                "blocked_by": [],
+            }
+        ],
+    )
+
+    finished = threading.Event()
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command[:2] == ["bash", "-lc"]:
+            class HookResult:
+                stdout = ""
+                stderr = ""
+                returncode = 0
+
+            return HookResult()
+
+        class Result:
+            stdout = "agent finished before interrupt\n"
+            stderr = ""
+            returncode = 0
+
+        finished.set()
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    def interrupt_after_worker_finishes(_seconds):
+        assert finished.wait(timeout=2)
+        _wait_for_supervised_futures(workspace)
+        raise KeyboardInterrupt
+
+    result = workspace.run_loop(interval_seconds=1, max_iterations=None, sleep_fn=interrupt_after_worker_finishes)
+
+    assert result["loop_status"] == "interrupted"
+    assert result["last_result"]["mode"] == "supervised-exit-reconcile"
+    assert result["last_result"]["completedResults"][0]["ok"] is True
+    assert workspace.build_status()["scheduler"]["running"] == []
+
+
+def test_issue_runner_supervised_terminal_issue_requests_cancel_and_defers_cleanup(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    active_issue = {
+        "id": "ISSUE-1",
+        "identifier": "ISSUE-1",
+        "title": "Cancelable issue",
+        "description": "This issue changes state while running.",
+        "priority": 1,
+        "state": "todo",
+        "labels": [],
+        "blocked_by": [],
+    }
+    issues_path = _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[active_issue],
+    )
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command[:2] == ["bash", "-lc"]:
+            class HookResult:
+                stdout = ""
+                stderr = ""
+                returncode = 0
+
+            return HookResult()
+
+        started.set()
+        assert release.wait(timeout=2)
+
+        class Result:
+            stdout = "agent finished after cancel request\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    first = workspace.supervise_once()
+    assert first["dispatchedWorkers"][0]["issue_id"] == "ISSUE-1"
+    assert started.wait(timeout=2)
+
+    terminal_issue = dict(active_issue)
+    terminal_issue["state"] = "done"
+    issues_path.write_text(json.dumps({"issues": [terminal_issue]}), encoding="utf-8")
+
+    canceled = workspace.supervise_once()
+
+    assert canceled["cancellationRequests"] == [
+        {"issue_id": "ISSUE-1", "identifier": "ISSUE-1", "reason": "terminal-state"}
+    ]
+    assert canceled["cleanup"][0]["deferred"] is True
+    running = workspace.build_status()["scheduler"]["running"]
+    assert running[0]["cancel_requested"] is True
+    assert running[0]["cancel_reason"] == "terminal-state"
+
+    release.set()
+    completed = None
+    for _ in range(20):
+        candidate = workspace.supervise_once()
+        if candidate.get("completedResults"):
+            completed = candidate
+            break
+        time.sleep(0.01)
+
+    assert completed is not None
+    result = completed["completedResults"][0]
+    assert result["ok"] is True
+    assert result["suppressRetry"] is True
+    assert result["retry"] is None
+    status = workspace.build_status()
+    assert status["scheduler"]["running"] == []
+    assert status["scheduler"]["retry_queue"] == []
+    assert not (workflow_root / "workspace" / "issues" / "ISSUE-1").exists()
 
 
 def test_issue_runner_codex_failure_preserves_partial_metrics(tmp_path):


### PR DESCRIPTION
## Summary
- add supervised async dispatch/reconciliation for the issue-runner service loop while keeping tick synchronous
- persist richer running worker state and handle terminal-state cancellation with deferred cleanup and retry suppression
- wire Codex app-server cancellation to turn/interrupt and document the updated operator/conformance behavior

## Tests
- pytest -q