### PR TITLE
[codex] support codex app-server in change-delivery

### DIFF
--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -198,8 +198,23 @@ def alert_state(workflow_root: Path) -> dict[str, Any]:
 
 def workflow_status(workflow_root: Path) -> dict[str, Any]:
     workflow_root = Path(workflow_root)
-    if _workflow_name(workflow_root) != "issue-runner":
+    workflow_name = _workflow_name(workflow_root)
+    if workflow_name not in {"issue-runner", "change-delivery"}:
         return {}
+    if workflow_name == "change-delivery":
+        scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
+        scheduler_payload = _load_optional_json(scheduler_path) or {}
+        totals = scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {}
+        return {
+            "workflow": "change-delivery",
+            "health": None,
+            "updated_at": scheduler_payload.get("updatedAt"),
+            "running_count": 0,
+            "retry_count": 0,
+            "selected_issue": None,
+            "total_tokens": int(totals.get("total_tokens") or 0),
+            "rate_limits": totals.get("rate_limits"),
+        }
     status_path = _resolve_issue_runner_storage_path(workflow_root, "status", "memory/workflow-status.json")
     scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
     status_payload = _load_optional_json(status_path) or {}

--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -25,6 +25,38 @@ action bodies.
 """
 
 
+def _object_value(value: Any, *keys: str) -> Any:
+    for key in keys:
+        if isinstance(value, dict) and key in value:
+            return value.get(key)
+        if hasattr(value, key):
+            return getattr(value, key)
+    return None
+
+
+def _prompt_output(value: Any) -> str:
+    output = _object_value(value, "output")
+    if output is not None:
+        return str(output).strip()
+    return str(value or "").strip()
+
+
+def _runtime_metrics_payload(value: Any) -> dict[str, Any]:
+    if value is None or isinstance(value, str):
+        return {}
+    tokens = _object_value(value, "tokens")
+    return {
+        "session_id": _object_value(value, "session_id", "sessionId"),
+        "thread_id": _object_value(value, "thread_id", "threadId"),
+        "turn_id": _object_value(value, "turn_id", "turnId"),
+        "last_event": _object_value(value, "last_event", "lastEvent"),
+        "last_message": _object_value(value, "last_message", "lastMessage"),
+        "turn_count": int(_object_value(value, "turn_count", "turnCount") or 0),
+        "tokens": tokens if isinstance(tokens, dict) else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        "rate_limits": _object_value(value, "rate_limits", "rateLimits"),
+    }
+
+
 def run_publish_ready_pr(
     *,
     reconcile_fn: Callable[..., dict[str, Any]],
@@ -182,6 +214,9 @@ def run_dispatch_lane_turn(
     reconcile_fn: Callable[..., dict[str, Any]],
     audit_fn: Callable[..., Any],
     render_implementation_dispatch_prompt_fn: Callable[..., str],
+    runtime_name: str | None = None,
+    runtime_kind: str = "acpx-codex",
+    record_runtime_result_fn: Callable[..., dict[str, Any]] | None = None,
     error_cls: type = subprocess.CalledProcessError,
 ) -> dict[str, Any]:
     """Adapter-owned implementation of ``_dispatch_lane_turn``.
@@ -237,7 +272,7 @@ def run_dispatch_lane_turn(
         action=action,
         workflow_state=(status.get('ledger') or {}).get('workflowState'),
     )
-    session_record_id = session_meta.get('record_id') or ensured.get('acpxRecordId')
+    session_record_id = session_meta.get('record_id') or _object_value(ensured, "record_id", "recordId", "acpxRecordId")
     try:
         prompt_result = run_prompt_fn(
             worktree=worktree,
@@ -262,27 +297,66 @@ def run_dispatch_lane_turn(
             resume_session_id=None,
         )
         session_meta = show_acpx_session_fn(worktree=worktree, session_name=session_name) or session_meta
-        session_record_id = session_meta.get('record_id') or ensured.get('acpxRecordId')
+        session_record_id = session_meta.get('record_id') or _object_value(ensured, "record_id", "recordId", "acpxRecordId")
         prompt_result = run_prompt_fn(
             worktree=worktree,
             session_name=session_name,
             prompt=prompt,
             codex_model=codex_model,
         )
+    runtime_metrics = _runtime_metrics_payload(prompt_result)
+    if record_runtime_result_fn is not None:
+        runtime_metrics = record_runtime_result_fn(
+            issue=issue,
+            session_name=session_name,
+            runtime_name=runtime_name,
+            runtime_kind=runtime_kind,
+            result=prompt_result,
+            metrics=runtime_metrics,
+            at=attempt_at,
+        ) or runtime_metrics
+    ensured_record_id = _object_value(ensured, "record_id", "recordId", "acpxRecordId")
+    ensured_session_id = _object_value(ensured, "session_id", "sessionId", "acpSessionId", "acpxSessionId")
+    if runtime_kind == "codex-app-server":
+        session_record_id = (
+            runtime_metrics.get("thread_id")
+            or runtime_metrics.get("session_id")
+            or session_meta.get('record_id')
+            or ensured_record_id
+        )
+    else:
+        session_record_id = (
+            session_meta.get('record_id')
+            or ensured_record_id
+            or runtime_metrics.get("thread_id")
+            or runtime_metrics.get("session_id")
+        )
+    resume_session_id = (
+        runtime_metrics.get("thread_id")
+        or runtime_metrics.get("session_id")
+        or session_meta.get('session_id')
+        or ensured_session_id
+    )
     ledger = load_ledger_fn()
     ledger.setdefault('implementation', {})
     ledger['codexModel'] = codex_model
     ledger['workflowActors'] = actor_labels_payload_fn(codex_model)
     ledger['implementation'] = {
         **ledger.get('implementation', {}),
-        'session': session_meta.get('record_id') or ensured.get('acpxRecordId'),
+        'session': session_record_id,
         'previousSession': ledger.get('implementation', {}).get('previousSession'),
-        'sessionRuntime': 'acpx-codex',
+        'sessionRuntime': runtime_kind or 'acpx-codex',
+        'runtimeName': runtime_name,
         'sessionName': session_name,
         'codexModel': codex_model,
         'agentName': coder_agent_name_for_model_fn(codex_model),
         'agentRole': 'coder_agent',
-        'resumeSessionId': session_meta.get('session_id'),
+        'resumeSessionId': resume_session_id,
+        'threadId': runtime_metrics.get("thread_id"),
+        'turnId': runtime_metrics.get("turn_id"),
+        'lastRuntimeEvent': runtime_metrics.get("last_event"),
+        'lastRuntimeMessage': runtime_metrics.get("last_message"),
+        'runtimeMetrics': runtime_metrics,
         'worktree': str(worktree),
         'updatedAt': attempt_at,
         'branch': branch,
@@ -298,22 +372,27 @@ def run_dispatch_lane_turn(
         'dispatched': True,
         'action': action,
         'issueNumber': issue.get('number'),
-        'sessionRuntime': 'acpx-codex',
+        'sessionRuntime': runtime_kind or 'acpx-codex',
+        'runtimeName': runtime_name,
         'sessionName': session_name,
         'codexModel': codex_model,
-        'sessionRecordId': session_meta.get('record_id') or ensured.get('acpxRecordId'),
-        'resumeSessionId': session_meta.get('session_id'),
+        'sessionRecordId': session_record_id,
+        'resumeSessionId': resume_session_id,
+        'threadId': runtime_metrics.get("thread_id"),
+        'turnId': runtime_metrics.get("turn_id"),
+        'metrics': runtime_metrics,
         'worktree': str(worktree),
         'worktreePrepared': worktree_info,
-        'promptResult': prompt_result,
+        'promptResult': _prompt_output(prompt_result),
         'health': reconciled.get('health'),
     }
     audit_fn(
         audit_action,
-        f"Dispatched persistent Codex lane turn via acpx session {session_name}",
+        f"Dispatched persistent Codex lane turn via {runtime_kind or 'acpx-codex'} session {session_name}",
         issueNumber=issue.get('number'),
         sessionName=session_name,
         sessionRecordId=result.get('sessionRecordId'),
+        threadId=result.get('threadId'),
         sessionAction=action,
     )
     return result

--- a/daedalus/workflows/change_delivery/preflight.py
+++ b/daedalus/workflows/change_delivery/preflight.py
@@ -30,7 +30,7 @@ class PreflightResult:
     can_reconcile: bool = True  # always True; preflight never blocks reconciliation
 
 
-_RECOGNIZED_RUNTIME_KINDS = frozenset({"acpx-codex", "claude-cli", "hermes-agent"})
+_RECOGNIZED_RUNTIME_KINDS = frozenset({"acpx-codex", "claude-cli", "codex-app-server", "hermes-agent"})
 _RECOGNIZED_REVIEWER_KINDS = frozenset({"github-comments", "disabled"})
 _RECOGNIZED_TRACKER_KINDS = frozenset({"github"})
 

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -41,6 +41,7 @@ properties:
     additionalProperties:
       oneOf:
         - $ref: "#/definitions/acpx-codex-runtime"
+        - $ref: "#/definitions/codex-app-server-runtime"
         - $ref: "#/definitions/claude-cli-runtime"
         - $ref: "#/definitions/hermes-agent-runtime"
 
@@ -181,6 +182,7 @@ properties:
       ledger: {type: string}
       health: {type: string}
       audit-log: {type: string}
+      scheduler: {type: string}
       cron-jobs-path: {type: string}
       hermes-cron-jobs-path: {type: string}
       sessions-state: {type: string}
@@ -289,6 +291,41 @@ definitions:
         type: array
         items: {type: string}
         minItems: 1
+
+  codex-app-server-runtime:
+    type: object
+    additionalProperties: false
+    required: [kind]
+    properties:
+      kind: {const: codex-app-server}
+      command:
+        oneOf:
+          - type: string
+          - type: array
+            items: {type: string}
+            minItems: 1
+      mode:
+        type: string
+        enum: [managed, external]
+      endpoint: {type: string}
+      healthcheck_path: {type: string}
+      ws_token_env: {type: string}
+      ws_token_file: {type: string}
+      ephemeral: {type: boolean}
+      approval_policy:
+        oneOf:
+          - type: string
+            enum: [untrusted, on-failure, on-request, never]
+          - type: object
+      thread_sandbox: {type: string}
+      turn_sandbox_policy:
+        oneOf:
+          - type: string
+            enum: [auto, read-only, workspace-write, danger-full-access]
+          - type: object
+      turn_timeout_ms: {type: integer, minimum: 1}
+      read_timeout_ms: {type: integer, minimum: 1}
+      stall_timeout_ms: {type: integer, minimum: 0}
 
   claude-cli-runtime:
     type: object

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -182,6 +182,12 @@ def _resolve_issue_runner_storage_path(workflow_root: Path, key: str, default: s
     return path
 
 
+def _storage_path(workflow_root: Path | None, key: str, default: str) -> Path | None:
+    if workflow_root is None:
+        return None
+    return _resolve_issue_runner_storage_path(Path(workflow_root), key, default)
+
+
 def _workflow_name(workflow_root: Path | None) -> str | None:
     if workflow_root is None:
         return None
@@ -358,18 +364,21 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
     lanes = _query_active_lanes(db_path)
     events = _read_events_tail(events_log_path, _RECENT_EVENTS_LIMIT)
     running = [_lane_to_running_entry(lane, events) for lane in lanes]
+    scheduler = _load_optional_json(_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")) or {}
+    codex_totals = dict(scheduler.get("codex_totals") or scheduler.get("codexTotals") or {})
+    rate_limits = codex_totals.pop("rate_limits", None)
     return {
         "generated_at": _now_iso(),
         "counts": {"running": len(running), "retrying": 0},
         "running": running,
         "retrying": [],
         "codex_totals": {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
+            "input_tokens": int(codex_totals.get("input_tokens") or 0),
+            "output_tokens": int(codex_totals.get("output_tokens") or 0),
+            "total_tokens": int(codex_totals.get("total_tokens") or 0),
             "seconds_running": 0,
         },
-        "rate_limits": None,
+        "rate_limits": rate_limits,
         "recent_events": events,
     }
 

--- a/daedalus/workflows/change_delivery/sessions.py
+++ b/daedalus/workflows/change_delivery/sessions.py
@@ -456,6 +456,15 @@ def build_acp_session_strategy(
             "resumeSessionId": resume_session_id or session_control.get("resumeSessionId"),
             "preferredAction": (session_action or {}).get("action"),
         }
+    if session_runtime == "codex-app-server":
+        return {
+            "runtime": "codex-app-server",
+            "spawnMode": "thread",
+            "nudgeTool": "codex app-server turn/start",
+            "targetSessionKey": session_name or session_control.get("targetSessionKey"),
+            "resumeSessionId": resume_session_id or session_control.get("resumeSessionId"),
+            "preferredAction": (session_action or {}).get("action"),
+        }
     return {
         "runtime": "acp",
         "spawnMode": "session",
@@ -581,9 +590,18 @@ def run_prompt_via_runtime(
     session_name: str,
     prompt: str,
     model: str,
-) -> str:
+) -> Any:
     """Runtime-aware version of run_acpx_prompt / the inline claude invocation."""
-    return workspace.runtime(runtime_name).run_prompt(
+    runtime = workspace.runtime(runtime_name)
+    runner = getattr(runtime, "run_prompt_result", None)
+    if callable(runner):
+        return runner(
+            worktree=worktree,
+            session_name=session_name,
+            prompt=prompt,
+            model=model,
+        )
+    return runtime.run_prompt(
         worktree=worktree,
         session_name=session_name,
         prompt=prompt,

--- a/daedalus/workflows/change_delivery/status.py
+++ b/daedalus/workflows/change_delivery/status.py
@@ -127,6 +127,9 @@ def normalize_implementation_for_active_lane(
     active_lane: dict[str, Any] | None,
     open_pr: dict[str, Any] | None,
     selected_codex_model: str | None,
+    session_runtime: str = "acpx-codex",
+    session_name: str | None = None,
+    resume_session_id: str | None = None,
 ) -> dict[str, Any]:
     impl = dict(implementation or {})
     if not active_lane:
@@ -134,14 +137,17 @@ def normalize_implementation_for_active_lane(
     lane_number = active_lane.get("number")
     expected_worktree = expected_lane_worktree(lane_number)
     expected_branch = (open_pr or {}).get("headRefName") or expected_lane_branch(active_lane)
+    expected_session_name = session_name or lane_acpx_session_name(lane_number)
     if implementation_lane_matches(impl, lane_number):
         if expected_worktree is not None:
             impl["worktree"] = str(expected_worktree)
         if expected_branch:
             impl["branch"] = expected_branch
-        impl.setdefault("sessionRuntime", "acpx-codex")
-        impl.setdefault("sessionName", lane_acpx_session_name(lane_number))
+        impl["sessionRuntime"] = session_runtime or impl.get("sessionRuntime") or "acpx-codex"
+        impl["sessionName"] = expected_session_name
         impl["codexModel"] = selected_codex_model
+        if resume_session_id:
+            impl["resumeSessionId"] = resume_session_id
         return impl
     return {
         "session": None,
@@ -150,10 +156,10 @@ def normalize_implementation_for_active_lane(
         "updatedAt": None,
         "branch": expected_branch,
         "status": "implementing" if not open_pr else impl.get("status"),
-        "sessionRuntime": "acpx-codex",
-        "sessionName": lane_acpx_session_name(lane_number),
+        "sessionRuntime": session_runtime or "acpx-codex",
+        "sessionName": expected_session_name,
         "codexModel": selected_codex_model,
-        "resumeSessionId": None,
+        "resumeSessionId": resume_session_id,
     }
 
 
@@ -228,6 +234,16 @@ def load_implementation_session_meta(
     impl = implementation or {}
     if impl.get("sessionRuntime") == "acpx-codex":
         return show_acpx_session_fn(worktree=worktree, session_name=impl.get("sessionName"))
+    if impl.get("sessionRuntime") == "codex-app-server":
+        thread_id = impl.get("threadId") or impl.get("resumeSessionId") or impl.get("session")
+        return {
+            "name": impl.get("sessionName"),
+            "closed": False,
+            "cwd": str(worktree) if worktree is not None else impl.get("worktree"),
+            "last_used_at": impl.get("updatedAt"),
+            "session_id": thread_id,
+            "record_id": thread_id,
+        }
     return load_latest_session_meta_fn(impl.get("session"))
 
 
@@ -453,6 +469,11 @@ def assemble_status_payload(
             "agentName": coder_agent_name,
             "agentRole": "coder_agent",
             "resumeSessionId": implementation.get("resumeSessionId"),
+            "threadId": implementation.get("threadId"),
+            "turnId": implementation.get("turnId"),
+            "lastRuntimeEvent": implementation.get("lastRuntimeEvent"),
+            "lastRuntimeMessage": implementation.get("lastRuntimeMessage"),
+            "runtimeMetrics": implementation.get("runtimeMetrics"),
             "worktree": implementation.get("worktree"),
             "localHeadSha": local_head_sha,
             "publishStatus": publish_status,
@@ -586,6 +607,11 @@ def apply_ledger_implementation_merge(
         "agentName": coder_agent_name,
         "agentRole": "coder_agent",
         "resumeSessionId": impl.get("resumeSessionId"),
+        "threadId": impl.get("threadId"),
+        "turnId": impl.get("turnId"),
+        "lastRuntimeEvent": impl.get("lastRuntimeEvent"),
+        "lastRuntimeMessage": impl.get("lastRuntimeMessage"),
+        "runtimeMetrics": impl.get("runtimeMetrics"),
         "worktree": impl.get("worktree"),
         "localHeadSha": impl.get("localHeadSha"),
         "publishStatus": impl.get("publishStatus"),

--- a/daedalus/workflows/change_delivery/workflow.template.md
+++ b/daedalus/workflows/change_delivery/workflow.template.md
@@ -64,6 +64,7 @@ storage:
   ledger: memory/workflow-status.json
   health: memory/workflow-health.json
   audit-log: memory/workflow-audit.jsonl
+  scheduler: memory/workflow-scheduler.json
 
 lane-selection:
   exclude-labels:

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -97,6 +97,7 @@ def _yaml_to_legacy_view(yaml_cfg: dict, workspace_root: "Path | None" = None) -
         "ledgerPath": _abs_or_join(storage.get("ledger", "memory/workflow-status.json"), local_path),
         "healthPath": _abs_or_join(storage.get("health", "memory/workflow-health.json"), local_path),
         "auditLogPath": _abs_or_join(storage.get("audit-log", "memory/workflow-audit.jsonl"), local_path),
+        "schedulerPath": _abs_or_join(storage.get("scheduler", "memory/workflow-scheduler.json"), local_path),
         "activeLaneLabel": repo.get("active-lane-label", "active-lane"),
         "engineOwner": instance.get("engine-owner", "openclaw"),
         "coreJobNames": core_job_names,
@@ -456,6 +457,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     migrate_persisted_ledger(ledger_path)
     health_path = Path(config["healthPath"])
     audit_log_path = Path(config["auditLogPath"])
+    scheduler_path = Path(config.get("schedulerPath") or (workspace_root / "memory/workflow-scheduler.json"))
     sessions_state_path = workspace_root / "state/sessions"
 
     # -- config constants ------------------------------------------------
@@ -555,6 +557,12 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     def save_ledger(payload: dict[str, Any]) -> None:
         _write_json(ledger_path, payload)
 
+    def load_scheduler() -> dict[str, Any]:
+        return _load_optional_json(scheduler_path) or {}
+
+    def save_scheduler(payload: dict[str, Any]) -> None:
+        _write_json(scheduler_path, payload)
+
     # Wire the comment publisher (returns None when observability is disabled —
     # the audit hook then becomes a pure log-write with no GitHub I/O).
     _ns_holder: dict[str, Any] = {}
@@ -620,6 +628,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         # --- workspace globals ---
         WORKSPACE=workspace_root,
         CONFIG=config,
+        WORKFLOW_YAML=yaml_cfg or {},
         WORKFLOW_POLICY=workflow_policy,
         DEFAULT_CONFIG_PATH=workspace_root / DEFAULT_WORKFLOW_MARKDOWN_FILENAME,
         SESSIONS_STATE_PATH=sessions_state_path,
@@ -630,6 +639,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         LEDGER_PATH=ledger_path,
         HEALTH_PATH=health_path,
         AUDIT_LOG_PATH=audit_log_path,
+        SCHEDULER_PATH=scheduler_path,
         ACTIVE_LANE_LABEL=active_lane_label,
         LANE_SELECTION_CFG=lane_selection_cfg,
         ENGINE_OWNER=engine_owner,
@@ -704,8 +714,10 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         _jobs_store_path=_jobs_store_path,
         load_jobs=load_jobs,
         load_ledger=load_ledger,
+        load_scheduler=load_scheduler,
         save_jobs=save_jobs,
         save_ledger=save_ledger,
+        save_scheduler=save_scheduler,
         audit=audit,
     )
     # Bind ns into the publisher's holder so its lambdas can read load_ledger().
@@ -741,12 +753,14 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     ns.reviewer = build_reviewer(ext_reviewer_cfg, ws_context=reviewer_ctx)
 
     # -- runtimes -------------------------------------------------------
-    # Phase 3 bridges runtime profiles from the old-JSON session/review
-    # policy fields. Phase 4 replaces this with YAML-driven instantiation.
+    # Legacy JSON configs synthesize runtime profiles from session/review
+    # policy fields. Repo-owned WORKFLOW.md configs use their top-level
+    # runtimes block directly, so shared runtimes such as codex-app-server are
+    # configured in one place and selected by agents.*.runtime.
     _session_policy = config.get("sessionPolicy", {}) or {}
     _review_policy = config.get("reviewPolicy", {}) or {}
 
-    _runtimes_cfg = {
+    _legacy_runtimes_cfg = {
         "acpx-codex": {
             "kind": "acpx-codex",
             "session-idle-freshness-seconds": int(
@@ -773,8 +787,13 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
             ),
         },
     }
+    _runtimes_cfg = {
+        str(name): dict(profile or {})
+        for name, profile in (((yaml_cfg or {}).get("runtimes") or _legacy_runtimes_cfg).items())
+    }
 
     _runtimes = build_runtimes(_runtimes_cfg, run=ns._run, run_json=ns._run_json)
+    ns.RUNTIME_PROFILES = _runtimes_cfg
 
     def _runtime_accessor(name: str):
         if name not in _runtimes:
@@ -936,6 +955,18 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             job["updated_at"] = ns._ms_to_iso(updated_ms)
 
     def _show_acpx_session(*, worktree, session_name):
+        issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+        thread_id = ns._codex_thread_for_issue_number(issue_number)
+        if thread_id:
+            entry = ((ns.load_scheduler().get("codex_threads") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
+            return {
+                "name": session_name,
+                "closed": False,
+                "cwd": str(worktree) if worktree is not None else None,
+                "last_used_at": entry.get("updated_at"),
+                "session_id": thread_id,
+                "record_id": thread_id,
+            }
         return ns._load_adapter_sessions_module().show_acpx_session(
             worktree=worktree, session_name=session_name, run_json=ns._run_json,
         )
@@ -946,6 +977,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _close_acpx_session(*, worktree, session_name):
+        issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+        ns._clear_codex_thread_for_issue_number(issue_number)
         return ns._load_adapter_sessions_module().close_acpx_session(
             worktree=worktree, session_name=session_name, run=ns._run,
         )
@@ -1244,6 +1277,105 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             load_latest_session_meta_fn=ns._load_latest_session_meta,
         )
 
+    def _scheduler_issue_key(issue_number):
+        if issue_number in (None, ""):
+            return None
+        return f"lane:{issue_number}"
+
+    def _scheduler_issue_number_from_session(*, worktree=None, session_name=None):
+        issue_number = ns._issue_number_from_worktree(worktree)
+        if issue_number is not None:
+            return issue_number
+        match = re.search(r"(\d+)", str(session_name or ""))
+        return int(match.group(1)) if match else None
+
+    def _codex_thread_for_issue_number(issue_number):
+        key = ns._scheduler_issue_key(issue_number)
+        if not key:
+            return None
+        entry = ((ns.load_scheduler().get("codex_threads") or {}).get(key) or {})
+        thread_id = str(entry.get("thread_id") or "").strip()
+        return thread_id or None
+
+    def _clear_codex_thread_for_issue_number(issue_number):
+        key = ns._scheduler_issue_key(issue_number)
+        if not key:
+            return False
+        scheduler = ns.load_scheduler()
+        threads = dict(scheduler.get("codex_threads") or {})
+        if key not in threads:
+            return False
+        threads.pop(key, None)
+        scheduler["workflow"] = "change-delivery"
+        scheduler["updatedAt"] = ns._now_iso()
+        scheduler["codex_threads"] = threads
+        scheduler.setdefault("codex_totals", {})
+        ns.save_scheduler(scheduler)
+        return True
+
+    def _record_coder_runtime_result(*, issue, session_name, runtime_name, runtime_kind, result, metrics, at):
+        metrics = dict(metrics or {})
+        if runtime_kind != "codex-app-server":
+            return metrics
+        key = ns._scheduler_issue_key((issue or {}).get("number"))
+        if not key:
+            return metrics
+        scheduler = ns.load_scheduler()
+        threads = dict(scheduler.get("codex_threads") or {})
+        thread_id = str(metrics.get("thread_id") or metrics.get("session_id") or "").strip()
+        if thread_id:
+            threads[key] = {
+                "issue_id": key,
+                "issue_number": (issue or {}).get("number"),
+                "identifier": f"#{(issue or {}).get('number')}",
+                "session_name": session_name,
+                "runtime_name": runtime_name,
+                "runtime_kind": runtime_kind,
+                "thread_id": thread_id,
+                "turn_id": metrics.get("turn_id"),
+                "updated_at": at,
+            }
+        totals = dict(scheduler.get("codex_totals") or {})
+        tokens = metrics.get("tokens") or {}
+        totals["input_tokens"] = int(totals.get("input_tokens") or 0) + int(tokens.get("input_tokens") or 0)
+        totals["output_tokens"] = int(totals.get("output_tokens") or 0) + int(tokens.get("output_tokens") or 0)
+        totals["total_tokens"] = int(totals.get("total_tokens") or 0) + int(tokens.get("total_tokens") or 0)
+        totals["turn_count"] = int(totals.get("turn_count") or 0) + int(metrics.get("turn_count") or 0)
+        if metrics.get("rate_limits") is not None:
+            totals["rate_limits"] = metrics.get("rate_limits")
+        scheduler.update(
+            {
+                "workflow": "change-delivery",
+                "updatedAt": ns._now_iso(),
+                "codex_threads": threads,
+                "codex_totals": totals,
+            }
+        )
+        ns.save_scheduler(scheduler)
+        return metrics
+
+    def _coder_agent_tiers():
+        return (((getattr(ns, "WORKFLOW_YAML", {}) or {}).get("agents") or {}).get("coder") or {})
+
+    def _coder_runtime_name_for_model(model):
+        tiers = ns._coder_agent_tiers()
+        model_text = str(model or "")
+        for tier in tiers.values():
+            if not isinstance(tier, dict):
+                continue
+            if model_text and str(tier.get("model") or "") == model_text and tier.get("runtime"):
+                return str(tier.get("runtime"))
+        default_tier = tiers.get("default") if isinstance(tiers, dict) else {}
+        if isinstance(default_tier, dict) and default_tier.get("runtime"):
+            return str(default_tier.get("runtime"))
+        return "acpx-codex"
+
+    def _runtime_kind(runtime_name):
+        return str(((getattr(ns, "RUNTIME_PROFILES", {}) or {}).get(runtime_name) or {}).get("kind") or runtime_name)
+
+    def _coder_runtime_kind_for_model(model):
+        return ns._runtime_kind(ns._coder_runtime_name_for_model(model))
+
     def _should_escalate_codex_model(*, lane_state=None, workflow_state=None, reviews=None):
         return ns._load_adapter_sessions_module().should_escalate_codex_model(
             lane_state=lane_state,
@@ -1290,21 +1422,29 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _ensure_acpx_session(*, worktree, session_name, codex_model, resume_session_id=None):
-        return ns._load_adapter_sessions_module().ensure_acpx_session(
+        runtime_name = ns._coder_runtime_name_for_model(codex_model)
+        runtime_kind = ns._runtime_kind(runtime_name)
+        if runtime_kind == "codex-app-server":
+            issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+            resume_session_id = ns._codex_thread_for_issue_number(issue_number) or resume_session_id
+        return ns._load_adapter_sessions_module().ensure_session_via_runtime(
+            workspace=ns,
+            runtime_name=runtime_name,
             worktree=worktree,
             session_name=session_name,
-            codex_model=codex_model,
+            model=codex_model,
             resume_session_id=resume_session_id,
-            run_json=ns._run_json,
         )
 
     def _run_acpx_prompt(*, worktree, session_name, prompt, codex_model):
-        return ns._load_adapter_sessions_module().run_acpx_prompt(
+        runtime_name = ns._coder_runtime_name_for_model(codex_model)
+        return ns._load_adapter_sessions_module().run_prompt_via_runtime(
+            workspace=ns,
+            runtime_name=runtime_name,
             worktree=worktree,
             session_name=session_name,
             prompt=prompt,
-            codex_model=codex_model,
-            run=ns._run,
+            model=codex_model,
         )
 
     # -----------------------------------------------------------------
@@ -1379,19 +1519,25 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _normalize_implementation_for_active_lane(implementation, *, active_lane, open_pr):
+        selected_codex_model = ns._codex_model_for_issue(
+            active_lane,
+            lane_state=(implementation or {}).get("laneState"),
+            workflow_state=(implementation or {}).get("status"),
+        )
+        session_runtime = ns._coder_runtime_kind_for_model(selected_codex_model)
+        resume_session_id = None
+        if session_runtime == "codex-app-server":
+            resume_session_id = ns._codex_thread_for_issue_number((active_lane or {}).get("number"))
         impl = dict(implementation or {})
         if not active_lane:
             return impl
-        selected_codex_model = ns._codex_model_for_issue(
-            active_lane,
-            lane_state=impl.get("laneState"),
-            workflow_state=impl.get("status"),
-        )
         return ns._load_adapter_status_module().normalize_implementation_for_active_lane(
             impl,
             active_lane=active_lane,
             open_pr=open_pr,
             selected_codex_model=selected_codex_model,
+            session_runtime=session_runtime,
+            resume_session_id=resume_session_id,
         )
 
     def _prepare_lane_worktree(*, worktree, branch, open_pr):
@@ -1971,6 +2117,14 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _dispatch_lane_turn(*, status, forced_action=None, audit_action="dispatch-implementation-turn"):
+        impl = status.get("implementation") or {}
+        codex_model = impl.get("codexModel") or ns._codex_model_for_issue(
+            status.get("activeLane"),
+            lane_state=impl.get("laneState"),
+            workflow_state=(status.get("ledger") or {}).get("workflowState"),
+            reviews=status.get("reviews") or {},
+        )
+        runtime_name = ns._coder_runtime_name_for_model(codex_model)
         return ns._load_adapter_actions_module().run_dispatch_lane_turn(
             status=status,
             forced_action=forced_action,
@@ -1991,6 +2145,9 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             reconcile_fn=ns.reconcile,
             audit_fn=ns.audit,
             render_implementation_dispatch_prompt_fn=ns._render_implementation_dispatch_prompt,
+            runtime_name=runtime_name,
+            runtime_kind=ns._runtime_kind(runtime_name),
+            record_runtime_result_fn=ns._record_coder_runtime_result,
             error_cls=subprocess.CalledProcessError,
         )
 

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -26,7 +26,7 @@ class Runtime(Protocol):
 
 || | `claude-cli` | `acpx-codex` | `hermes-agent` | `codex-app-server` |
 |---|---|---|---|---|---|
-| Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot | ❌ one-turn protocol client |
+| Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot | ✅ resumable Codex thread |
 | `ensure_session` | no-op | `acpx codex sessions ensure` | no-op | no-op |
 | `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | requires `command:` override | JSON-RPC over stdio to `codex app-server` |
 | `assess_health` | always healthy | freshness + grace window | always healthy | always healthy |
@@ -149,8 +149,10 @@ socket transport.
 It maps `thread/tokenUsage/updated` into Daedalus token totals and
 `account/rateLimits/updated` into the latest rate-limit snapshot. It rejects
 non-interactive approval requests so an unattended service does not hang.
-`issue-runner` persists `issue_id -> thread_id` in scheduler state and resumes
-the existing Codex thread on later ticks instead of starting a fresh thread.
+Bundled workflows persist work-item thread mappings in scheduler state
+(`issue-runner`: `issue_id -> thread_id`; `change-delivery`:
+`lane:<issue-number> -> thread_id`) and resume the existing Codex thread on
+later ticks instead of starting a fresh thread.
 In the supervised `issue-runner run` loop, terminal tracker transitions request
 cooperative cancellation; the Codex adapter sends `turn/interrupt` for the
 active turn before surfacing the cancellation result to the scheduler.

--- a/docs/examples/change-delivery.workflow.md
+++ b/docs/examples/change-delivery.workflow.md
@@ -64,6 +64,7 @@ storage:
   ledger: memory/workflow-status.json
   health: memory/workflow-health.json
   audit-log: memory/workflow-audit.jsonl
+  scheduler: memory/workflow-scheduler.json
 
 lane-selection:
   exclude-labels:

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -59,9 +59,11 @@ Conforms to Symphony §13.7 / Daedalus spec §6.4:
 }
 ```
 
-`issue-runner` reports aggregate Codex token totals and latest rate-limit data
-from its scheduler state. `change-delivery` still preserves the same response
-shape but does not yet track equivalent per-lane usage totals.
+Both bundled workflows report aggregate Codex token totals and latest
+rate-limit data from scheduler state when their active runtime is
+`codex-app-server`. `change-delivery` still derives running lane rows from its
+SQLite lane model; `issue-runner` derives running and retrying rows directly
+from its scheduler file.
 
 ### `GET /api/v1/<identifier>`
 

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -157,8 +157,8 @@ Use `--service-mode shadow` if you want read-only parity validation first.
 That `shadow` mode applies to `change-delivery`. `issue-runner` supports
 `active` mode only.
 
-If your `issue-runner` contract uses `codex.mode: external`, bring up the
-shared Codex listener once:
+If your workflow contract uses an external `codex-app-server` runtime, bring up
+the shared Codex listener once:
 
 ```bash
 hermes daedalus codex-app-server up

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -20,8 +20,8 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised `change-delivery` active iterations, worker reconciliation, and persisted scheduler state now exist. |
 | Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery. `change-delivery` now supervises one active worker iteration at a time, but the broader engine is still not uniformly scheduler-driven. |
 | Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
-| Coding-agent protocol | Partial | `issue-runner` ships a protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, and cooperative turn interruption. |
-| Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; `issue-runner` records per-run token/rate-limit metrics and exposes `codex_totals` plus Codex thread mappings. |
+| Coding-agent protocol | Partial | `issue-runner` and `change-delivery` can use the shared protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, and persisted thread resume. Cooperative turn interruption is currently wired through `issue-runner` supervision. |
+| Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; bundled workflows record Codex token/rate-limit totals and expose Codex thread mappings when using `codex-app-server`. |
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
 
@@ -30,14 +30,15 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 Daedalus currently differs from the Symphony draft in four material ways:
 
 1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow and has a Linear adapter, but the broader product story is still not Linear-first.
-2. Runtime adapters are still mixed: `issue-runner` has a protocol-level Codex app-server path, while the rest of Daedalus remains CLI/session-oriented.
+2. Runtime adapters are still mixed: both bundled workflows can use Codex app-server, but non-Codex command runtimes remain CLI/session-oriented.
 3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
 4. Long-running service paths have async supervision for `issue-runner` workers and `change-delivery` active iterations, but manual `tick` remains synchronous and command-style runtimes still have limited cancellation semantics.
 
 ## Recommended Next Gaps
 
-1. Keep Codex app-server sessions warm across worker turns instead of opening a connection per run.
-2. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
-3. Add real Linear integration smoke tests and publish a stricter conformance checklist.
+1. Add cooperative cancellation for `change-delivery` Codex app-server turns, matching `issue-runner` terminal-state interruption.
+2. Keep Codex app-server transports warm across worker turns instead of opening a connection per run.
+3. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
+4. Add real Linear integration smoke tests and publish a stricter conformance checklist.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -41,6 +41,35 @@ flow.
 `change-delivery` composes the shared `runtimes/` backends with workflow-specific
 prompts, reviewers, GitHub behavior, and merge policy.
 
+## Codex Runtime Options
+
+The default template uses `acpx-codex` for the coder role. To run the coder
+through Codex app-server instead, change only `runtimes` and
+`agents.coder.*.runtime` in `WORKFLOW.md`:
+
+```yaml
+runtimes:
+  coder-runtime:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    ephemeral: false
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+
+agents:
+  coder:
+    default:
+      name: Internal_Coder_Agent
+      model: gpt-5.5
+      runtime: coder-runtime
+```
+
+When `codex-app-server` is selected, Daedalus stores
+`lane:<issue-number> -> thread_id` plus token/rate-limit totals in
+`memory/workflow-scheduler.json` and resumes that thread on later ticks.
+
 ## Operator path
 
 Default onboarding:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -38,6 +38,15 @@ def test_happy_path_returns_ok():
     assert result.can_reconcile is True
 
 
+def test_codex_app_server_runtime_kind_returns_ok():
+    cfg = _minimal_ok_config()
+    cfg["runtimes"]["r1"]["kind"] = "codex-app-server"
+
+    result = run_preflight(cfg)
+
+    assert result.ok is True
+
+
 def test_non_dict_config_yields_front_matter_error():
     result = run_preflight("not-a-dict")  # type: ignore[arg-type]
     assert result.ok is False

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -197,6 +197,58 @@ def _make_issue_runner_root(root: Path) -> None:
     )
 
 
+def _make_change_delivery_root(root: Path) -> None:
+    from workflows.contract import render_workflow_markdown
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "memory").mkdir()
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "change-delivery",
+                "schema-version": 1,
+                "instance": {"name": "attmous-daedalus-change-delivery", "engine-owner": "hermes"},
+                "repository": {"local-path": "/tmp/repo", "github-slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+                "runtimes": {
+                    "coder-runtime": {"kind": "codex-app-server", "command": "codex app-server"},
+                    "reviewer-runtime": {"kind": "claude-cli", "max-turns-per-invocation": 24, "timeout-seconds": 1200},
+                },
+                "agents": {
+                    "coder": {"default": {"name": "coder", "model": "gpt-5.5", "runtime": "coder-runtime"}},
+                    "internal-reviewer": {"name": "reviewer", "model": "claude-sonnet-4-6", "runtime": "reviewer-runtime"},
+                    "external-reviewer": {"enabled": False, "name": "external"},
+                },
+                "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+                "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+                "storage": {
+                    "ledger": "memory/workflow-status.json",
+                    "health": "memory/workflow-health.json",
+                    "audit-log": "memory/workflow-audit.jsonl",
+                    "scheduler": "memory/workflow-scheduler.json",
+                },
+            },
+            prompt_template="Deliver the active change.",
+        ),
+        encoding="utf-8",
+    )
+    (root / "memory" / "workflow-scheduler.json").write_text(
+        json.dumps(
+            {
+                "workflow": "change-delivery",
+                "updatedAt": "2026-04-30T12:00:20Z",
+                "codex_threads": {"lane:42": {"thread_id": "thread-42"}},
+                "codex_totals": {
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "total_tokens": 18,
+                    "rate_limits": {"requests_remaining": 88},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 # --------------------------------------------------------------------- views
 
 
@@ -282,6 +334,23 @@ def test_issue_runner_state_view_reads_scheduler_and_audit_files(tmp_path: Path)
     assert view["codex_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
     assert view["recent_events"][0]["event"] == "issue_runner.tick.completed"
+
+
+def test_change_delivery_state_view_reads_codex_scheduler_totals(tmp_path: Path) -> None:
+    from workflows.change_delivery.server.views import state_view
+
+    root = tmp_path / "change_delivery_root"
+    _make_change_delivery_root(root)
+    db = tmp_path / "daedalus.db"
+    events = tmp_path / "events.jsonl"
+    _make_lanes_db(db)
+    _make_events_log(events, [])
+
+    view = state_view(db, events, workflow_root=root)
+
+    assert view["counts"] == {"running": 1, "retrying": 0}
+    assert view["codex_totals"]["total_tokens"] == 18
+    assert view["rate_limits"] == {"requests_remaining": 88}
 
 
 def test_issue_runner_issue_view_resolves_running_and_retry_entries(tmp_path: Path) -> None:

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
@@ -373,6 +374,71 @@ def test_run_dispatch_lane_turn_executes_continue_session_when_healthy(tmp_path)
     assert state["close_calls"] == 0  # continue-session doesn't close
     assert state["run_prompt_calls"]
     assert state["audits"][0]["action"] == "dispatch-implementation-turn"
+
+
+def test_run_dispatch_lane_turn_records_codex_app_server_thread_metrics(tmp_path):
+    actions_module = load_module("daedalus_workflows_change_delivery_actions_codex", "workflows/change_delivery/actions.py")
+    state, worktree, deps = _dispatch_deps(tmp_path)
+    status = {
+        "activeLane": {"number": 224, "title": "T", "url": "https://example.test/issue/224"},
+        "implementation": {
+            "worktree": str(worktree),
+            "branch": "issue-224",
+            "sessionName": "lane-224",
+            "codexModel": "gpt-5.5",
+            "resumeSessionId": "thread-existing",
+            "sessionActionRecommendation": {"action": "continue-session"},
+            "laneState": {},
+        },
+        "ledger": {"workflowState": "implementing_local"},
+        "reviews": {},
+        "openPr": None,
+    }
+
+    def run_prompt_fn(*, worktree, session_name, prompt, codex_model):
+        return SimpleNamespace(
+            output="codex ok\n",
+            session_id="thread-1",
+            thread_id="thread-1",
+            turn_id="turn-1",
+            last_event="turn/completed",
+            last_message="done",
+            turn_count=1,
+            tokens={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+            rate_limits={"requests_remaining": 99},
+        )
+
+    recorded = {}
+
+    def record_runtime_result_fn(**kwargs):
+        recorded.update(kwargs)
+        return kwargs["metrics"]
+
+    result = actions_module.run_dispatch_lane_turn(
+        status=status,
+        forced_action=None,
+        audit_action="dispatch-implementation-turn",
+        **{
+            **deps,
+            "run_prompt_fn": run_prompt_fn,
+            "runtime_name": "coder-runtime",
+            "runtime_kind": "codex-app-server",
+            "record_runtime_result_fn": record_runtime_result_fn,
+        },
+    )
+
+    assert result["sessionRuntime"] == "codex-app-server"
+    assert result["runtimeName"] == "coder-runtime"
+    assert result["threadId"] == "thread-1"
+    assert result["turnId"] == "turn-1"
+    assert result["promptResult"] == "codex ok"
+    assert result["metrics"]["tokens"]["total_tokens"] == 18
+    assert recorded["issue"]["number"] == 224
+    impl = state["save_ledger"][-1]["implementation"]
+    assert impl["sessionRuntime"] == "codex-app-server"
+    assert impl["session"] == "thread-1"
+    assert impl["resumeSessionId"] == "thread-1"
+    assert impl["runtimeMetrics"]["rate_limits"] == {"requests_remaining": 99}
 
 
 def test_run_dispatch_lane_turn_closes_session_for_restart(tmp_path):

--- a/tests/test_workflows_code_review_adapter_status.py
+++ b/tests/test_workflows_code_review_adapter_status.py
@@ -221,6 +221,24 @@ def test_normalize_implementation_for_active_lane_resets_mismatched_lane_to_fres
     }
 
 
+def test_normalize_implementation_for_active_lane_accepts_codex_app_server_runtime():
+    status_module = load_module("daedalus_workflows_change_delivery_status_codex_runtime", "workflows/change_delivery/status.py")
+
+    result = status_module.normalize_implementation_for_active_lane(
+        {"worktree": "/tmp/issue-224", "branch": "codex/issue-224-old"},
+        active_lane={"number": 224, "title": "[A07] Active lane"},
+        open_pr=None,
+        selected_codex_model="gpt-5.5",
+        session_runtime="codex-app-server",
+        resume_session_id="thread-224",
+    )
+
+    assert result["sessionRuntime"] == "codex-app-server"
+    assert result["sessionName"] == "lane-224"
+    assert result["resumeSessionId"] == "thread-224"
+    assert result["codexModel"] == "gpt-5.5"
+
+
 def test_collect_worktree_repo_facts_reads_branch_commit_count_and_head_sha(tmp_path):
     status_module = load_module("daedalus_workflows_change_delivery_status_test", "workflows/change_delivery/status.py")
 
@@ -361,6 +379,33 @@ def test_load_implementation_session_meta_falls_back_to_legacy_session_lookup_wh
 
     assert result == {"name": "session-123", "closed": False}
     assert seen == {"session_name": "session-123"}
+
+
+def test_load_implementation_session_meta_synthesizes_codex_app_server_thread_meta(tmp_path):
+    status_module = load_module("daedalus_workflows_change_delivery_status_codex_meta", "workflows/change_delivery/status.py")
+    worktree = tmp_path / "worktree"
+
+    result = status_module.load_implementation_session_meta(
+        {
+            "sessionRuntime": "codex-app-server",
+            "sessionName": "lane-224",
+            "session": "thread-224",
+            "resumeSessionId": "thread-224",
+            "updatedAt": "2026-04-30T00:00:00Z",
+        },
+        worktree,
+        show_acpx_session_fn=lambda **_kwargs: (_ for _ in ()).throw(AssertionError("acpx lookup should not run")),
+        load_latest_session_meta_fn=lambda _session: (_ for _ in ()).throw(AssertionError("legacy lookup should not run")),
+    )
+
+    assert result == {
+        "name": "lane-224",
+        "closed": False,
+        "cwd": str(worktree),
+        "last_used_at": "2026-04-30T00:00:00Z",
+        "session_id": "thread-224",
+        "record_id": "thread-224",
+    }
 
 
 def test_increment_no_progress_ticks_resets_on_approval_or_merge():

--- a/tests/test_workflows_code_review_schema.py
+++ b/tests/test_workflows_code_review_schema.py
@@ -82,6 +82,25 @@ def test_schema_accepts_minimal_valid_config():
     jsonschema.validate(_minimal_valid_config(), _load_schema())
 
 
+def test_schema_accepts_codex_app_server_runtime_for_coder():
+    cfg = _minimal_valid_config()
+    cfg["runtimes"]["coder-runtime"] = {
+        "kind": "codex-app-server",
+        "command": "codex app-server",
+        "mode": "managed",
+        "ephemeral": False,
+        "approval_policy": "never",
+        "thread_sandbox": "workspace-write",
+        "turn_sandbox_policy": "workspace-write",
+        "turn_timeout_ms": 3600000,
+        "read_timeout_ms": 5000,
+        "stall_timeout_ms": 300000,
+    }
+    cfg["agents"]["coder"]["default"]["runtime"] = "coder-runtime"
+
+    jsonschema.validate(cfg, _load_schema())
+
+
 def test_schema_rejects_missing_workflow_key():
     cfg = _minimal_valid_config()
     del cfg["workflow"]

--- a/tests/test_workflows_code_review_sessions.py
+++ b/tests/test_workflows_code_review_sessions.py
@@ -281,6 +281,28 @@ def test_build_acp_session_strategy_supports_acpx_and_legacy_runtime_shapes():
     }
 
 
+def test_build_acp_session_strategy_supports_codex_app_server_threads():
+    sessions_module = load_module("daedalus_workflows_change_delivery_sessions_codex_strategy", "workflows/change_delivery/sessions.py")
+
+    result = sessions_module.build_acp_session_strategy(
+        implementation_session_key="legacy-key",
+        session_action={"action": "continue-session"},
+        lane_state={"sessionControl": {"targetSessionKey": "old-target", "resumeSessionId": "old-thread"}},
+        session_runtime="codex-app-server",
+        session_name="lane-224",
+        resume_session_id="thread-224",
+    )
+
+    assert result == {
+        "runtime": "codex-app-server",
+        "spawnMode": "thread",
+        "nudgeTool": "codex app-server turn/start",
+        "targetSessionKey": "lane-224",
+        "resumeSessionId": "thread-224",
+        "preferredAction": "continue-session",
+    }
+
+
 def test_should_nudge_session_blocks_recent_same_head_but_allows_other_cases():
     sessions_module = load_module("daedalus_workflows_change_delivery_sessions_test", "workflows/change_delivery/sessions.py")
 

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import yaml
 
@@ -509,6 +510,118 @@ def test_workspace_from_yaml_exposes_same_surface_as_legacy_json(tmp_path):
     assert callable(ws.runtime)
     assert hasattr(ws.runtime("acpx-codex"), "ensure_session")
     assert hasattr(ws.runtime("claude-cli"), "run_prompt")
+
+
+def test_workspace_yaml_can_select_codex_app_server_coder_runtime(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["runtimes"] = {
+        "coder-runtime": {
+            "kind": "codex-app-server",
+            "command": "codex app-server",
+            "mode": "managed",
+            "ephemeral": False,
+            "approval_policy": "never",
+            "thread_sandbox": "workspace-write",
+            "turn_sandbox_policy": "workspace-write",
+        },
+        "reviewer-runtime": {
+            "kind": "claude-cli",
+            "max-turns-per-invocation": 24,
+            "timeout-seconds": 1200,
+        },
+    }
+    cfg["agents"]["coder"]["default"]["runtime"] = "coder-runtime"
+    cfg["agents"]["internal-reviewer"]["runtime"] = "reviewer-runtime"
+
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+
+    assert ws._coder_runtime_name_for_model("gpt-5.3-codex-spark/high") == "coder-runtime"
+    assert ws._coder_runtime_kind_for_model("gpt-5.3-codex-spark/high") == "codex-app-server"
+    assert hasattr(ws.runtime("coder-runtime"), "run_prompt_result")
+
+
+def test_workspace_records_change_delivery_codex_threads_and_totals(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["storage"]["scheduler"] = "memory/workflow-scheduler.json"
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+
+    metrics = ws._record_coder_runtime_result(
+        issue={"number": 224},
+        session_name="lane-224",
+        runtime_name="coder-runtime",
+        runtime_kind="codex-app-server",
+        result=SimpleNamespace(),
+        metrics={
+            "session_id": "thread-224",
+            "thread_id": "thread-224",
+            "turn_id": "turn-1",
+            "turn_count": 1,
+            "tokens": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+            "rate_limits": {"requests_remaining": 99},
+        },
+        at="2026-04-30T00:00:00Z",
+    )
+
+    scheduler = json.loads((tmp_path / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
+    assert metrics["thread_id"] == "thread-224"
+    assert scheduler["workflow"] == "change-delivery"
+    assert scheduler["codex_threads"]["lane:224"]["thread_id"] == "thread-224"
+    assert scheduler["codex_totals"]["total_tokens"] == 18
+    assert scheduler["codex_totals"]["rate_limits"] == {"requests_remaining": 99}
+    assert ws._codex_thread_for_issue_number(224) == "thread-224"
+
+
+def test_workspace_ensure_coder_session_resumes_persisted_codex_thread(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["runtimes"] = {
+        "coder-runtime": {"kind": "codex-app-server", "command": "codex app-server"},
+        "reviewer-runtime": {
+            "kind": "claude-cli",
+            "max-turns-per-invocation": 24,
+            "timeout-seconds": 1200,
+        },
+    }
+    cfg["agents"]["coder"]["default"]["runtime"] = "coder-runtime"
+    cfg["agents"]["internal-reviewer"]["runtime"] = "reviewer-runtime"
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+    ws._record_coder_runtime_result(
+        issue={"number": 224},
+        session_name="lane-224",
+        runtime_name="coder-runtime",
+        runtime_kind="codex-app-server",
+        result=SimpleNamespace(),
+        metrics={
+            "thread_id": "thread-224",
+            "turn_id": "turn-1",
+            "turn_count": 1,
+            "tokens": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        },
+        at="2026-04-30T00:00:00Z",
+    )
+
+    calls = {}
+
+    class FakeRuntime:
+        def ensure_session(self, **kwargs):
+            calls.update(kwargs)
+            return SimpleNamespace(record_id=None, session_id=kwargs.get("resume_session_id"), name=kwargs.get("session_name"))
+
+    ws.runtime = lambda name: FakeRuntime()
+    handle = ws._ensure_acpx_session(
+        worktree=Path("/tmp/issue-224"),
+        session_name="lane-224",
+        codex_model="gpt-5.3-codex-spark/high",
+        resume_session_id=None,
+    )
+
+    assert calls["resume_session_id"] == "thread-224"
+    assert handle.session_id == "thread-224"
 
 
 def test_workspace_raises_on_agent_referencing_unknown_runtime(tmp_path):


### PR DESCRIPTION
## Summary

Adds shared `codex-app-server` runtime support to the `change-delivery` workflow so operators can select it from repo-owned `WORKFLOW.md` without new workflow-specific protocol code.

## What changed

- Extends the change-delivery schema/template to allow `codex-app-server` runtimes and scheduler storage.
- Routes coder dispatch through shared runtime selection, persists `lane:<issue-number> -> thread_id`, and resumes existing Codex threads on later turns.
- Records Codex token/rate-limit totals in scheduler state and exposes them through status/watch surfaces.
- Updates operator/runtime/conformance docs and adds focused tests for schema, workspace, actions, sessions, preflight, and status views.

## Validation

- `pytest -q`
- `git diff --check`