### PR TITLE
[codex] cancel change-delivery Codex turns cooperatively

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1,10 +1,12 @@
 import argparse
 import calendar
 import concurrent.futures
+import inspect
 import importlib.util
 import json
 import sqlite3
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -16,6 +18,7 @@ from workflows.shared.paths import (
     workflow_cli_argv,
 )
 from workflows.change_delivery.event_taxonomy import (
+    DAEDALUS_ACTIVE_ACTION_CANCELED,
     DAEDALUS_ACTIVE_ACTION_COMPLETED,
     DAEDALUS_ACTIVE_ACTION_FAILED,
     DAEDALUS_ACTIVE_ACTION_REQUESTED,
@@ -1616,16 +1619,76 @@ def _run_legacy_restart_actor_session(*, workflow_root: Path) -> dict[str, Any]:
     return _run_workflow_cli_json(workflow_root=workflow_root, command="restart-actor-session")
 
 
+def _run_workspace_action(
+    *,
+    workflow_root: Path,
+    action_name: str,
+    cancel_event: Any | None = None,
+) -> dict[str, Any]:
+    workspace = _load_legacy_workflow_module(workflow_root)
+    set_cancel_event = getattr(workspace, "set_active_cancel_event", None)
+    if callable(set_cancel_event):
+        set_cancel_event(cancel_event)
+    try:
+        action = getattr(workspace, action_name)
+        return action()
+    finally:
+        if callable(set_cancel_event):
+            set_cancel_event(None)
+
+
 def _default_active_action_runners(*, workflow_root: Path) -> dict[str, Any]:
     return {
-        "dispatch_implementation_turn": lambda: _run_legacy_dispatch_implementation_turn(workflow_root=workflow_root),
-        "dispatch_repair_handoff": lambda: _run_legacy_dispatch_repair_handoff(workflow_root=workflow_root),
-        "restart_actor_session": lambda: _run_legacy_restart_actor_session(workflow_root=workflow_root),
-        "push_pr_update": lambda: _run_legacy_push_pr_update(workflow_root=workflow_root),
-        "publish_pr": lambda: _run_legacy_publish_pr(workflow_root=workflow_root),
-        "request_internal_review": lambda: _run_legacy_request_internal_review(workflow_root=workflow_root),
-        "merge_pr": lambda: _run_legacy_merge_pr(workflow_root=workflow_root),
+        "dispatch_implementation_turn": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="dispatch_implementation_turn",
+            cancel_event=cancel_event,
+        ),
+        "dispatch_repair_handoff": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="dispatch_repair_handoff",
+            cancel_event=cancel_event,
+        ),
+        "restart_actor_session": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="restart_actor_session",
+            cancel_event=cancel_event,
+        ),
+        "push_pr_update": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="push_pr_update",
+            cancel_event=cancel_event,
+        ),
+        "publish_pr": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="publish_ready_pr",
+            cancel_event=cancel_event,
+        ),
+        "request_internal_review": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="dispatch_inter_review_agent_review",
+            cancel_event=cancel_event,
+        ),
+        "merge_pr": lambda cancel_event=None: _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name="merge_and_promote",
+            cancel_event=cancel_event,
+        ),
     }
+
+
+def _invoke_action_runner(runner: Any, *, cancel_event: Any | None = None) -> dict[str, Any]:
+    try:
+        signature = inspect.signature(runner)
+    except (TypeError, ValueError):
+        return runner()
+    parameters = signature.parameters
+    accepts_cancel_event = "cancel_event" in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    if accepts_cancel_event:
+        return runner(cancel_event=cancel_event)
+    return runner()
 
 
 def _summarize_active_action_result(*, action_type: str, result: dict[str, Any]) -> str:
@@ -2996,6 +3059,7 @@ def execute_requested_action(
     now_iso: str | None = None,
     action_runners: dict[str, Any] | None = None,
     failure_analyst: Any | None = None,
+    cancel_event: Any | None = None,
 ) -> dict[str, Any]:
     now_iso = now_iso or _now_iso()
     runners = _default_active_action_runners(workflow_root=workflow_root)
@@ -3030,7 +3094,7 @@ def execute_requested_action(
         runner = runners.get(action.get("action_type"))
         if runner is None:
             raise RuntimeError(f"unsupported action_type: {action.get('action_type')}")
-        result = runner()
+        result = _invoke_action_runner(runner, cancel_event=cancel_event)
         post_action_status = result.get("after") if isinstance(result.get("after"), dict) else None
         if post_action_status is None:
             # Post-action status read prefers the plugin-side workspace
@@ -3082,6 +3146,43 @@ def execute_requested_action(
                 )
         conn.commit()
     except Exception as exc:
+        if cancel_event is not None and getattr(cancel_event, "is_set", lambda: False)():
+            cancel_summary = f"active action canceled: {type(exc).__name__}: {exc}"
+            if action:
+                conn.execute(
+                    """
+                    UPDATE lane_actions
+                    SET status='canceled', completed_at=?, result_code=?, result_summary=?, error_payload_json=?
+                    WHERE action_id=?
+                    """,
+                    (
+                        now_iso,
+                        "canceled",
+                        cancel_summary,
+                        json.dumps({"canceled": True, "error": str(exc)}, sort_keys=True),
+                        action_id,
+                    ),
+                )
+                conn.commit()
+                append_daedalus_event(
+                    event_log_path=paths["event_log_path"],
+                    event={
+                        "event_id": f"evt:active_action_canceled:{action_id}:{now_iso}",
+                        "event_type": DAEDALUS_ACTIVE_ACTION_CANCELED,
+                        "event_version": 1,
+                        "created_at": now_iso,
+                        "producer": "Workflow_Orchestrator",
+                        "project_key": _project_key_for(workflow_root),
+                        "lane_id": action.get("lane_id"),
+                        "issue_number": None,
+                        "head_sha": action.get("target_head_sha"),
+                        "causal_event_id": None,
+                        "causal_action_id": action_id,
+                        "dedupe_key": f"active_action_canceled:{action_id}:{now_iso}",
+                        "payload": {"action_type": action.get("action_type"), "result_code": "canceled"},
+                    },
+                )
+            return {"executed": False, "canceled": True, "action_id": action_id, "reason": "cancel-requested", "error": cancel_summary}
         failure_scope = _failure_scope_for_action((action or {}).get("action_type"))
         raw_failure_class = f"{(action or {}).get('action_type') or 'unknown_action'}_failed"
         failure_summary = str(exc)
@@ -3573,7 +3674,15 @@ def run_shadow_loop(
     }
 
 
-def run_active_iteration(*, workflow_root: Path, instance_id: str, legacy_status: dict[str, Any] | None = None, now_iso: str | None = None, action_runners: dict[str, Any] | None = None) -> dict[str, Any]:
+def run_active_iteration(
+    *,
+    workflow_root: Path,
+    instance_id: str,
+    legacy_status: dict[str, Any] | None = None,
+    now_iso: str | None = None,
+    action_runners: dict[str, Any] | None = None,
+    cancel_event: Any | None = None,
+) -> dict[str, Any]:
     now_iso = now_iso or _now_iso()
     heartbeat = refresh_runtime_lease(workflow_root=workflow_root, instance_id=instance_id, now_iso=now_iso)
     if not heartbeat.get("refreshed"):
@@ -3646,6 +3755,7 @@ def run_active_iteration(*, workflow_root: Path, instance_id: str, legacy_status
         action_id=requested_actions[0]["action_id"],
         now_iso=now_iso,
         action_runners=action_runners,
+        cancel_event=cancel_event,
     )
     return {
         "iteration_status": "executed",
@@ -3668,9 +3778,88 @@ def _active_loop_running_snapshot(supervised_iteration: dict[str, Any] | None) -
     now_epoch = int(time.time())
     return {
         "worker_id": supervised_iteration.get("worker_id"),
+        "lane_id": supervised_iteration.get("lane_id"),
+        "issue_number": supervised_iteration.get("issue_number"),
         "started_at": started_at,
         "running_for_seconds": max(now_epoch - started_epoch, 0) if started_epoch is not None else None,
+        "cancel_requested": bool(supervised_iteration.get("cancel_requested")),
+        "cancel_reason": supervised_iteration.get("cancel_reason"),
     }
+
+
+def _active_lane_id_from_status(status: dict[str, Any] | None) -> str | None:
+    active_lane = (status or {}).get("activeLane") or {}
+    issue_number = active_lane.get("number")
+    if not issue_number:
+        return None
+    return _lane_id(issue_number)
+
+
+def _active_issue_number_from_status(status: dict[str, Any] | None) -> int | None:
+    active_lane = (status or {}).get("activeLane") or {}
+    issue_number = active_lane.get("number")
+    try:
+        return int(issue_number) if issue_number is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _active_loop_cancel_reason(
+    *,
+    supervised_iteration: dict[str, Any] | None,
+    legacy_status: dict[str, Any] | None,
+) -> str | None:
+    if not supervised_iteration or supervised_iteration.get("cancel_requested"):
+        return None
+    expected_lane_id = supervised_iteration.get("lane_id")
+    if not expected_lane_id:
+        return None
+    current_lane_id = _active_lane_id_from_status(legacy_status)
+    if current_lane_id == expected_lane_id:
+        return None
+    return "no-active-lane" if current_lane_id is None else "active-lane-changed"
+
+
+def _interrupt_active_loop_codex_turn(
+    *,
+    workflow_root: Path,
+    supervised_iteration: dict[str, Any],
+    reason: str,
+) -> dict[str, Any] | None:
+    try:
+        workspace = _load_legacy_workflow_module(workflow_root)
+        interrupter = getattr(workspace, "_interrupt_active_coder_turn", None)
+        if not callable(interrupter):
+            return None
+        return interrupter(issue_number=supervised_iteration.get("issue_number"), reason=reason)
+    except Exception as exc:
+        return {"interrupted": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
+def _request_active_loop_cancel(
+    *,
+    workflow_root: Path,
+    supervised_iteration: dict[str, Any] | None,
+    reason: str,
+) -> bool:
+    if not supervised_iteration or supervised_iteration.get("cancel_requested"):
+        return False
+    supervised_iteration["cancel_requested"] = True
+    supervised_iteration["cancel_reason"] = reason
+    event = supervised_iteration.get("cancel_event")
+    if hasattr(event, "set"):
+        event.set()
+    future = supervised_iteration.get("future")
+    if isinstance(future, concurrent.futures.Future):
+        future.cancel()
+    interrupt_result = _interrupt_active_loop_codex_turn(
+        workflow_root=workflow_root,
+        supervised_iteration=supervised_iteration,
+        reason=reason,
+    )
+    if interrupt_result is not None:
+        supervised_iteration["cancel_interrupt"] = interrupt_result
+    return True
 
 
 def _reconcile_active_loop_iteration(
@@ -3696,6 +3885,9 @@ def _reconcile_active_loop_iteration(
                 "worker_id": supervised_iteration.get("worker_id"),
                 "started_at": supervised_iteration.get("started_at"),
                 "completed_at": _now_iso(),
+                "cancel_requested": bool(supervised_iteration.get("cancel_requested")),
+                "cancel_reason": supervised_iteration.get("cancel_reason"),
+                "cancel_interrupt": supervised_iteration.get("cancel_interrupt"),
             }
         else:
             result = {
@@ -3704,6 +3896,9 @@ def _reconcile_active_loop_iteration(
                 "worker_id": supervised_iteration.get("worker_id"),
                 "started_at": supervised_iteration.get("started_at"),
                 "completed_at": _now_iso(),
+                "cancel_requested": bool(supervised_iteration.get("cancel_requested")),
+                "cancel_reason": supervised_iteration.get("cancel_reason"),
+                "cancel_interrupt": supervised_iteration.get("cancel_interrupt"),
                 "result": result,
             }
     except BaseException as exc:
@@ -3713,6 +3908,9 @@ def _reconcile_active_loop_iteration(
             "worker_id": supervised_iteration.get("worker_id"),
             "started_at": supervised_iteration.get("started_at"),
             "completed_at": _now_iso(),
+            "cancel_requested": bool(supervised_iteration.get("cancel_requested")),
+            "cancel_reason": supervised_iteration.get("cancel_reason"),
+            "cancel_interrupt": supervised_iteration.get("cancel_interrupt"),
             "error": f"{type(exc).__name__}: {exc}",
         }
     return [result], None
@@ -3758,7 +3956,26 @@ def run_active_loop(
                 last_result = completed[-1]
             if supervised_iteration is not None:
                 heartbeat = refresh_runtime_lease(workflow_root=workflow_root, instance_id=instance_id, now_iso=_now_iso())
+                try:
+                    current_legacy_status = legacy_status_provider() if legacy_status_provider else _load_legacy_workflow_module(workflow_root).build_status()
+                except Exception:
+                    current_legacy_status = None
+                cancel_reason = _active_loop_cancel_reason(
+                    supervised_iteration=supervised_iteration,
+                    legacy_status=current_legacy_status,
+                )
+                if cancel_reason:
+                    _request_active_loop_cancel(
+                        workflow_root=workflow_root,
+                        supervised_iteration=supervised_iteration,
+                        reason=cancel_reason,
+                    )
                 if not heartbeat.get("refreshed"):
+                    _request_active_loop_cancel(
+                        workflow_root=workflow_root,
+                        supervised_iteration=supervised_iteration,
+                        reason="lease-not-refreshed",
+                    )
                     last_result = {
                         "iteration_status": "blocked",
                         "reason": heartbeat.get("reason"),
@@ -3777,17 +3994,30 @@ def run_active_loop(
                 # instead of immediately dispatching a second active iteration.
                 pass
             else:
-                legacy_status = legacy_status_provider() if legacy_status_provider else None
+                if legacy_status_provider:
+                    legacy_status = legacy_status_provider()
+                else:
+                    try:
+                        legacy_status = _load_legacy_workflow_module(workflow_root).build_status()
+                    except Exception:
+                        legacy_status = None
                 started_at = _now_iso()
+                cancel_event = threading.Event()
                 supervised_iteration = {
                     "worker_id": f"active-worker:{instance_id}:{iterations + 1}:{started_at}",
                     "started_at": started_at,
+                    "lane_id": _active_lane_id_from_status(legacy_status),
+                    "issue_number": _active_issue_number_from_status(legacy_status),
+                    "cancel_event": cancel_event,
+                    "cancel_requested": False,
+                    "cancel_reason": None,
                     "future": executor.submit(
                         run_active_iteration,
                         workflow_root=workflow_root,
                         instance_id=instance_id,
                         legacy_status=legacy_status,
                         action_runners=action_runners,
+                        cancel_event=cancel_event,
                     ),
                 }
                 last_result = {
@@ -3801,6 +4031,11 @@ def run_active_loop(
             sleep_fn(interval_seconds)
     except KeyboardInterrupt:
         loop_status = "interrupted"
+        _request_active_loop_cancel(
+            workflow_root=workflow_root,
+            supervised_iteration=supervised_iteration,
+            reason="operator-interrupt",
+        )
     finally:
         completed, supervised_iteration = _reconcile_active_loop_iteration(supervised_iteration, settle_timeout_seconds=0.25)
         if completed:

--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -13,7 +13,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from . import PromptRunResult, SessionHandle, SessionHealth, register
@@ -437,6 +437,7 @@ class CodexAppServerRuntime:
         self._last_result: PromptRunResult | None = None
         self._resume_thread_ids: dict[str, str] = {}
         self._cancel_event: threading.Event | None = None
+        self._progress_callback: Callable[[PromptRunResult], None] | None = None
 
     def _record_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -449,6 +450,30 @@ class CodexAppServerRuntime:
 
     def set_cancel_event(self, event: threading.Event | None) -> None:
         self._cancel_event = event
+
+    def set_progress_callback(self, callback: Callable[[PromptRunResult], None] | None) -> None:
+        self._progress_callback = callback
+
+    def interrupt_turn(
+        self,
+        *,
+        thread_id: str,
+        turn_id: str,
+        worktree: Path | None = None,
+    ) -> bool:
+        thread_id = str(thread_id or "").strip()
+        turn_id = str(turn_id or "").strip()
+        if not thread_id or not turn_id:
+            return False
+        cwd = worktree or Path.cwd()
+        client = self._build_client(worktree=cwd, env=os.environ.copy())
+        state = _RunState(session_id=thread_id, thread_id=thread_id, turn_id=turn_id)
+        try:
+            self._initialize(client=client, state=state)
+            self._interrupt_turn(client=client, state=state)
+            return True
+        finally:
+            client.close()
 
     def ensure_session(
         self,
@@ -530,6 +555,7 @@ class CodexAppServerRuntime:
                     on_message=lambda message: self._consume_message(message, state=state),
                 )
             self._consume_thread_start_response(thread_result, state=state)
+            self._notify_progress(state)
             turn_result = client.request(
                 "turn/start",
                 self._turn_start_params(worktree=worktree, thread_id=state.thread_id, prompt=prompt, model=model),
@@ -537,6 +563,7 @@ class CodexAppServerRuntime:
                 on_message=lambda message: self._consume_message(message, state=state),
             )
             self._consume_turn_response(turn_result, state=state)
+            self._notify_progress(state)
             result = self._read_turn_to_completion(client=client, state=state)
             self._last_result = result
             return result
@@ -811,6 +838,14 @@ class CodexAppServerRuntime:
         except CodexAppServerError:
             return
 
+    def _notify_progress(self, state: _RunState) -> None:
+        if self._progress_callback is None:
+            return
+        try:
+            self._progress_callback(self._result_from_state(state))
+        except Exception:
+            return
+
     def _consume_message(self, message: dict[str, Any], *, state: _RunState) -> bool:
         method = str(message.get("method") or "").strip()
         if not method:
@@ -873,9 +908,11 @@ class CodexAppServerRuntime:
                         f"codex-app-server failed: {failure}",
                         result=self._result_from_state(state),
                     )
+            self._notify_progress(state)
             return True
         elif self._is_request_notification(method):
             state.last_message = f"unsupported app-server request: {method}"
+        self._notify_progress(state)
         return False
 
     def _is_request_notification(self, method: str) -> bool:

--- a/daedalus/watch.py
+++ b/daedalus/watch.py
@@ -72,12 +72,22 @@ def _workflow_status_panel(workflow_status: Mapping[str, Any]) -> Panel | None:
         f"health={workflow_status.get('health') or '?'}",
         f"running={workflow_status.get('running_count') or 0}",
         f"retry={workflow_status.get('retry_count') or 0}",
+        f"canceling={workflow_status.get('canceling_count') or 0}",
         f"tokens={workflow_status.get('total_tokens') or 0}",
     ]
     if workflow_status.get("selected_issue"):
         lines.append(f"selected={workflow_status.get('selected_issue')}")
     if workflow_status.get("rate_limits"):
         lines.append(f"rate_limits={workflow_status.get('rate_limits')}")
+    for turn in workflow_status.get("codex_turns") or []:
+        if turn.get("status") == "canceling" or turn.get("cancel_requested"):
+            lines.append(
+                "codex_canceling="
+                f"{turn.get('issue_identifier') or turn.get('issue_id')} "
+                f"thread={turn.get('thread_id')} "
+                f"turn={turn.get('turn_id')} "
+                f"reason={turn.get('cancel_reason') or '?'}"
+            )
     if workflow_status.get("updated_at"):
         lines.append(f"updated_at={workflow_status.get('updated_at')}")
     return Panel("\n".join(_esc(str(line)) for line in lines), title="Workflow status")

--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -196,6 +196,28 @@ def alert_state(workflow_root: Path) -> dict[str, Any]:
         return {}
 
 
+def _codex_turn_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = []
+    for issue_id, raw_entry in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).items():
+        if not isinstance(raw_entry, dict):
+            continue
+        issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+        entries.append(
+            {
+                "issue_id": raw_entry.get("issue_id") or issue_id,
+                "issue_number": issue_number,
+                "issue_identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
+                "thread_id": raw_entry.get("thread_id") or raw_entry.get("threadId"),
+                "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                "status": raw_entry.get("status"),
+                "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
+                "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
+                "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+            }
+        )
+    return sorted(entries, key=lambda item: str(item.get("issue_id") or ""))
+
+
 def workflow_status(workflow_root: Path) -> dict[str, Any]:
     workflow_root = Path(workflow_root)
     workflow_name = _workflow_name(workflow_root)
@@ -205,13 +227,16 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
         scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
         scheduler_payload = _load_optional_json(scheduler_path) or {}
         totals = scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {}
+        codex_turns = _codex_turn_entries(scheduler_payload)
         return {
             "workflow": "change-delivery",
             "health": None,
             "updated_at": scheduler_payload.get("updatedAt"),
-            "running_count": 0,
+            "running_count": len([entry for entry in codex_turns if entry.get("status") == "running"]),
             "retry_count": 0,
+            "canceling_count": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
             "selected_issue": None,
+            "codex_turns": codex_turns,
             "total_tokens": int(totals.get("total_tokens") or 0),
             "rate_limits": totals.get("rate_limits"),
         }

--- a/daedalus/workflows/change_delivery/event_taxonomy.py
+++ b/daedalus/workflows/change_delivery/event_taxonomy.py
@@ -35,7 +35,7 @@ STARTUP_FAILED        = "startup_failed"
 
 
 # ---- Daedalus-native orchestration events (canonical, prefixed). ----
-# These cover the 13 distinct event_type literals currently emitted by
+# These cover the distinct event_type literals currently emitted by
 # runtime.py via append_daedalus_event.
 DAEDALUS_RUNTIME_STARTED              = "daedalus.runtime_started"
 DAEDALUS_RUNTIME_HEARTBEAT            = "daedalus.runtime_heartbeat"
@@ -44,6 +44,7 @@ DAEDALUS_ACTIVE_EXECUTION_CONTROL_UPDATED = "daedalus.active_execution_control_u
 DAEDALUS_SHADOW_ACTION_REQUESTED      = "daedalus.shadow_action_requested"
 DAEDALUS_ACTIVE_ACTION_REQUESTED      = "daedalus.active_action_requested"
 DAEDALUS_ACTIVE_ACTION_COMPLETED      = "daedalus.active_action_completed"
+DAEDALUS_ACTIVE_ACTION_CANCELED       = "daedalus.active_action_canceled"
 DAEDALUS_ACTIVE_ACTION_FAILED         = "daedalus.active_action_failed"
 DAEDALUS_RECOVERY_REQUESTED           = "daedalus.recovery_requested"
 DAEDALUS_OPERATOR_ATTENTION_REQUIRED  = "daedalus.operator_attention_required"
@@ -74,6 +75,7 @@ EVENT_ALIASES: dict[str, str] = {
     "shadow_action_requested":             DAEDALUS_SHADOW_ACTION_REQUESTED,
     "active_action_requested":             DAEDALUS_ACTIVE_ACTION_REQUESTED,
     "active_action_completed":             DAEDALUS_ACTIVE_ACTION_COMPLETED,
+    "active_action_canceled":              DAEDALUS_ACTIVE_ACTION_CANCELED,
     "active_action_failed":                DAEDALUS_ACTIVE_ACTION_FAILED,
     "recovery_requested":                  DAEDALUS_RECOVERY_REQUESTED,
     "operator_attention_required":         DAEDALUS_OPERATOR_ATTENTION_REQUIRED,

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -357,6 +357,31 @@ def _issue_runner_issue_view(
     return {**entry, "recent_events": issue_events}
 
 
+def _codex_turn_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = []
+    for issue_id, raw_entry in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).items():
+        if not isinstance(raw_entry, dict):
+            continue
+        issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+        entries.append(
+            {
+                "issue_id": raw_entry.get("issue_id") or issue_id,
+                "issue_number": issue_number,
+                "issue_identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
+                "session_name": raw_entry.get("session_name") or raw_entry.get("sessionName"),
+                "runtime_name": raw_entry.get("runtime_name") or raw_entry.get("runtimeName"),
+                "runtime_kind": raw_entry.get("runtime_kind") or raw_entry.get("runtimeKind"),
+                "thread_id": raw_entry.get("thread_id") or raw_entry.get("threadId"),
+                "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                "status": raw_entry.get("status"),
+                "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
+                "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
+                "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+            }
+        )
+    return sorted(entries, key=lambda item: str(item.get("issue_id") or ""))
+
+
 def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None = None) -> dict[str, Any]:
     """Snapshot view conforming to Symphony §13.7 / spec §6.4."""
     if _workflow_name(workflow_root) == "issue-runner":
@@ -367,11 +392,17 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
     scheduler = _load_optional_json(_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")) or {}
     codex_totals = dict(scheduler.get("codex_totals") or scheduler.get("codexTotals") or {})
     rate_limits = codex_totals.pop("rate_limits", None)
+    codex_turns = _codex_turn_entries(scheduler)
     return {
         "generated_at": _now_iso(),
         "counts": {"running": len(running), "retrying": 0},
         "running": running,
         "retrying": [],
+        "codex_turns": codex_turns,
+        "codex_turn_counts": {
+            "running": len([entry for entry in codex_turns if entry.get("status") == "running"]),
+            "canceling": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
+        },
         "codex_totals": {
             "input_tokens": int(codex_totals.get("input_tokens") or 0),
             "output_tokens": int(codex_totals.get("output_tokens") or 0),

--- a/daedalus/workflows/change_delivery/sessions.py
+++ b/daedalus/workflows/change_delivery/sessions.py
@@ -590,23 +590,37 @@ def run_prompt_via_runtime(
     session_name: str,
     prompt: str,
     model: str,
+    cancel_event: Any | None = None,
+    progress_callback: Callable[[Any], None] | None = None,
 ) -> Any:
     """Runtime-aware version of run_acpx_prompt / the inline claude invocation."""
     runtime = workspace.runtime(runtime_name)
+    set_cancel_event = getattr(runtime, "set_cancel_event", None)
+    set_progress_callback = getattr(runtime, "set_progress_callback", None)
+    if callable(set_cancel_event):
+        set_cancel_event(cancel_event)
+    if callable(set_progress_callback):
+        set_progress_callback(progress_callback)
     runner = getattr(runtime, "run_prompt_result", None)
-    if callable(runner):
-        return runner(
+    try:
+        if callable(runner):
+            return runner(
+                worktree=worktree,
+                session_name=session_name,
+                prompt=prompt,
+                model=model,
+            )
+        return runtime.run_prompt(
             worktree=worktree,
             session_name=session_name,
             prompt=prompt,
             model=model,
         )
-    return runtime.run_prompt(
-        worktree=worktree,
-        session_name=session_name,
-        prompt=prompt,
-        model=model,
-    )
+    finally:
+        if callable(set_progress_callback):
+            set_progress_callback(None)
+        if callable(set_cancel_event):
+            set_cancel_event(None)
 
 
 def close_session_via_runtime(*, workspace, runtime_name: str, worktree, session_name: str) -> None:

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -630,6 +630,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         CONFIG=config,
         WORKFLOW_YAML=yaml_cfg or {},
         WORKFLOW_POLICY=workflow_policy,
+        ACTIVE_CANCEL_EVENT=None,
         DEFAULT_CONFIG_PATH=workspace_root / DEFAULT_WORKFLOW_MARKDOWN_FILENAME,
         SESSIONS_STATE_PATH=sessions_state_path,
         REPO_PATH=repo_path,
@@ -836,6 +837,33 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
     means the adapter CLI + orchestrator can call ``ws._name`` without the
     wrapper needing to redeclare them.
     """
+
+    def set_active_cancel_event(event):
+        ns.ACTIVE_CANCEL_EVENT = event
+        return None
+
+    def _object_value(value, *keys):
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                return value.get(key)
+            if hasattr(value, key):
+                return getattr(value, key)
+        return None
+
+    def _runtime_metrics_payload(value):
+        if value is None or isinstance(value, str):
+            return {}
+        tokens = _object_value(value, "tokens")
+        return {
+            "session_id": _object_value(value, "session_id", "sessionId"),
+            "thread_id": _object_value(value, "thread_id", "threadId"),
+            "turn_id": _object_value(value, "turn_id", "turnId"),
+            "last_event": _object_value(value, "last_event", "lastEvent"),
+            "last_message": _object_value(value, "last_message", "lastMessage"),
+            "turn_count": int(_object_value(value, "turn_count", "turnCount") or 0),
+            "tokens": tokens if isinstance(tokens, dict) else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "rate_limits": _object_value(value, "rate_limits", "rateLimits"),
+        }
 
     def _lane_state_path(worktree):
         return ns._load_adapter_paths_module().lane_state_path(worktree)
@@ -1333,6 +1361,9 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
                 "runtime_kind": runtime_kind,
                 "thread_id": thread_id,
                 "turn_id": metrics.get("turn_id"),
+                "status": "completed",
+                "cancel_requested": False,
+                "cancel_reason": None,
                 "updated_at": at,
             }
         totals = dict(scheduler.get("codex_totals") or {})
@@ -1353,6 +1384,100 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
         ns.save_scheduler(scheduler)
         return metrics
+
+    def _record_coder_runtime_progress(*, issue_number, session_name, runtime_name, runtime_kind, worktree, result):
+        if runtime_kind != "codex-app-server":
+            return None
+        metrics = ns._runtime_metrics_payload(result)
+        thread_id = str(metrics.get("thread_id") or metrics.get("session_id") or "").strip()
+        if not thread_id:
+            return None
+        key = ns._scheduler_issue_key(issue_number)
+        if not key:
+            return None
+        scheduler = ns.load_scheduler()
+        threads = dict(scheduler.get("codex_threads") or {})
+        prior = dict(threads.get(key) or {})
+        threads[key] = {
+            **prior,
+            "issue_id": key,
+            "issue_number": issue_number,
+            "identifier": f"#{issue_number}",
+            "session_name": session_name,
+            "runtime_name": runtime_name,
+            "runtime_kind": runtime_kind,
+            "thread_id": thread_id,
+            "turn_id": metrics.get("turn_id") or prior.get("turn_id"),
+            "worktree": str(worktree) if worktree is not None else prior.get("worktree"),
+            "status": "running",
+            "last_event": metrics.get("last_event"),
+            "last_message": metrics.get("last_message"),
+            "updated_at": ns._now_iso(),
+        }
+        scheduler.update(
+            {
+                "workflow": "change-delivery",
+                "updatedAt": ns._now_iso(),
+                "codex_threads": threads,
+                "codex_totals": scheduler.get("codex_totals") or {},
+            }
+        )
+        ns.save_scheduler(scheduler)
+        return metrics
+
+    def _interrupt_active_coder_turn(*, issue_number=None, reason="cancel-requested"):
+        scheduler = ns.load_scheduler()
+        threads = dict(scheduler.get("codex_threads") or {})
+        key = ns._scheduler_issue_key(issue_number) if issue_number is not None else None
+        if key is None:
+            running_entries = [
+                (entry_key, entry)
+                for entry_key, entry in threads.items()
+                if isinstance(entry, dict) and entry.get("status") == "running"
+            ]
+            if len(running_entries) != 1:
+                return {"interrupted": False, "reason": "missing-active-turn"}
+            key, entry = running_entries[0]
+        else:
+            entry = threads.get(key) or {}
+        thread_id = str((entry or {}).get("thread_id") or "").strip()
+        turn_id = str((entry or {}).get("turn_id") or "").strip()
+        runtime_name = str((entry or {}).get("runtime_name") or "").strip()
+        if not thread_id or not turn_id or not runtime_name:
+            return {"interrupted": False, "reason": "missing-active-turn"}
+        runtime = ns.runtime(runtime_name)
+        interrupter = getattr(runtime, "interrupt_turn", None)
+        if not callable(interrupter):
+            return {"interrupted": False, "reason": "runtime-does-not-support-interrupt"}
+        worktree = Path(entry.get("worktree")) if entry.get("worktree") else None
+        try:
+            interrupted = bool(interrupter(thread_id=thread_id, turn_id=turn_id, worktree=worktree))
+        except Exception as exc:
+            return {"interrupted": False, "reason": f"{type(exc).__name__}: {exc}"}
+        updated_entry = {
+            **entry,
+            "status": "canceling" if interrupted else entry.get("status"),
+            "cancel_requested": interrupted,
+            "cancel_reason": reason if interrupted else entry.get("cancel_reason"),
+            "updated_at": ns._now_iso(),
+        }
+        threads[key] = updated_entry
+        scheduler.update(
+            {
+                "workflow": "change-delivery",
+                "updatedAt": ns._now_iso(),
+                "codex_threads": threads,
+                "codex_totals": scheduler.get("codex_totals") or {},
+            }
+        )
+        ns.save_scheduler(scheduler)
+        return {
+            "interrupted": interrupted,
+            "issue_id": key,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+            "reason": reason,
+        }
 
     def _coder_agent_tiers():
         return (((getattr(ns, "WORKFLOW_YAML", {}) or {}).get("agents") or {}).get("coder") or {})
@@ -1438,6 +1563,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def _run_acpx_prompt(*, worktree, session_name, prompt, codex_model):
         runtime_name = ns._coder_runtime_name_for_model(codex_model)
+        runtime_kind = ns._runtime_kind(runtime_name)
+        issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
         return ns._load_adapter_sessions_module().run_prompt_via_runtime(
             workspace=ns,
             runtime_name=runtime_name,
@@ -1445,6 +1572,19 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             session_name=session_name,
             prompt=prompt,
             model=codex_model,
+            cancel_event=ns.ACTIVE_CANCEL_EVENT,
+            progress_callback=(
+                lambda result: ns._record_coder_runtime_progress(
+                    issue_number=issue_number,
+                    session_name=session_name,
+                    runtime_name=runtime_name,
+                    runtime_kind=runtime_kind,
+                    worktree=worktree,
+                    result=result,
+                )
+                if runtime_kind == "codex-app-server"
+                else None
+            ),
         )
 
     # -----------------------------------------------------------------

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -153,16 +153,21 @@ Bundled workflows persist work-item thread mappings in scheduler state
 (`issue-runner`: `issue_id -> thread_id`; `change-delivery`:
 `lane:<issue-number> -> thread_id`) and resume the existing Codex thread on
 later ticks instead of starting a fresh thread.
-In the supervised `issue-runner run` loop, terminal tracker transitions request
-cooperative cancellation; the Codex adapter sends `turn/interrupt` for the
-active turn before surfacing the cancellation result to the scheduler.
+In supervised service loops, cancellation is cooperative. `issue-runner`
+requests cancellation when a running issue reaches a terminal tracker state.
+`change-delivery` requests cancellation when the active lane disappears,
+changes, the runtime lease is lost, or the service is interrupted. The Codex
+adapter sends `turn/interrupt` for the active turn and records the cancellation
+state in scheduler metadata.
 
 ## Adding a new runtime
 
 1. Subclass nothing — just implement the Protocol shape.
 2. Decorate with `@register("<your-kind>")` from `runtimes`.
 3. Add the kind to `schema.yaml` so config validation accepts it.
-4. Optionally implement `last_activity_ts()` for stall participation.
+4. Optionally implement `set_cancel_event()`, `set_progress_callback()`, and
+   `interrupt_turn()` if the runtime supports cooperative turn cancellation.
+5. Optionally implement `last_activity_ts()` for stall participation.
 
 ## Where this lives in code
 

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -63,7 +63,8 @@ Both bundled workflows report aggregate Codex token totals and latest
 rate-limit data from scheduler state when their active runtime is
 `codex-app-server`. `change-delivery` still derives running lane rows from its
 SQLite lane model; `issue-runner` derives running and retrying rows directly
-from its scheduler file.
+from its scheduler file. `change-delivery` also includes `codex_turns` so
+operators can inspect active or canceling Codex `thread_id` / `turn_id` pairs.
 
 ### `GET /api/v1/<identifier>`
 

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -20,7 +20,7 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised `change-delivery` active iterations, worker reconciliation, and persisted scheduler state now exist. |
 | Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery. `change-delivery` now supervises one active worker iteration at a time, but the broader engine is still not uniformly scheduler-driven. |
 | Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
-| Coding-agent protocol | Partial | `issue-runner` and `change-delivery` can use the shared protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, and persisted thread resume. Cooperative turn interruption is currently wired through `issue-runner` supervision. |
+| Coding-agent protocol | Partial | `issue-runner` and `change-delivery` can use the shared protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, and cooperative turn interruption. |
 | Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; bundled workflows record Codex token/rate-limit totals and expose Codex thread mappings when using `codex-app-server`. |
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
@@ -36,9 +36,8 @@ Daedalus currently differs from the Symphony draft in four material ways:
 
 ## Recommended Next Gaps
 
-1. Add cooperative cancellation for `change-delivery` Codex app-server turns, matching `issue-runner` terminal-state interruption.
-2. Keep Codex app-server transports warm across worker turns instead of opening a connection per run.
-3. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
-4. Add real Linear integration smoke tests and publish a stricter conformance checklist.
+1. Keep Codex app-server transports warm across worker turns instead of opening a connection per run.
+2. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
+3. Add real Linear integration smoke tests and publish a stricter conformance checklist.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -68,7 +68,12 @@ agents:
 
 When `codex-app-server` is selected, Daedalus stores
 `lane:<issue-number> -> thread_id` plus token/rate-limit totals in
-`memory/workflow-scheduler.json` and resumes that thread on later ticks.
+`memory/workflow-scheduler.json` and resumes that thread on later ticks. During
+supervised active service runs, Daedalus also records the active `turn_id`.
+If the active lane disappears, changes, the lease is lost, or the service is
+interrupted, the runtime requests `turn/interrupt` and marks the scheduler
+thread entry as `canceling`. Operators can see those entries in `/daedalus
+watch` and the HTTP state payload under `codex_turns`.
 
 ## Operator path
 

--- a/tests/test_daedalus_watch_render.py
+++ b/tests/test_daedalus_watch_render.py
@@ -96,6 +96,36 @@ def test_render_frame_includes_issue_runner_workflow_status():
     assert "selected=#123" in out
 
 
+def test_render_frame_includes_canceling_codex_turns():
+    watch = _module()
+    out = watch.render_frame_to_string({
+        "active_lanes": [],
+        "workflow_status": {
+            "workflow": "change-delivery",
+            "running_count": 0,
+            "retry_count": 0,
+            "canceling_count": 1,
+            "total_tokens": 18,
+            "codex_turns": [
+                {
+                    "issue_id": "lane:42",
+                    "issue_identifier": "#42",
+                    "thread_id": "thread-42",
+                    "turn_id": "turn-42",
+                    "status": "canceling",
+                    "cancel_reason": "operator-interrupt",
+                }
+            ],
+        },
+        "alert_state": {},
+        "recent_events": [],
+    })
+    assert "canceling=1" in out
+    assert "codex_canceling=#42" in out
+    assert "thread=thread-42" in out
+    assert "reason=operator-interrupt" in out
+
+
 import json
 import sqlite3
 

--- a/tests/test_daedalus_watch_sources.py
+++ b/tests/test_daedalus_watch_sources.py
@@ -170,3 +170,59 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     assert workflow_status["running_count"] == 1
     assert workflow_status["retry_count"] == 1
     assert workflow_status["total_tokens"] == 18
+
+
+def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
+    from workflows.contract import render_workflow_markdown
+
+    sources = _module()
+    root = _make_workflow_root(tmp_path)
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "change-delivery",
+                "schema-version": 1,
+                "instance": {"name": "attmous-daedalus-change-delivery", "engine-owner": "hermes"},
+                "repository": {"local-path": "/tmp/repo", "github-slug": "attmous/daedalus"},
+                "runtimes": {"coder-runtime": {"kind": "codex-app-server", "command": "codex app-server"}},
+                "agents": {"coder": {"default": {"name": "coder", "model": "gpt-5.5", "runtime": "coder-runtime"}}},
+                "gates": {"internal-review": {}, "external-review": {}, "merge": {}},
+                "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+                "storage": {"scheduler": "memory/workflow-scheduler.json"},
+            },
+            prompt_template="Deliver the active change.",
+        ),
+        encoding="utf-8",
+    )
+    (root / "memory").mkdir(exist_ok=True)
+    (root / "memory" / "workflow-scheduler.json").write_text(
+        json.dumps(
+            {
+                "workflow": "change-delivery",
+                "updatedAt": "2026-04-30T12:00:20Z",
+                "codex_threads": {
+                    "lane:42": {
+                        "issue_id": "lane:42",
+                        "issue_number": 42,
+                        "identifier": "#42",
+                        "thread_id": "thread-42",
+                        "turn_id": "turn-42",
+                        "status": "canceling",
+                        "cancel_requested": True,
+                        "cancel_reason": "operator-interrupt",
+                    }
+                },
+                "codex_totals": {"total_tokens": 18},
+            }
+        )
+    )
+
+    workflow_status = sources.workflow_status(root)
+
+    assert workflow_status["workflow"] == "change-delivery"
+    assert workflow_status["running_count"] == 0
+    assert workflow_status["canceling_count"] == 1
+    assert workflow_status["total_tokens"] == 18
+    assert workflow_status["codex_turns"][0]["thread_id"] == "thread-42"
+    assert workflow_status["codex_turns"][0]["turn_id"] == "turn-42"
+    assert workflow_status["codex_turns"][0]["cancel_reason"] == "operator-interrupt"

--- a/tests/test_event_taxonomy.py
+++ b/tests/test_event_taxonomy.py
@@ -28,6 +28,7 @@ def test_daedalus_native_constants_have_prefix():
         et.DAEDALUS_SHADOW_ACTION_REQUESTED,
         et.DAEDALUS_ACTIVE_ACTION_REQUESTED,
         et.DAEDALUS_ACTIVE_ACTION_COMPLETED,
+        et.DAEDALUS_ACTIVE_ACTION_CANCELED,
         et.DAEDALUS_ACTIVE_ACTION_FAILED,
         et.DAEDALUS_RECOVERY_REQUESTED,
         et.DAEDALUS_OPERATOR_ATTENTION_REQUIRED,
@@ -64,6 +65,7 @@ def test_canonicalize_resolves_legacy_aliases():
     assert canonicalize("shadow_action_requested") == "daedalus.shadow_action_requested"
     assert canonicalize("active_action_requested") == "daedalus.active_action_requested"
     assert canonicalize("active_action_completed") == "daedalus.active_action_completed"
+    assert canonicalize("active_action_canceled") == "daedalus.active_action_canceled"
     assert canonicalize("active_action_failed") == "daedalus.active_action_failed"
     assert canonicalize("recovery_requested") == "daedalus.recovery_requested"
     assert canonicalize("operator_attention_required") == "daedalus.operator_attention_required"

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -478,6 +478,72 @@ def test_run_active_loop_heartbeats_while_supervised_iteration_is_running(runtim
     assert len(heartbeats) >= 2
 
 
+def test_run_active_loop_cancels_supervised_iteration_when_active_lane_disappears(runtime_module, tmp_path, monkeypatch):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    active_status = _active_dispatch_legacy_status()
+    no_lane_status = {**active_status, "activeLane": None, "nextAction": {"type": "noop", "reason": "no-active-lane"}}
+
+    monkeypatch.setattr(
+        runtime_module,
+        "derive_shadow_actions_for_lane",
+        lambda **_kwargs: [{"action_type": "dispatch_implementation_turn", "reason": "implementation-in-progress", "target_head_sha": "abc123"}],
+    )
+
+    started = threading.Event()
+    provider_calls = {"count": 0}
+
+    def legacy_status_provider():
+        provider_calls["count"] += 1
+        return active_status if provider_calls["count"] == 1 else no_lane_status
+
+    def run_action(*, cancel_event=None):
+        assert cancel_event is not None
+        started.set()
+        assert cancel_event.wait(timeout=2)
+        raise RuntimeError("stopped after cancel")
+
+    def sleep_fn(_seconds):
+        assert started.wait(timeout=2)
+        time.sleep(0.01)
+
+    result = runtime_module.run_active_loop(
+        workflow_root=workflow_root,
+        project_key="workflow-example",
+        instance_id="active-test",
+        interval_seconds=1,
+        max_iterations=2,
+        legacy_status_provider=legacy_status_provider,
+        sleep_fn=sleep_fn,
+        action_runners={"dispatch_implementation_turn": run_action},
+    )
+
+    assert result["loop_status"] == "completed"
+    assert result["running_iteration"] is None
+    assert result["last_result"]["cancel_requested"] is True
+    assert result["last_result"]["cancel_reason"] == "no-active-lane"
+    assert result["last_result"]["executed_action"]["canceled"] is True
+
+    conn = sqlite3.connect(runtime_module._runtime_paths(workflow_root)["db_path"])
+    try:
+        action_status = conn.execute(
+            """
+            SELECT status
+            FROM lane_actions
+            WHERE action_type=? AND action_mode='active'
+            ORDER BY requested_at DESC
+            """,
+            ("dispatch_implementation_turn",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert action_status == "canceled"
+
+    events = [json.loads(line) for line in paths["event_log_path"].read_text(encoding="utf-8").splitlines()]
+    assert any(event.get("event_type") == "daedalus.active_action_canceled" for event in events)
+
+
 
 def test_doctor_reports_stuck_dispatched_actions(tools_module, monkeypatch):
     relay_stub = SimpleNamespace(

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -568,6 +568,31 @@ def test_codex_app_server_runtime_cancellation_interrupts_active_turn(tmp_path):
     assert interrupt["params"] == {"threadId": "thread-cancel", "turnId": "turn-cancel"}
 
 
+def test_codex_app_server_runtime_interrupt_turn_sends_protocol_request(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_cancellable_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_cancellable_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "read_timeout_ms": 100,
+        },
+        run=None,
+    )
+
+    assert runtime.interrupt_turn(thread_id="thread-cancel", turn_id="turn-cancel", worktree=worktree) is True
+
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    interrupt = next(item for item in requests if item.get("method") == "turn/interrupt")
+    assert interrupt["params"] == {"threadId": "thread-cancel", "turnId": "turn-cancel"}
+
+
 def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path):
     from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
 

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -236,7 +236,21 @@ def _make_change_delivery_root(root: Path) -> None:
             {
                 "workflow": "change-delivery",
                 "updatedAt": "2026-04-30T12:00:20Z",
-                "codex_threads": {"lane:42": {"thread_id": "thread-42"}},
+                "codex_threads": {
+                    "lane:42": {
+                        "issue_id": "lane:42",
+                        "issue_number": 42,
+                        "identifier": "#42",
+                        "runtime_name": "coder-runtime",
+                        "runtime_kind": "codex-app-server",
+                        "thread_id": "thread-42",
+                        "turn_id": "turn-42",
+                        "status": "canceling",
+                        "cancel_requested": True,
+                        "cancel_reason": "operator-interrupt",
+                        "updated_at": "2026-04-30T12:00:20Z",
+                    }
+                },
                 "codex_totals": {
                     "input_tokens": 11,
                     "output_tokens": 7,
@@ -349,8 +363,13 @@ def test_change_delivery_state_view_reads_codex_scheduler_totals(tmp_path: Path)
     view = state_view(db, events, workflow_root=root)
 
     assert view["counts"] == {"running": 1, "retrying": 0}
+    assert view["codex_turn_counts"] == {"running": 0, "canceling": 1}
     assert view["codex_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
+    assert view["codex_turns"][0]["issue_id"] == "lane:42"
+    assert view["codex_turns"][0]["thread_id"] == "thread-42"
+    assert view["codex_turns"][0]["turn_id"] == "turn-42"
+    assert view["codex_turns"][0]["cancel_reason"] == "operator-interrupt"
 
 
 def test_issue_runner_issue_view_resolves_running_and_retry_entries(tmp_path: Path) -> None:

--- a/tests/test_workflows_code_review_sessions.py
+++ b/tests/test_workflows_code_review_sessions.py
@@ -392,6 +392,52 @@ def test_run_prompt_via_runtime_delegates_to_ws_runtime():
     assert out == "stdout-output"
 
 
+def test_run_prompt_via_runtime_wires_cancel_event_and_progress_callback():
+    from pathlib import Path
+    from workflows.change_delivery import sessions
+
+    captured = {}
+    cancel_event = object()
+
+    def progress_callback(_result):
+        captured["progress"] = True
+
+    class FakeRuntime:
+        def set_cancel_event(self, event):
+            captured.setdefault("cancel_events", []).append(event)
+
+        def set_progress_callback(self, callback):
+            captured.setdefault("progress_callbacks", []).append(callback)
+
+        def run_prompt_result(self, *, worktree, session_name, prompt, model):
+            captured["called"] = (worktree, session_name, prompt, model)
+            callback = captured["progress_callbacks"][-1]
+            callback("partial")
+            return "structured-result"
+
+    class FakeWs:
+        def runtime(self, name):
+            captured["runtime_name"] = name
+            return FakeRuntime()
+
+    out = sessions.run_prompt_via_runtime(
+        workspace=FakeWs(),
+        runtime_name="coder-runtime",
+        worktree=Path("/tmp/wt"),
+        session_name="lane-224",
+        prompt="do work",
+        model="gpt-5.5",
+        cancel_event=cancel_event,
+        progress_callback=progress_callback,
+    )
+
+    assert out == "structured-result"
+    assert captured["cancel_events"] == [cancel_event, None]
+    assert captured["progress_callbacks"][0] is progress_callback
+    assert captured["progress_callbacks"][-1] is None
+    assert captured["progress"] is True
+
+
 def test_close_session_via_runtime_delegates_to_ws_runtime():
     from pathlib import Path
     from workflows.change_delivery import sessions

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -575,6 +575,49 @@ def test_workspace_records_change_delivery_codex_threads_and_totals(tmp_path):
     assert ws._codex_thread_for_issue_number(224) == "thread-224"
 
 
+def test_workspace_records_progress_and_interrupts_active_codex_turn(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["storage"]["scheduler"] = "memory/workflow-scheduler.json"
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+
+    ws._record_coder_runtime_progress(
+        issue_number=224,
+        session_name="lane-224",
+        runtime_name="coder-runtime",
+        runtime_kind="codex-app-server",
+        worktree=Path("/tmp/issue-224"),
+        result=SimpleNamespace(
+            session_id="thread-224",
+            thread_id="thread-224",
+            turn_id="turn-active",
+            last_event="turn/started",
+            last_message="started",
+            turn_count=1,
+            tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        ),
+    )
+
+    calls = {}
+
+    class FakeRuntime:
+        def interrupt_turn(self, **kwargs):
+            calls.update(kwargs)
+            return True
+
+    ws.runtime = lambda _name: FakeRuntime()
+    result = ws._interrupt_active_coder_turn(issue_number=224, reason="operator-interrupt")
+
+    scheduler = json.loads((tmp_path / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
+    entry = scheduler["codex_threads"]["lane:224"]
+    assert result["interrupted"] is True
+    assert calls == {"thread_id": "thread-224", "turn_id": "turn-active", "worktree": Path("/tmp/issue-224")}
+    assert entry["status"] == "canceling"
+    assert entry["cancel_requested"] is True
+    assert entry["cancel_reason"] == "operator-interrupt"
+
+
 def test_workspace_ensure_coder_session_resumes_persisted_codex_thread(tmp_path):
     from workflows.change_delivery.workspace import make_workspace
 


### PR DESCRIPTION
## Summary

Adds cooperative cancellation for `change-delivery` Codex app-server turns and makes cancellation visible to operators.

## What changed

- Threads a supervised active-loop cancel event into change-delivery runtime execution.
- Extends the shared `codex-app-server` runtime with progress callbacks and explicit `turn/interrupt`.
- Persists active Codex `thread_id` / `turn_id` progress in scheduler state and marks interrupted entries as `canceling`.
- Cancels active iterations when the active lane disappears/changes, the runtime lease is lost, or the service is interrupted.
- Adds `daedalus.active_action_canceled` plus watch/HTTP visibility for canceling Codex turns.
- Updates runtime, HTTP, change-delivery, and Symphony conformance docs.

## Validation

- `pytest -q` (`794 passed, 6 skipped`)
- `python -m py_compile daedalus/runtime.py daedalus/runtimes/codex_app_server.py daedalus/workflows/change_delivery/sessions.py daedalus/workflows/change_delivery/workspace.py daedalus/workflows/change_delivery/server/views.py daedalus/watch.py daedalus/watch_sources.py daedalus/workflows/change_delivery/event_taxonomy.py`
- `git diff --check`