### PR TITLE
Supervise change-delivery active loop

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1,5 +1,6 @@
 import argparse
 import calendar
+import concurrent.futures
 import importlib.util
 import json
 import sqlite3
@@ -1557,6 +1558,7 @@ def request_active_actions_for_lane(*, workflow_root: Path, lane_id: str, now_is
                         actor=actor_dict,
                         review=internal_review,
                         now_iso=now_iso,
+                        project_key=_project_key_for(workflow_root),
                     )
                 )
         conn.commit()
@@ -2077,6 +2079,7 @@ def _target_actor_id_for_active_action(*, action_type: str | None, lane: dict[st
 def _make_relay_event(
     *,
     event_type: str,
+    project_key: str,
     now_iso: str,
     lane_id: str | None,
     issue_number: int | None,
@@ -2092,7 +2095,7 @@ def _make_relay_event(
         "event_version": 1,
         "created_at": now_iso,
         "producer": "Workflow_Orchestrator",
-        "project_key": _project_key_for(workflow_root),
+        "project_key": project_key,
         "lane_id": lane_id,
         "issue_number": issue_number,
         "head_sha": head_sha,
@@ -2133,6 +2136,7 @@ def _semantic_request_events_for_action(
     actor: dict[str, Any] | None,
     review: dict[str, Any] | None,
     now_iso: str,
+    project_key: str,
 ) -> list[dict[str, Any]]:
     lane = lane or {}
     actor = actor or {}
@@ -2146,6 +2150,7 @@ def _semantic_request_events_for_action(
         return [
             _make_relay_event(
                 event_type="implementation_requested",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2170,6 +2175,7 @@ def _semantic_request_events_for_action(
         return [
             _make_relay_event(
                 event_type="internal_review_requested",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2188,6 +2194,7 @@ def _semantic_request_events_for_action(
         return [
             _make_relay_event(
                 event_type="merge_requested",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2213,6 +2220,7 @@ def _semantic_completion_events_for_action(
     result: dict[str, Any],
     post_legacy_status: dict[str, Any] | None,
     now_iso: str,
+    project_key: str,
 ) -> list[dict[str, Any]]:
     lane_before = lane_before or {}
     lane_after = lane_after or lane_before
@@ -2232,6 +2240,7 @@ def _semantic_completion_events_for_action(
         events.append(
             _make_relay_event(
                 event_type="implementation_completed",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2254,6 +2263,7 @@ def _semantic_completion_events_for_action(
         events.append(
             _make_relay_event(
                 event_type="internal_review_completed",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2278,6 +2288,7 @@ def _semantic_completion_events_for_action(
         events.append(
             _make_relay_event(
                 event_type="pr_published",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2299,6 +2310,7 @@ def _semantic_completion_events_for_action(
         events.append(
             _make_relay_event(
                 event_type="pr_updated",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2318,6 +2330,7 @@ def _semantic_completion_events_for_action(
         events.append(
             _make_relay_event(
                 event_type="merge_completed",
+                project_key=project_key,
                 now_iso=now_iso,
                 lane_id=lane_id,
                 issue_number=issue_number,
@@ -2343,6 +2356,7 @@ def _semantic_completion_events_for_action(
             events.append(
                 _make_relay_event(
                     event_type="next_lane_promoted",
+                    project_key=project_key,
                     now_iso=now_iso,
                     lane_id=f"lane:{next_issue_number}",
                     issue_number=next_issue_number,
@@ -2355,7 +2369,7 @@ def _semantic_completion_events_for_action(
     return events
 
 
-def _semantic_failure_events_for_action(*, action: dict[str, Any] | None, failure_class: str, failure_summary: str, now_iso: str) -> list[dict[str, Any]]:
+def _semantic_failure_events_for_action(*, action: dict[str, Any] | None, failure_class: str, failure_summary: str, now_iso: str, project_key: str) -> list[dict[str, Any]]:
     action = action or {}
     action_type = action.get("action_type")
     if action_type not in {"dispatch_implementation_turn", "dispatch_repair_handoff", "restart_actor_session"}:
@@ -2363,6 +2377,7 @@ def _semantic_failure_events_for_action(*, action: dict[str, Any] | None, failur
     return [
         _make_relay_event(
             event_type="implementation_failed",
+            project_key=project_key,
             now_iso=now_iso,
             lane_id=action.get("lane_id"),
             issue_number=None,
@@ -3223,6 +3238,7 @@ def execute_requested_action(
             failure_class=failure_class,
             failure_summary=failure_summary,
             now_iso=now_iso,
+            project_key=_project_key_for(workflow_root),
         ):
             append_daedalus_event(event_log_path=paths["event_log_path"], event=event)
         for event in analysis_events:
@@ -3302,6 +3318,7 @@ def execute_requested_action(
         result=result,
         post_legacy_status=post_action_status,
         now_iso=now_iso,
+        project_key=_project_key_for(workflow_root),
     ):
         append_daedalus_event(event_log_path=paths["event_log_path"], event=event)
     return {"executed": True, "action_id": action_id, "action_type": action.get("action_type"), "result": result}
@@ -3643,6 +3660,64 @@ def run_active_iteration(*, workflow_root: Path, instance_id: str, legacy_status
     }
 
 
+def _active_loop_running_snapshot(supervised_iteration: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not supervised_iteration:
+        return None
+    started_at = supervised_iteration.get("started_at")
+    started_epoch = _iso_to_epoch(started_at)
+    now_epoch = int(time.time())
+    return {
+        "worker_id": supervised_iteration.get("worker_id"),
+        "started_at": started_at,
+        "running_for_seconds": max(now_epoch - started_epoch, 0) if started_epoch is not None else None,
+    }
+
+
+def _reconcile_active_loop_iteration(
+    supervised_iteration: dict[str, Any] | None,
+    *,
+    settle_timeout_seconds: float = 0.0,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    if not supervised_iteration:
+        return [], None
+    future = supervised_iteration.get("future")
+    if not isinstance(future, concurrent.futures.Future):
+        return [], None
+    if not future.done() and settle_timeout_seconds > 0:
+        concurrent.futures.wait([future], timeout=settle_timeout_seconds, return_when=concurrent.futures.FIRST_COMPLETED)
+    if not future.done():
+        return [], supervised_iteration
+    try:
+        result = future.result()
+        if isinstance(result, dict):
+            result = {
+                **result,
+                "supervised": True,
+                "worker_id": supervised_iteration.get("worker_id"),
+                "started_at": supervised_iteration.get("started_at"),
+                "completed_at": _now_iso(),
+            }
+        else:
+            result = {
+                "iteration_status": "completed",
+                "supervised": True,
+                "worker_id": supervised_iteration.get("worker_id"),
+                "started_at": supervised_iteration.get("started_at"),
+                "completed_at": _now_iso(),
+                "result": result,
+            }
+    except BaseException as exc:
+        result = {
+            "iteration_status": "failed",
+            "supervised": True,
+            "worker_id": supervised_iteration.get("worker_id"),
+            "started_at": supervised_iteration.get("started_at"),
+            "completed_at": _now_iso(),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return [result], None
+
+
 def run_active_loop(
     *,
     workflow_root: Path,
@@ -3672,32 +3747,71 @@ def run_active_loop(
             }
     iterations = 0
     last_result = None
+    supervised_iteration: dict[str, Any] | None = None
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="daedalus-change-delivery")
+    loop_status = "completed"
     try:
         while True:
-            legacy_status = legacy_status_provider() if legacy_status_provider else None
-            last_result = run_active_iteration(
-                workflow_root=workflow_root,
-                instance_id=instance_id,
-                legacy_status=legacy_status,
-                now_iso=_now_iso(),
-                action_runners=action_runners,
-            )
+            completed, supervised_iteration = _reconcile_active_loop_iteration(supervised_iteration)
+            completed_this_cycle = bool(completed)
+            if completed:
+                last_result = completed[-1]
+            if supervised_iteration is not None:
+                heartbeat = refresh_runtime_lease(workflow_root=workflow_root, instance_id=instance_id, now_iso=_now_iso())
+                if not heartbeat.get("refreshed"):
+                    last_result = {
+                        "iteration_status": "blocked",
+                        "reason": heartbeat.get("reason"),
+                        "owner_instance_id": heartbeat.get("owner_instance_id"),
+                        "running_iteration": _active_loop_running_snapshot(supervised_iteration),
+                    }
+                else:
+                    last_result = {
+                        "iteration_status": "waiting",
+                        "supervised": True,
+                        "heartbeat": heartbeat,
+                        "running_iteration": _active_loop_running_snapshot(supervised_iteration),
+                    }
+            elif completed_this_cycle:
+                # Let the service loop publish and sleep after reconciliation
+                # instead of immediately dispatching a second active iteration.
+                pass
+            else:
+                legacy_status = legacy_status_provider() if legacy_status_provider else None
+                started_at = _now_iso()
+                supervised_iteration = {
+                    "worker_id": f"active-worker:{instance_id}:{iterations + 1}:{started_at}",
+                    "started_at": started_at,
+                    "future": executor.submit(
+                        run_active_iteration,
+                        workflow_root=workflow_root,
+                        instance_id=instance_id,
+                        legacy_status=legacy_status,
+                        action_runners=action_runners,
+                    ),
+                }
+                last_result = {
+                    "iteration_status": "dispatched",
+                    "supervised": True,
+                    "running_iteration": _active_loop_running_snapshot(supervised_iteration),
+                }
             iterations += 1
             if max_iterations is not None and iterations >= max_iterations:
                 break
             sleep_fn(interval_seconds)
     except KeyboardInterrupt:
-        return {
-            "loop_status": "interrupted",
-            "instance_id": instance_id,
-            "iterations": iterations,
-            "last_result": last_result,
-        }
+        loop_status = "interrupted"
+    finally:
+        completed, supervised_iteration = _reconcile_active_loop_iteration(supervised_iteration, settle_timeout_seconds=0.25)
+        if completed:
+            last_result = completed[-1]
+        executor.shutdown(wait=False, cancel_futures=False)
     return {
-        "loop_status": "completed",
+        "loop_status": loop_status,
         "instance_id": instance_id,
         "iterations": iterations,
         "last_result": last_result,
+        "running_iteration": _active_loop_running_snapshot(supervised_iteration),
     }
 
 

--- a/docs/concepts/shadow-active.md
+++ b/docs/concepts/shadow-active.md
@@ -54,7 +54,7 @@ sequenceDiagram
 
 - `daedalus/runtime.py active-gate-status` — what's blocking promotion
 - `daedalus/runtime.py iterate-shadow` / `iterate-active` — single tick in either mode
-- `daedalus/runtime.py run-shadow` / `run-active` — long-running supervised loop
+- `daedalus/runtime.py run-shadow` / `run-active` — long-running loop; active mode supervises its worker iteration and keeps the lease fresh while actions run
 - `/daedalus shadow-report` — diff between shadow plan and active reality
 
 ## Where this lives in code

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -129,7 +129,7 @@ Daedalus service
 | Command | What it does |
 |---|---|
 | `/daedalus start` | Bootstrap runtime row + emit start event |
-| `/daedalus run-active` | Active loop (use systemd; not this directly) |
+| `/daedalus run-active` | Supervised active service loop (use systemd; not this directly) |
 | `/daedalus run-shadow` | Shadow loop (use systemd; not this directly) |
 | `/daedalus iterate-active` | One tick of the active loop |
 | `/daedalus iterate-shadow` | One tick of the shadow loop |

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -17,8 +17,8 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | `WORKFLOW.md` loader | Partial | Supported as a repo-owned public contract. Front matter maps to the selected workflow schema; `issue-runner` is the closer generic reference surface, while `change-delivery` still carries richer GitHub-specific semantics. |
 | Typed config + hot reload | Implemented | Bundled workflows load repo-owned `WORKFLOW.md`; `issue-runner` now keeps last-known-good config on invalid reloads. |
 | Issue tracker client boundary | Partial | `issue-runner` has shared `local-json`, `github`, and Linear clients. The Linear query shape follows the Symphony baseline, but still needs real-service smoke validation. |
-| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised worker dispatch/reconciliation, and persisted scheduler state now exist. |
-| Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery, but the broader engine is still not uniformly scheduler-driven. |
+| Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised `change-delivery` active iterations, worker reconciliation, and persisted scheduler state now exist. |
+| Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery. `change-delivery` now supervises one active worker iteration at a time, but the broader engine is still not uniformly scheduler-driven. |
 | Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
 | Coding-agent protocol | Partial | `issue-runner` ships a protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, and cooperative turn interruption. |
 | Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; `issue-runner` records per-run token/rate-limit metrics and exposes `codex_totals` plus Codex thread mappings. |
@@ -27,12 +27,12 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 
 ## Important Differences
 
-Daedalus currently differs from the Symphony draft in three material ways:
+Daedalus currently differs from the Symphony draft in four material ways:
 
 1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow and has a Linear adapter, but the broader product story is still not Linear-first.
 2. Runtime adapters are still mixed: `issue-runner` has a protocol-level Codex app-server path, while the rest of Daedalus remains CLI/session-oriented.
 3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
-4. `issue-runner` has async supervision in the long-running `run` path, but manual `tick` remains synchronous and command-style runtimes still have limited cancellation semantics.
+4. Long-running service paths have async supervision for `issue-runner` workers and `change-delivery` active iterations, but manual `tick` remains synchronous and command-style runtimes still have limited cancellation semantics.
 
 ## Recommended Next Gaps
 

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -61,6 +61,18 @@ Common workflow commands:
 - `/workflow change-delivery publish-ready-pr`
 - `/workflow change-delivery merge-and-promote`
 
+## Runtime behavior
+
+Manual ticks remain synchronous: `/workflow change-delivery tick` and
+`/daedalus iterate-active` run one action inline and return the final result.
+
+The long-running active service path is supervised. `/daedalus run-active`
+dispatches one active iteration into an in-process worker, keeps the Daedalus
+lease fresh while the worker runs, reconciles completed workers before shutdown,
+and persists action completion/failure in the runtime DB. This prevents a fast
+completed action from being marked as synthetic restart failure after a bounded
+or interrupted service run.
+
 ## Related docs
 
 - [Architecture](../architecture.md)

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -2,6 +2,8 @@ import argparse
 import importlib.util
 import json
 import sqlite3
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -343,6 +345,137 @@ def test_reap_stuck_dispatched_actions_marks_dispatcher_lost_and_queues_recovery
     assert recovery[1] == "requested"
     assert recovery[2] == 1
     assert recovery[3] == 1
+
+
+def _active_dispatch_legacy_status() -> dict:
+    return {
+        "activeLane": {"number": 221, "url": "https://example.com/issues/221", "title": "Issue 221", "labels": []},
+        "repo": "/tmp/repo",
+        "implementation": {
+            "worktree": "/tmp/issue-221",
+            "branch": "codex/issue-221-test",
+            "localHeadSha": "abc123",
+            "laneState": {
+                "implementation": {
+                    "lastMeaningfulProgressAt": "2026-04-22T00:00:00Z",
+                    "lastMeaningfulProgressKind": "implementing_local",
+                },
+                "pr": {"lastPublishedHeadSha": None},
+            },
+            "activeSessionHealth": {"healthy": False, "lastUsedAt": None},
+            "sessionActionRecommendation": {"action": "restart-session"},
+        },
+        "reviews": {},
+        "ledger": {"workflowState": "implementing_local", "reviewState": "implementing_local", "repairBrief": None},
+        "derivedReviewLoopState": "awaiting_reviews",
+        "derivedMergeBlocked": False,
+        "derivedMergeBlockers": [],
+        "openPr": None,
+        "activeLaneError": None,
+        "staleLaneReasons": [],
+        "nextAction": {"type": "dispatch_codex_turn", "reason": "implementation-in-progress"},
+    }
+
+
+def test_run_active_loop_reconciles_fast_supervised_iteration_before_bounded_exit(runtime_module, tmp_path, monkeypatch):
+    workflow_root = tmp_path / "workflow"
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    legacy_status = _active_dispatch_legacy_status()
+
+    monkeypatch.setattr(
+        runtime_module,
+        "derive_shadow_actions_for_lane",
+        lambda **_kwargs: [{"action_type": "dispatch_implementation_turn", "reason": "implementation-in-progress", "target_head_sha": "abc123"}],
+    )
+
+    calls = []
+
+    def run_action():
+        calls.append("dispatch")
+        return {"dispatched": True, "after": legacy_status}
+
+    result = runtime_module.run_active_loop(
+        workflow_root=workflow_root,
+        project_key="workflow-example",
+        instance_id="active-test",
+        interval_seconds=1,
+        max_iterations=1,
+        legacy_status_provider=lambda: legacy_status,
+        sleep_fn=lambda _seconds: None,
+        action_runners={"dispatch_implementation_turn": run_action},
+    )
+
+    assert result["loop_status"] == "completed"
+    assert result["running_iteration"] is None
+    assert result["last_result"]["supervised"] is True
+    assert result["last_result"]["iteration_status"] == "executed"
+    assert calls == ["dispatch"]
+
+    conn = sqlite3.connect(runtime_module._runtime_paths(workflow_root)["db_path"])
+    try:
+        action_status = conn.execute(
+            """
+            SELECT status
+            FROM lane_actions
+            WHERE action_type=? AND action_mode='active'
+            ORDER BY requested_at DESC
+            """,
+            ("dispatch_implementation_turn",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert action_status == "completed"
+
+
+def test_run_active_loop_heartbeats_while_supervised_iteration_is_running(runtime_module, tmp_path, monkeypatch):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    legacy_status = _active_dispatch_legacy_status()
+
+    monkeypatch.setattr(
+        runtime_module,
+        "derive_shadow_actions_for_lane",
+        lambda **_kwargs: [{"action_type": "dispatch_implementation_turn", "reason": "implementation-in-progress", "target_head_sha": "abc123"}],
+    )
+
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+    sleeps = {"count": 0}
+
+    def run_action():
+        calls.append("dispatch")
+        started.set()
+        assert release.wait(timeout=2)
+        return {"dispatched": True, "after": legacy_status}
+
+    def sleep_fn(_seconds):
+        sleeps["count"] += 1
+        assert started.wait(timeout=2)
+        if sleeps["count"] >= 2:
+            release.set()
+        time.sleep(0.01)
+
+    result = runtime_module.run_active_loop(
+        workflow_root=workflow_root,
+        project_key="workflow-example",
+        instance_id="active-test",
+        interval_seconds=1,
+        max_iterations=3,
+        legacy_status_provider=lambda: legacy_status,
+        sleep_fn=sleep_fn,
+        action_runners={"dispatch_implementation_turn": run_action},
+    )
+
+    assert result["loop_status"] == "completed"
+    assert result["running_iteration"] is None
+    assert result["last_result"]["iteration_status"] == "executed"
+    assert calls == ["dispatch"]
+
+    events = [json.loads(line) for line in paths["event_log_path"].read_text(encoding="utf-8").splitlines()]
+    heartbeats = [event for event in events if event.get("event_type") == "daedalus.runtime_heartbeat"]
+    assert len(heartbeats) >= 2
 
 
 


### PR DESCRIPTION
## Summary
- run change-delivery active service iterations through a supervised in-process worker
- keep the Daedalus lease fresh while the worker is still running and reconcile completed workers before bounded/interrupted loop exit
- document manual tick vs supervised service behavior and update Symphony conformance notes

## Tests
- pytest tests/test_runtime_tools_alerts.py tests/test_tools_run_cli_command_dispatch.py tests/test_systemd_template_units.py tests/test_workflows_code_review_tools_bridge.py -q
- pytest -q