### PR TITLE
[codex] add warm codex app-server transports

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1624,8 +1624,9 @@ def _run_workspace_action(
     workflow_root: Path,
     action_name: str,
     cancel_event: Any | None = None,
+    workspace: Any | None = None,
 ) -> dict[str, Any]:
-    workspace = _load_legacy_workflow_module(workflow_root)
+    workspace = workspace if workspace is not None else _load_legacy_workflow_module(workflow_root)
     set_cancel_event = getattr(workspace, "set_active_cancel_event", None)
     if callable(set_cancel_event):
         set_cancel_event(cancel_event)
@@ -1638,43 +1639,64 @@ def _run_workspace_action(
 
 
 def _default_active_action_runners(*, workflow_root: Path) -> dict[str, Any]:
+    workspace_holder: dict[str, Any] = {}
+
+    def _workspace():
+        if "workspace" not in workspace_holder:
+            workspace_holder["workspace"] = _load_legacy_workflow_module(workflow_root)
+        return workspace_holder["workspace"]
+
+    def _run(action_name: str, *, cancel_event: Any | None = None) -> dict[str, Any]:
+        return _run_workspace_action(
+            workflow_root=workflow_root,
+            action_name=action_name,
+            cancel_event=cancel_event,
+            workspace=_workspace(),
+        )
+
+    def _close() -> None:
+        workspace = workspace_holder.get("workspace")
+        close = getattr(workspace, "close", None)
+        if callable(close):
+            close()
+
     return {
-        "dispatch_implementation_turn": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="dispatch_implementation_turn",
+        "__close__": _close,
+        "dispatch_implementation_turn": lambda cancel_event=None: _run(
+            "dispatch_implementation_turn",
             cancel_event=cancel_event,
         ),
-        "dispatch_repair_handoff": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="dispatch_repair_handoff",
+        "dispatch_repair_handoff": lambda cancel_event=None: _run(
+            "dispatch_repair_handoff",
             cancel_event=cancel_event,
         ),
-        "restart_actor_session": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="restart_actor_session",
+        "restart_actor_session": lambda cancel_event=None: _run(
+            "restart_actor_session",
             cancel_event=cancel_event,
         ),
-        "push_pr_update": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="push_pr_update",
+        "push_pr_update": lambda cancel_event=None: _run(
+            "push_pr_update",
             cancel_event=cancel_event,
         ),
-        "publish_pr": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="publish_ready_pr",
+        "publish_pr": lambda cancel_event=None: _run(
+            "publish_ready_pr",
             cancel_event=cancel_event,
         ),
-        "request_internal_review": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="dispatch_inter_review_agent_review",
+        "request_internal_review": lambda cancel_event=None: _run(
+            "dispatch_inter_review_agent_review",
             cancel_event=cancel_event,
         ),
-        "merge_pr": lambda cancel_event=None: _run_workspace_action(
-            workflow_root=workflow_root,
-            action_name="merge_and_promote",
+        "merge_pr": lambda cancel_event=None: _run(
+            "merge_and_promote",
             cancel_event=cancel_event,
         ),
     }
+
+
+def _close_action_runners(action_runners: dict[str, Any] | None) -> None:
+    close = (action_runners or {}).get("__close__")
+    if callable(close):
+        close()
 
 
 def _invoke_action_runner(runner: Any, *, cancel_event: Any | None = None) -> dict[str, Any]:
@@ -3063,6 +3085,7 @@ def execute_requested_action(
 ) -> dict[str, Any]:
     now_iso = now_iso or _now_iso()
     runners = _default_active_action_runners(workflow_root=workflow_root)
+    owned_action_runners = runners if action_runners is None else None
     if action_runners:
         runners.update(action_runners)
     paths = _runtime_paths(workflow_root)
@@ -3394,6 +3417,7 @@ def execute_requested_action(
         return {"executed": False, "action_id": action_id, "reason": "execution-failed", "error": failure_summary}
     finally:
         conn.close()
+        _close_action_runners(owned_action_runners)
     append_daedalus_event(
         event_log_path=paths["event_log_path"],
         event={
@@ -3947,6 +3971,10 @@ def run_active_loop(
     last_result = None
     supervised_iteration: dict[str, Any] | None = None
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="daedalus-change-delivery")
+    owned_action_runners = None
+    if action_runners is None:
+        owned_action_runners = _default_active_action_runners(workflow_root=workflow_root)
+        action_runners = owned_action_runners
     loop_status = "completed"
     try:
         while True:
@@ -4041,6 +4069,12 @@ def run_active_loop(
         if completed:
             last_result = completed[-1]
         executor.shutdown(wait=False, cancel_futures=False)
+        if supervised_iteration is None:
+            _close_action_runners(owned_action_runners)
+        elif owned_action_runners is not None:
+            future = supervised_iteration.get("future")
+            if isinstance(future, concurrent.futures.Future):
+                future.add_done_callback(lambda _future, runners=owned_action_runners: _close_action_runners(runners))
     return {
         "loop_status": loop_status,
         "instance_id": instance_id,

--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -268,7 +268,11 @@ class _WebSocketAppServerClient(_AppServerClient):
         if self._closed:
             raise CodexAppServerError("codex-app-server websocket is closed", stderr=self.stderr_text)
         data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        self._send_frame(opcode=0x1, payload=data)
+        try:
+            self._send_frame(opcode=0x1, payload=data)
+        except OSError as exc:
+            self._closed = True
+            raise CodexAppServerError(f"codex-app-server websocket write failed: {exc}", stderr=self.stderr_text) from exc
         self._on_activity()
 
     def _connect(self, *, endpoint: str, auth_token: str | None, timeout_s: float) -> socket.socket:
@@ -433,11 +437,16 @@ class CodexAppServerRuntime:
         self._approval_policy = cfg.get("approval_policy")
         self._thread_sandbox = str(cfg.get("thread_sandbox") or "").strip() or None
         self._turn_sandbox_policy = cfg.get("turn_sandbox_policy")
+        self._keep_alive = self._bool_config(cfg.get("keep_alive", cfg.get("keep-alive")), default=(self._mode == "external"))
+        if self._keep_alive and self._mode != "external":
+            raise CodexAppServerError("codex-app-server keep_alive requires mode: external")
         self._last_activity: float | None = None
         self._last_result: PromptRunResult | None = None
         self._resume_thread_ids: dict[str, str] = {}
         self._cancel_event: threading.Event | None = None
         self._progress_callback: Callable[[PromptRunResult], None] | None = None
+        self._client_lock = threading.Lock()
+        self._warm_client: _AppServerClient | None = None
 
     def _record_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -474,6 +483,24 @@ class CodexAppServerRuntime:
             return True
         finally:
             client.close()
+
+    def close(self) -> None:
+        with self._client_lock:
+            self._drop_warm_client()
+
+    def diagnostics(self) -> dict[str, Any]:
+        with self._client_lock:
+            warm_client_present = self._warm_client is not None
+            warm_client_open = warm_client_present and not self._client_is_closed(self._warm_client)
+        return {
+            "kind": "codex-app-server",
+            "mode": self._mode,
+            "transport": "websocket" if self._mode == "external" else "stdio",
+            "endpoint": self._endpoint,
+            "keep_alive": self._keep_alive,
+            "warm_client_present": warm_client_present,
+            "warm_client_open": warm_client_open,
+        }
 
     def ensure_session(
         self,
@@ -532,51 +559,122 @@ class CodexAppServerRuntime:
                 else str(self._turn_sandbox_policy)
             )
 
-        self._record_activity()
-        client = self._build_client(worktree=worktree, env={**os.environ, **env})
         state = _RunState()
+        client: _AppServerClient | None = None
+        keep_client = False
         try:
-            self._initialize(client=client, state=state)
-            resume_thread_id = self._resume_thread_id(worktree=worktree, session_name=session_name)
-            if resume_thread_id:
-                state.thread_id = resume_thread_id
-                state.session_id = resume_thread_id
-                thread_result = client.request(
-                    "thread/resume",
-                    self._thread_resume_params(thread_id=resume_thread_id, worktree=worktree, model=model),
-                    timeout_s=self._read_timeout_s(),
-                    on_message=lambda message: self._consume_message(message, state=state),
-                )
+            self._record_activity()
+            if self._keep_alive:
+                with self._client_lock:
+                    result: PromptRunResult | None = None
+                    for attempt in range(2):
+                        state = _RunState()
+                        client = self._warm_client_for_run(worktree=worktree, env={**os.environ, **env}, state=state)
+                        keep_client = True
+                        try:
+                            result = self._run_prompt_result_on_client(
+                                client=client,
+                                state=state,
+                                worktree=worktree,
+                                session_name=session_name,
+                                prompt=prompt,
+                                model=model,
+                            )
+                            break
+                        except CodexAppServerError:
+                            if attempt == 0 and self._client_is_closed(client):
+                                self._drop_warm_client()
+                                client = None
+                                continue
+                            raise
+                    if result is None:
+                        raise CodexAppServerError("codex-app-server did not return a result")
             else:
-                thread_result = client.request(
-                    "thread/start",
-                    self._thread_start_params(worktree=worktree, model=model),
-                    timeout_s=self._read_timeout_s(),
-                    on_message=lambda message: self._consume_message(message, state=state),
+                client = self._build_client(worktree=worktree, env={**os.environ, **env})
+                self._initialize(client=client, state=state)
+                result = self._run_prompt_result_on_client(
+                    client=client,
+                    state=state,
+                    worktree=worktree,
+                    session_name=session_name,
+                    prompt=prompt,
+                    model=model,
                 )
-            self._consume_thread_start_response(thread_result, state=state)
-            self._notify_progress(state)
-            turn_result = client.request(
-                "turn/start",
-                self._turn_start_params(worktree=worktree, thread_id=state.thread_id, prompt=prompt, model=model),
-                timeout_s=self._read_timeout_s(),
-                on_message=lambda message: self._consume_message(message, state=state),
-            )
-            self._consume_turn_response(turn_result, state=state)
-            self._notify_progress(state)
-            result = self._read_turn_to_completion(client=client, state=state)
             self._last_result = result
             return result
         except CodexAppServerError as exc:
             result = exc.result or self._result_from_state(state)
             self._last_result = result
             exc.result = result
-            if exc.stderr is None:
+            if exc.stderr is None and client is not None:
                 exc.stderr = client.stderr_text
-            if exc.returncode is None:
+            if exc.returncode is None and client is not None:
                 exc.returncode = client.returncode
+            if keep_client and client is not None and self._client_is_closed(client):
+                self._drop_warm_client()
             raise
         finally:
+            if client is not None and not keep_client:
+                client.close()
+
+    def _run_prompt_result_on_client(
+        self,
+        *,
+        client: _AppServerClient,
+        state: _RunState,
+        worktree: Path,
+        session_name: str,
+        prompt: str,
+        model: str,
+    ) -> PromptRunResult:
+        resume_thread_id = self._resume_thread_id(worktree=worktree, session_name=session_name)
+        if resume_thread_id:
+            state.thread_id = resume_thread_id
+            state.session_id = resume_thread_id
+            thread_result = client.request(
+                "thread/resume",
+                self._thread_resume_params(thread_id=resume_thread_id, worktree=worktree, model=model),
+                timeout_s=self._read_timeout_s(),
+                on_message=lambda message: self._consume_message(message, state=state),
+            )
+        else:
+            thread_result = client.request(
+                "thread/start",
+                self._thread_start_params(worktree=worktree, model=model),
+                timeout_s=self._read_timeout_s(),
+                on_message=lambda message: self._consume_message(message, state=state),
+            )
+        self._consume_thread_start_response(thread_result, state=state)
+        self._notify_progress(state)
+        turn_result = client.request(
+            "turn/start",
+            self._turn_start_params(worktree=worktree, thread_id=state.thread_id, prompt=prompt, model=model),
+            timeout_s=self._read_timeout_s(),
+            on_message=lambda message: self._consume_message(message, state=state),
+        )
+        self._consume_turn_response(turn_result, state=state)
+        self._notify_progress(state)
+        return self._read_turn_to_completion(client=client, state=state)
+
+    def _warm_client_for_run(self, *, worktree: Path, env: dict[str, str], state: _RunState) -> _AppServerClient:
+        if self._warm_client is not None and self._client_is_closed(self._warm_client):
+            self._drop_warm_client()
+        if self._warm_client is None:
+            self._warm_client = self._build_client(worktree=worktree, env=env)
+            try:
+                self._initialize(client=self._warm_client, state=state)
+            except Exception:
+                self._drop_warm_client()
+                raise
+        return self._warm_client
+
+    def _client_is_closed(self, client: _AppServerClient) -> bool:
+        return client.returncode is not None
+
+    def _drop_warm_client(self) -> None:
+        client = self._warm_client
+        self._warm_client = None
+        if client is not None:
             client.close()
 
     def _command_argv(self) -> list[str]:

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -312,6 +312,8 @@ definitions:
       ws_token_env: {type: string}
       ws_token_file: {type: string}
       ephemeral: {type: boolean}
+      keep_alive: {type: boolean}
+      keep-alive: {type: boolean}
       approval_policy:
         oneOf:
           - type: string

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -803,7 +803,14 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
             )
         return _runtimes[name]
 
+    def _close_runtimes() -> None:
+        for runtime in _runtimes.values():
+            close = getattr(runtime, "close", None)
+            if callable(close):
+                close()
+
     ns.runtime = _runtime_accessor
+    ns.close = _close_runtimes
 
     # YAML-shape cross-reference validation: every agent's runtime: field must
     # name a key in the top-level runtimes: mapping. The schema doesn't enforce

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -144,6 +144,8 @@ properties:
       ws_token_env: {type: string}
       ws_token_file: {type: string}
       ephemeral: {type: boolean}
+      keep_alive: {type: boolean}
+      keep-alive: {type: boolean}
       approval_policy:
         oneOf:
           - type: string

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -218,6 +218,8 @@ def _runtime_profiles_from_config(config: dict[str, Any]) -> dict[str, dict[str,
             "turn_timeout_ms",
             "read_timeout_ms",
             "stall_timeout_ms",
+            "keep_alive",
+            "keep-alive",
         ):
             if profile.get(key) in (None, "", []):
                 value = codex_cfg.get(key)
@@ -294,6 +296,18 @@ class IssueRunnerWorkspace:
     def runtime(self, name: str) -> Runtime:
         return self.runtimes[name]
 
+    def close(self) -> None:
+        if self._supervisor_executor is not None:
+            self._supervisor_executor.shutdown(wait=False, cancel_futures=False)
+            self._supervisor_executor = None
+        self._close_runtimes()
+
+    def _close_runtimes(self) -> None:
+        for runtime in self.runtimes.values():
+            close = getattr(runtime, "close", None)
+            if callable(close):
+                close()
+
     def _agent_runtime_name(self) -> str:
         agent_cfg = self.config.get("agent") or {}
         runtime_name = str(agent_cfg.get("runtime") or "").strip()
@@ -361,6 +375,7 @@ class IssueRunnerWorkspace:
                 "codex_totals": dict(self.codex_totals or {}),
                 "codex_threads": self._codex_threads_snapshot(),
             },
+            "runtimeDiagnostics": self._runtime_diagnostics(),
             "selectedIssue": selected,
             "workspaceRoot": str(self.issue_workspace_root),
             "lastRun": (last_run or {}).get("lastRun"),
@@ -396,6 +411,20 @@ class IssueRunnerWorkspace:
             "checks": checks,
             "updatedAt": _now_iso(),
         }
+
+    def _runtime_diagnostics(self) -> dict[str, dict[str, Any]]:
+        diagnostics: dict[str, dict[str, Any]] = {}
+        for name, runtime in sorted(self.runtimes.items()):
+            provider = getattr(runtime, "diagnostics", None)
+            if not callable(provider):
+                continue
+            try:
+                payload = provider()
+            except Exception as exc:
+                payload = {"error": f"{type(exc).__name__}: {exc}"}
+            if isinstance(payload, dict):
+                diagnostics[name] = payload
+        return diagnostics
 
     def _load_scheduler_state(self) -> dict[str, Any]:
         return _load_optional_json(self.scheduler_path) or {}
@@ -835,6 +864,7 @@ class IssueRunnerWorkspace:
         env: dict[str, str] | None = None
         created_workspace = False
         attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
+        set_cancel_event_fn = None
 
         try:
             if cancel_event is not None and cancel_event.is_set():
@@ -877,10 +907,13 @@ class IssueRunnerWorkspace:
             runtime_name = self._agent_runtime_name()
             runtime_profiles = _runtime_profiles_from_config(self.config)
             runtime_cfg = runtime_profiles.get(runtime_name) or {}
-            runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
-            set_cancel_event = getattr(runtime, "set_cancel_event", None)
-            if callable(set_cancel_event) and cancel_event is not None:
-                set_cancel_event(cancel_event)
+            if self._supervisor_max_workers() == 1:
+                runtime = self.runtime(runtime_name)
+            else:
+                runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
+            set_cancel_event_fn = getattr(runtime, "set_cancel_event", None)
+            if callable(set_cancel_event_fn) and cancel_event is not None:
+                set_cancel_event_fn(cancel_event)
             session_name = issue_session_name(issue)
             model = str(agent_cfg.get("model") or "")
             resume_thread_id = None
@@ -948,6 +981,9 @@ class IssueRunnerWorkspace:
                 "runtime": runtime_name if runtime is not None else None,
                 "runtimeKind": runtime_cfg.get("kind") if runtime is not None else None,
             }
+        finally:
+            if callable(set_cancel_event_fn):
+                set_cancel_event_fn(None)
 
     def _apply_issue_results(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         applied: list[dict[str, Any]] = []
@@ -1636,6 +1672,7 @@ class IssueRunnerWorkspace:
     ) -> dict[str, Any]:
         iterations = 0
         last_result = None
+        loop_status = "completed"
         try:
             while True:
                 self.reload_contract()
@@ -1645,15 +1682,12 @@ class IssueRunnerWorkspace:
                     break
                 sleep_fn(self._poll_interval_seconds(interval_seconds))
         except KeyboardInterrupt:
-            last_result = self._reconcile_before_loop_exit(last_result)
-            return {
-                "loop_status": "interrupted",
-                "iterations": iterations,
-                "last_result": last_result,
-            }
+            loop_status = "interrupted"
         last_result = self._reconcile_before_loop_exit(last_result)
+        if not self._supervisor_futures:
+            self.close()
         return {
-            "loop_status": "completed",
+            "loop_status": loop_status,
             "iterations": iterations,
             "last_result": last_result,
         }
@@ -1725,6 +1759,8 @@ class IssueRunnerWorkspace:
         self.health_path = _resolve_path(storage_cfg.get("health") or "memory/workflow-health.json", "memory/workflow-health.json")
         self.audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
         self.scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
+        if not self._supervisor_futures:
+            self._close_runtimes()
         self.runtimes = _build_runtimes_from_config(cfg, run=self._run, run_json=self._run_json)
         if self.scheduler_path != previous_scheduler_path:
             self._restore_scheduler_state()

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -137,14 +137,19 @@ runtimes:
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz
     ephemeral: false
+    keep_alive: true
     ws_token_env: CODEX_APP_SERVER_TOKEN  # only if the listener requires auth
 ```
 
-External mode checks `GET /readyz` before connecting, then opens one JSON-RPC
-WebSocket connection for the run. `ephemeral: false` keeps Codex threads visible
-through app-server thread APIs. The default stdio transport cannot be shared:
-Daedalus can only attach to an already-started app-server when it exposes a
-socket transport.
+External mode checks `GET /readyz` before connecting. By default it keeps the
+WebSocket transport warm for the lifetime of the runtime object
+(`keep_alive: true`), so supervised services can reuse one initialized JSON-RPC
+connection across turns. If the socket is closed or the app-server restarts,
+the next turn reconnects and initializes a fresh connection. `ephemeral: false`
+keeps Codex threads visible through app-server thread APIs. The default stdio
+transport cannot be shared: Daedalus can only attach to an already-started
+app-server when it exposes a socket transport. Setting `keep_alive: true` with
+managed stdio mode is invalid and fails config loading.
 
 It maps `thread/tokenUsage/updated` into Daedalus token totals and
 `account/rateLimits/updated` into the latest rate-limit snapshot. It rejects
@@ -159,6 +164,11 @@ requests cancellation when a running issue reaches a terminal tracker state.
 changes, the runtime lease is lost, or the service is interrupted. The Codex
 adapter sends `turn/interrupt` for the active turn and records the cancellation
 state in scheduler metadata.
+
+Runtimes may expose lightweight diagnostics. The Codex app-server adapter
+reports its mode, transport, `keep_alive` setting, endpoint, and whether a warm
+client is currently open; workflows can include that payload in their status
+surfaces without changing the shared runtime protocol.
 
 ## Adding a new runtime
 

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -20,7 +20,7 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised `change-delivery` active iterations, worker reconciliation, and persisted scheduler state now exist. |
 | Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery. `change-delivery` now supervises one active worker iteration at a time, but the broader engine is still not uniformly scheduler-driven. |
 | Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
-| Coding-agent protocol | Partial | `issue-runner` and `change-delivery` can use the shared protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, and cooperative turn interruption. |
+| Coding-agent protocol | Partial | `issue-runner` and `change-delivery` can use the shared protocol-valid `codex-app-server` JSON-RPC adapter with managed stdio, external WebSocket mode, a managed app-server user unit, persisted thread resume, cooperative turn interruption, and warm external transports. |
 | Observability surface | Partial | Events, status, watch, and HTTP surfaces exist; bundled workflows record Codex token/rate-limit totals and expose Codex thread mappings when using `codex-app-server`. |
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
@@ -36,8 +36,7 @@ Daedalus currently differs from the Symphony draft in four material ways:
 
 ## Recommended Next Gaps
 
-1. Keep Codex app-server transports warm across worker turns instead of opening a connection per run.
-2. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
-3. Add real Linear integration smoke tests and publish a stricter conformance checklist.
+1. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
+2. Add real Linear integration smoke tests and publish a stricter conformance checklist.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -54,6 +54,7 @@ runtimes:
     mode: external
     endpoint: ws://127.0.0.1:4500
     ephemeral: false
+    keep_alive: true
     approval_policy: never
     thread_sandbox: workspace-write
     turn_sandbox_policy: workspace-write

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -38,6 +38,25 @@ For each eligible tracker issue:
 - `codex`: spec-shaped Codex runner settings; set `mode: external` and `endpoint: ws://127.0.0.1:<port>` to connect to an already-running app-server, and keep `ephemeral: false` if you want Codex threads to remain inspectable
 - `daedalus.runtimes`: shared runtime backend profiles used by the current implementation when you are not using the top-level `codex` block
 
+External Codex app-server example:
+
+```yaml
+agent:
+  model: gpt-5.5
+  runtime: codex
+
+runtimes:
+  codex:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    ephemeral: false
+    keep_alive: true
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+```
+
 Supported tracker kinds today:
 
 - `github`
@@ -57,7 +76,9 @@ Scheduler state is persisted under `storage.scheduler` (default:
 running-worker recovery, aggregate Codex token totals, and Codex
 `issue_id -> thread_id` mappings survive loop restarts. When a mapped thread
 exists, the Codex app-server adapter resumes it with `thread/resume` before
-starting the next turn.
+starting the next turn. `status` also includes runtime diagnostics when the
+selected runtime exposes them, including Codex app-server transport mode and
+warm-client state.
 
 ## Operator path
 
@@ -112,7 +133,7 @@ tables.
 
 - The Linear adapter follows the Symphony baseline query shape, but still needs real Linear integration smoke coverage before claiming production-grade Linear support.
 - Managed service mode is `active` only. `shadow` remains specific to `change-delivery`.
-- The bundled Codex app-server adapter supports managed stdio and external WebSocket transports, durable thread resume across ticks, and cooperative in-flight cancellation in the supervised `run` loop.
+- The bundled Codex app-server adapter supports managed stdio, warm external WebSocket transports, durable thread resume across ticks, and cooperative in-flight cancellation in the supervised `run` loop.
 - Cancellation is cooperative. Codex app-server turns are interrupted when Daedalus requests cancellation; command-style runtimes may only observe cancellation before they start or after they exit.
 
 ## Related docs

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -544,6 +544,87 @@ def test_run_active_loop_cancels_supervised_iteration_when_active_lane_disappear
     assert any(event.get("event_type") == "daedalus.active_action_canceled" for event in events)
 
 
+def test_default_active_action_runners_reuse_workspace_and_close(runtime_module, tmp_path, monkeypatch):
+    calls = {"load": 0, "close": 0, "actions": []}
+
+    class FakeWorkspace:
+        def set_active_cancel_event(self, event):
+            calls.setdefault("cancel_events", []).append(event)
+
+        def dispatch_implementation_turn(self):
+            calls["actions"].append("dispatch")
+            return {"dispatched": True}
+
+        def close(self):
+            calls["close"] += 1
+
+    def load_workspace(_workflow_root):
+        calls["load"] += 1
+        return FakeWorkspace()
+
+    monkeypatch.setattr(runtime_module, "_load_legacy_workflow_module", load_workspace)
+    runners = runtime_module._default_active_action_runners(workflow_root=tmp_path)
+    cancel_event = threading.Event()
+
+    assert runners["dispatch_implementation_turn"](cancel_event=cancel_event) == {"dispatched": True}
+    assert runners["dispatch_implementation_turn"]() == {"dispatched": True}
+    runners["__close__"]()
+
+    assert calls["load"] == 1
+    assert calls["close"] == 1
+    assert calls["actions"] == ["dispatch", "dispatch"]
+    assert calls["cancel_events"] == [cancel_event, None, None, None]
+
+
+def test_active_loop_closes_owned_workspace_after_bounded_exit_worker_finishes(runtime_module, tmp_path, monkeypatch):
+    workflow_root = tmp_path / "workflow"
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    legacy_status = _active_dispatch_legacy_status()
+
+    monkeypatch.setattr(
+        runtime_module,
+        "derive_shadow_actions_for_lane",
+        lambda **_kwargs: [{"action_type": "dispatch_implementation_turn", "reason": "implementation-in-progress", "target_head_sha": "abc123"}],
+    )
+
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+
+    class FakeWorkspace:
+        def build_status(self):
+            return legacy_status
+
+        def set_active_cancel_event(self, _event):
+            return None
+
+        def dispatch_implementation_turn(self):
+            started.set()
+            assert release.wait(timeout=2)
+            return {"dispatched": True, "after": legacy_status}
+
+        def close(self):
+            closed.set()
+
+    monkeypatch.setattr(runtime_module, "_load_legacy_workflow_module", lambda _workflow_root: FakeWorkspace())
+
+    result = runtime_module.run_active_loop(
+        workflow_root=workflow_root,
+        project_key="workflow-example",
+        instance_id="active-test",
+        interval_seconds=1,
+        max_iterations=1,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert result["loop_status"] == "completed"
+    assert result["running_iteration"] is not None
+    assert started.wait(timeout=2)
+    assert not closed.is_set()
+    release.set()
+    assert closed.wait(timeout=2)
+
+
 
 def test_doctor_reports_stuck_dispatched_actions(tools_module, monkeypatch):
     relay_stub = SimpleNamespace(

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -191,6 +191,7 @@ def _write_fake_cancellable_app_server(path: Path, requests_path: Path) -> None:
 class _FakeWebSocketAppServer:
     def __init__(self):
         self.requests: list[dict] = []
+        self.websocket_connections = 0
         self._stop = threading.Event()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -233,6 +234,7 @@ class _FakeWebSocketAppServer:
             if headers.get("upgrade", "").lower() != "websocket":
                 conn.sendall(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
                 return
+            self.websocket_connections += 1
             key = headers["sec-websocket-key"]
             accept = base64.b64encode(
                 hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("ascii")).digest()
@@ -340,6 +342,56 @@ class _FakeWebSocketAppServer:
                 return b""
             data += chunk
         return data
+
+
+class _FakePersistentWebSocketAppServer(_FakeWebSocketAppServer):
+    def _run_jsonrpc(self, conn: socket.socket):
+        thread_id = "thread-warm"
+        turn_count = 0
+        while True:
+            payload = self._read_ws_text(conn)
+            if payload is None:
+                return
+            message = json.loads(payload)
+            self.requests.append(message)
+            method = message.get("method")
+            request_id = message.get("id")
+            if method == "initialize":
+                self._send_ws_json(conn, {"id": request_id, "result": {"userAgent": "fake-warm-codex"}})
+            elif method == "initialized":
+                continue
+            elif method == "thread/start":
+                thread = {"id": thread_id, "status": "running", "turns": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"thread": thread}})
+            elif method == "thread/resume":
+                thread_id = str((message.get("params") or {}).get("threadId") or thread_id)
+                thread = {"id": thread_id, "status": "running", "turns": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"thread": thread}})
+            elif method == "turn/start":
+                turn_count += 1
+                turn = {"id": f"turn-warm-{turn_count}", "status": "running", "items": []}
+                self._send_ws_json(conn, {"id": request_id, "result": {"turn": turn}})
+                self._send_ws_json(
+                    conn,
+                    {"method": "turn/started", "params": {"threadId": thread_id, "turn": turn}},
+                )
+                self._send_ws_json(
+                    conn,
+                    {
+                        "method": "agent/message_delta",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": turn["id"],
+                            "itemId": f"item-{turn_count}",
+                            "delta": f"warm {turn_count}",
+                        },
+                    },
+                )
+                completed = {"id": turn["id"], "status": "completed", "items": []}
+                self._send_ws_json(
+                    conn,
+                    {"method": "turn/completed", "params": {"threadId": thread_id, "turn": completed}},
+                )
 
 
 def test_codex_app_server_runtime_speaks_jsonrpc_and_maps_metrics(tmp_path):
@@ -610,6 +662,20 @@ def test_codex_app_server_runtime_rejects_non_protocol_approval_policy(tmp_path)
         )
 
 
+def test_codex_app_server_runtime_rejects_keep_alive_in_managed_mode():
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
+
+    with pytest.raises(CodexAppServerError, match="keep_alive requires mode: external"):
+        CodexAppServerRuntime(
+            {
+                "mode": "managed",
+                "command": [sys.executable, "-c", ""],
+                "keep_alive": True,
+            },
+            run=None,
+        )
+
+
 def test_codex_app_server_runtime_connects_to_external_websocket(tmp_path):
     from runtimes.codex_app_server import CodexAppServerRuntime
 
@@ -653,3 +719,220 @@ def test_codex_app_server_runtime_connects_to_external_websocket(tmp_path):
         "type": "workspaceWrite",
         "writableRoots": [str(tmp_path)],
     }
+
+
+def test_codex_app_server_runtime_reuses_external_websocket_by_default(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakePersistentWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        try:
+            assert runtime.diagnostics()["keep_alive"] is True
+            first = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="First",
+                model="gpt-5.5",
+            )
+            runtime.ensure_session(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                model="gpt-5.5",
+                resume_session_id=first.thread_id,
+            )
+            second = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="Second",
+                model="gpt-5.5",
+            )
+        finally:
+            runtime.close()
+
+    methods = [item.get("method") for item in server.requests]
+    assert server.websocket_connections == 1
+    assert methods.count("initialize") == 1
+    assert methods.count("turn/start") == 2
+    assert second.output == "warm 2\n"
+
+
+def test_codex_app_server_runtime_reuses_external_websocket_when_keep_alive(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakePersistentWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "keep_alive": True,
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        try:
+            first = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="First",
+                model="gpt-5.5",
+            )
+            runtime.ensure_session(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                model="gpt-5.5",
+                resume_session_id=first.thread_id,
+            )
+            second = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="Second",
+                model="gpt-5.5",
+            )
+        finally:
+            runtime.close()
+
+    methods = [item.get("method") for item in server.requests]
+    assert server.websocket_connections == 1
+    assert methods.count("initialize") == 1
+    assert methods.count("initialized") == 1
+    assert methods.count("thread/start") == 1
+    assert methods.count("thread/resume") == 1
+    assert methods.count("turn/start") == 2
+    assert first.output == "warm 1\n"
+    assert first.turn_id == "turn-warm-1"
+    assert second.output == "warm 2\n"
+    assert second.turn_id == "turn-warm-2"
+
+
+def test_codex_app_server_runtime_opens_fresh_external_websocket_when_keep_alive_false(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakePersistentWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "keep_alive": False,
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        first = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-1",
+            prompt="First",
+            model="gpt-5.5",
+        )
+        second = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-2",
+            prompt="Second",
+            model="gpt-5.5",
+        )
+
+    methods = [item.get("method") for item in server.requests]
+    assert server.websocket_connections == 2
+    assert methods.count("initialize") == 2
+    assert methods.count("thread/start") == 2
+    assert first.output == "warm 1\n"
+    assert second.output == "warm 1\n"
+
+
+def test_codex_app_server_runtime_close_drops_warm_external_websocket(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakePersistentWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "keep_alive": True,
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        first = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-1",
+            prompt="First",
+            model="gpt-5.5",
+        )
+        diagnostics = runtime.diagnostics()
+        assert diagnostics["warm_client_present"] is True
+        assert diagnostics["warm_client_open"] is True
+        runtime.close()
+        diagnostics = runtime.diagnostics()
+        assert diagnostics["warm_client_present"] is False
+        assert diagnostics["warm_client_open"] is False
+        second = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-2",
+            prompt="Second",
+            model="gpt-5.5",
+        )
+        runtime.close()
+
+    methods = [item.get("method") for item in server.requests]
+    assert server.websocket_connections == 2
+    assert methods.count("initialize") == 2
+    assert first.output == "warm 1\n"
+    assert second.output == "warm 1\n"
+
+
+def test_codex_app_server_runtime_reconnects_when_warm_websocket_closes(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakeWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "keep_alive": True,
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        try:
+            first = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="First",
+                model="gpt-5.5",
+            )
+            second = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-2",
+                prompt="Second",
+                model="gpt-5.5",
+            )
+        finally:
+            runtime.close()
+
+    methods = [item.get("method") for item in server.requests]
+    assert server.websocket_connections == 2
+    assert methods.count("initialize") == 2
+    assert methods.count("turn/start") == 2
+    assert first.output == "ws ok\n"
+    assert second.output == "ws ok\n"

--- a/tests/test_workflows_code_review_schema.py
+++ b/tests/test_workflows_code_review_schema.py
@@ -89,6 +89,7 @@ def test_schema_accepts_codex_app_server_runtime_for_coder():
         "command": "codex app-server",
         "mode": "managed",
         "ephemeral": False,
+        "keep_alive": False,
         "approval_policy": "never",
         "thread_sandbox": "workspace-write",
         "turn_sandbox_policy": "workspace-write",

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -121,6 +121,7 @@ def test_issue_runner_schema_accepts_external_codex_app_server_runtime():
                 "healthcheck_path": "/readyz",
                 "ws_token_env": "CODEX_APP_SERVER_TOKEN",
                 "ephemeral": False,
+                "keep_alive": True,
                 "approval_policy": "never",
                 "thread_sandbox": "workspace-write",
                 "turn_sandbox_policy": "workspace-write",

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -329,6 +329,10 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     assert status["metrics"]["tokens"]["total_tokens"] == 18
     assert status["metrics"]["rate_limits"]["requests_remaining"] == 99
     assert status["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert status["runtimeDiagnostics"]["codex"]["kind"] == "codex-app-server"
+    assert status["runtimeDiagnostics"]["codex"]["mode"] == "managed"
+    assert status["runtimeDiagnostics"]["codex"]["transport"] == "stdio"
+    assert status["runtimeDiagnostics"]["codex"]["keep_alive"] is False
 
 
 def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
@@ -758,6 +762,8 @@ def test_issue_runner_run_loop_reconciles_completed_worker_before_bounded_exit(t
         run=fake_run,
         run_json=lambda *args, **kwargs: {},
     )
+    close_calls = []
+    workspace.runtimes["default"].close = lambda: close_calls.append("closed")
     original_supervise_once = workspace.supervise_once
 
     def supervise_and_wait():
@@ -778,6 +784,7 @@ def test_issue_runner_run_loop_reconciles_completed_worker_before_bounded_exit(t
     assert status["scheduler"]["retry_queue"][0]["error"] == "continuation"
     scheduler = json.loads((workflow_root / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
     assert scheduler["running"] == []
+    assert close_calls == ["closed"]
 
 
 def test_issue_runner_run_loop_reconciles_completed_worker_before_interrupt_exit(tmp_path):
@@ -1040,6 +1047,41 @@ def test_issue_runner_run_loop_keeps_last_known_good_on_invalid_reload(tmp_path)
     assert result["last_result"]["ok"] is True
     events = (workflow_root / "memory" / "workflow-audit.jsonl").read_text(encoding="utf-8")
     assert "daedalus.config_reload_failed" in events
+
+
+def test_issue_runner_reload_closes_old_runtimes_when_no_workers_are_running(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[],
+        prompt_template="Issue: {{ issue.identifier }}",
+    )
+    workflow_file = workflow_root / "WORKFLOW.md"
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=lambda *args, **kwargs: None,
+        run_json=lambda *args, **kwargs: {},
+    )
+    close_calls = []
+    workspace.runtimes["default"].close = lambda: close_calls.append("closed")
+
+    updated_cfg = dict(cfg)
+    updated_cfg["polling"] = {"interval_seconds": 5}
+    time.sleep(0.01)
+    workflow_file.write_text(
+        render_workflow_markdown(config=updated_cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+    workspace.reload_contract()
+
+    assert close_calls == ["closed"]
 
 
 def test_issue_runner_rejects_workspace_symlink_escape(tmp_path):


### PR DESCRIPTION
## Summary

Adds warm external WebSocket transport reuse for the shared `codex-app-server` runtime while keeping managed stdio mode one-shot. External mode now defaults to `keep_alive: true`, reconnects when a warm socket is stale, exposes lightweight runtime diagnostics, and fails fast if `keep_alive` is configured with managed mode.

This also wires service-lifetime runtime reuse and cleanup through the bundled workflows: `change-delivery` reuses cached active action runners safely, and `issue-runner` reuses shared runtimes for sequential supervised workers, closes old runtimes on safe reload/shutdown, and surfaces runtime diagnostics in status.

Docs and schemas were updated for `keep_alive`, including issue-runner and change-delivery examples.

## Validation

- `python -m py_compile daedalus/runtimes/codex_app_server.py daedalus/runtime.py daedalus/workflows/issue_runner/workspace.py`
- `git diff --check`
- `pytest -q` (`803 passed, 6 skipped`)