### PR TITLE
[codex] add GitHub issue-runner smoke preflight

### DIFF
--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -58,6 +58,9 @@ def describe_tracker_source(*, workflow_root: Path, tracker_cfg: dict[str, Any])
     if kind == "local-json":
         return str(resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg))
     if kind == "github":
+        slug = tracker_cfg.get("github_slug") or tracker_cfg.get("github-slug")
+        if slug:
+            return f"github:{slug}"
         repo_path = tracker_cfg.get("repo_path") or tracker_cfg.get("repo-path")
         if repo_path:
             path = Path(str(repo_path)).expanduser()

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -9,7 +9,75 @@ from typing import Any, Callable
 from . import TrackerConfigError, issue_priority_sort_key, normalize_issue, register
 
 
-_GITHUB_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_GITHUB_SLUG_RE = re.compile(
+    r"^(?:(?P<host>[A-Za-z0-9.-]+(?::[0-9]+)?)/)?"
+    r"(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)$"
+)
+
+
+def _github_slug_match(raw: str) -> re.Match[str] | None:
+    return _GITHUB_SLUG_RE.match(raw)
+
+
+def _github_slug_config_error() -> TrackerConfigError:
+    return TrackerConfigError(
+        "repository.github-slug must be in owner/repo or host/owner/repo form for tracker.kind='github'"
+    )
+
+
+def github_auth_host_from_slug(slug: str | None) -> str | None:
+    raw = str(slug or "").strip()
+    if not raw:
+        return None
+    match = _github_slug_match(raw)
+    if not match:
+        raise _github_slug_config_error()
+    return match.group("host") or "github.com"
+
+
+def github_name_with_owner_from_slug(slug: str | None) -> str | None:
+    raw = str(slug or "").strip()
+    if not raw:
+        return None
+    match = _github_slug_match(raw)
+    if not match:
+        raise _github_slug_config_error()
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def github_auth_success_accounts(
+    payload: dict[str, Any],
+    *,
+    hostname: str | None = None,
+) -> tuple[str | None, list[dict[str, Any]]]:
+    hosts = payload.get("hosts") if isinstance(payload, dict) else None
+    if not isinstance(hosts, dict):
+        raise RuntimeError("gh auth status did not return host information")
+
+    if hostname:
+        accounts = hosts.get(hostname) or []
+        if not isinstance(accounts, list):
+            raise RuntimeError(f"gh auth status returned invalid {hostname} account information")
+        valid_accounts = [account for account in accounts if isinstance(account, dict)]
+        success_accounts = [
+            account for account in valid_accounts if account.get("state") == "success"
+        ]
+        if not success_accounts:
+            raise RuntimeError(
+                f"gh is not authenticated for {hostname}; run `gh auth login --hostname {hostname}`"
+            )
+        return hostname, success_accounts
+
+    for host, accounts in hosts.items():
+        if not isinstance(accounts, list):
+            continue
+        valid_accounts = [account for account in accounts if isinstance(account, dict)]
+        success_accounts = [
+            account for account in valid_accounts if account.get("state") == "success"
+        ]
+        if success_accounts:
+            return str(host), success_accounts
+    raise RuntimeError("gh is not authenticated for any GitHub host; run `gh auth login`")
 
 
 def issue_label_names(issue: dict[str, Any] | None) -> set[str]:
@@ -77,10 +145,8 @@ def github_slug_from_config(
     ).strip()
     if not raw:
         return None
-    if not _GITHUB_SLUG_RE.match(raw):
-        raise TrackerConfigError(
-            "repository.github-slug must be in owner/repo form for tracker.kind='github'"
-        )
+    if not _github_slug_match(raw):
+        raise _github_slug_config_error()
     return raw
 
 
@@ -244,15 +310,26 @@ class GithubTrackerClient:
             raise RuntimeError("expected gh repo view JSON object payload")
         return payload
 
-    def auth_status_payload(self) -> dict[str, Any]:
-        payload = self._run_json(
-            [
+    def auth_status_payload(self, hostname: str | None = None) -> dict[str, Any]:
+        command = [
+            "gh",
+            "auth",
+            "status",
+            "--json",
+            "hosts",
+        ]
+        if hostname:
+            command = [
                 "gh",
                 "auth",
                 "status",
+                "--hostname",
+                hostname,
                 "--json",
                 "hosts",
-            ],
+            ]
+        payload = self._run_json(
+            command,
             cwd=self._repo_path,
         )
         if not isinstance(payload, dict):

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
 from . import TrackerConfigError, issue_priority_sort_key, normalize_issue, register
+
+
+_GITHUB_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def issue_label_names(issue: dict[str, Any] | None) -> set[str]:
@@ -59,12 +63,83 @@ def _subprocess_run_json(command: list[str], *, cwd: Path | None = None) -> Any:
     return payload
 
 
+def github_slug_from_config(
+    tracker_cfg: dict[str, Any],
+    repository_cfg: dict[str, Any] | None = None,
+) -> str | None:
+    repository_cfg = repository_cfg or {}
+    raw = str(
+        tracker_cfg.get("github_slug")
+        or tracker_cfg.get("github-slug")
+        or repository_cfg.get("github_slug")
+        or repository_cfg.get("github-slug")
+        or ""
+    ).strip()
+    if not raw:
+        return None
+    if not _GITHUB_SLUG_RE.match(raw):
+        raise TrackerConfigError(
+            "repository.github-slug must be in owner/repo form for tracker.kind='github'"
+        )
+    return raw
+
+
+def _configured_states(tracker_cfg: dict[str, Any], *keys: str) -> list[str]:
+    for key in keys:
+        value = tracker_cfg.get(key)
+        if isinstance(value, list):
+            return [str(item).strip().lower() for item in value if str(item).strip()]
+    return []
+
+
+def validate_github_tracker_config(
+    *,
+    workflow_root: Path,
+    tracker_cfg: dict[str, Any],
+    repository_cfg: dict[str, Any] | None = None,
+    repo_path: Path | None = None,
+) -> None:
+    repository_cfg = repository_cfg or {}
+    slug = github_slug_from_config(tracker_cfg, repository_cfg)
+    resolved_repo_path = _resolve_repo_path(
+        workflow_root=workflow_root,
+        tracker_cfg=tracker_cfg,
+        repo_path=repo_path,
+        required=slug is None,
+    )
+    if resolved_repo_path is not None and not resolved_repo_path.exists():
+        raise TrackerConfigError(
+            f"repository.local-path does not exist for tracker.kind='github': {resolved_repo_path}"
+        )
+
+    active_states = _configured_states(tracker_cfg, "active_states", "active-states")
+    terminal_states = _configured_states(tracker_cfg, "terminal_states", "terminal-states")
+    if not active_states or set(active_states) != {"open"}:
+        raise TrackerConfigError(
+            "tracker.kind='github' requires tracker.active_states: [open]"
+        )
+    if not terminal_states or set(terminal_states) != {"closed"}:
+        raise TrackerConfigError(
+            "tracker.kind='github' requires tracker.terminal_states: [closed]"
+        )
+
+    for key in ("required_labels", "required-labels", "exclude_labels", "exclude-labels"):
+        value = tracker_cfg.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            raise TrackerConfigError(f"tracker.{key} must be a list for tracker.kind='github'")
+        if any(not str(item).strip() for item in value):
+            raise TrackerConfigError(f"tracker.{key} must not contain blank labels")
+
+
 def _resolve_repo_path(
     *,
     workflow_root: Path,
     tracker_cfg: dict[str, Any],
     repo_path: Path | None,
-) -> Path:
+    required: bool = True,
+) -> Path | None:
     if repo_path is not None:
         return repo_path.expanduser().resolve()
 
@@ -74,8 +149,10 @@ def _resolve_repo_path(
         or ""
     ).strip()
     if not raw:
+        if not required:
+            return None
         raise TrackerConfigError(
-            "tracker.kind='github' requires repository.local-path or tracker.repo_path"
+            "tracker.kind='github' requires repository.github-slug or repository.local-path"
         )
     path = Path(raw).expanduser()
     if not path.is_absolute():
@@ -110,12 +187,23 @@ class GithubTrackerClient:
             workflow_root=workflow_root,
             tracker_cfg=tracker_cfg,
             repo_path=repo_path,
+            required=github_slug_from_config(tracker_cfg) is None,
         )
+        self._repo_slug = github_slug_from_config(tracker_cfg)
         self._run_json = run_json or _subprocess_run_json
 
     @property
-    def repo_path(self) -> Path:
+    def repo_path(self) -> Path | None:
         return self._repo_path
+
+    @property
+    def repo_slug(self) -> str | None:
+        return self._repo_slug
+
+    def _with_repo(self, command: list[str]) -> list[str]:
+        if not self._repo_slug:
+            return command
+        return [*command, "--repo", self._repo_slug]
 
     def list_issue_payloads(
         self,
@@ -125,22 +213,51 @@ class GithubTrackerClient:
         fields: str,
     ) -> list[dict[str, Any]]:
         payload = self._run_json(
-            [
-                "gh",
-                "issue",
-                "list",
-                "--state",
-                state,
-                "--limit",
-                str(limit),
-                "--json",
-                fields,
-            ],
+            self._with_repo(
+                [
+                    "gh",
+                    "issue",
+                    "list",
+                    "--state",
+                    state,
+                    "--limit",
+                    str(limit),
+                    "--json",
+                    fields,
+                ]
+            ),
             cwd=self._repo_path,
         )
         if not isinstance(payload, list):
             raise RuntimeError("expected gh issue list JSON array payload")
         return [item for item in payload if isinstance(item, dict)]
+
+    def repo_view_payload(self) -> dict[str, Any]:
+        command = ["gh", "repo", "view", "--json", "nameWithOwner"]
+        if self._repo_slug:
+            command = ["gh", "repo", "view", self._repo_slug, "--json", "nameWithOwner"]
+        payload = self._run_json(
+            command,
+            cwd=self._repo_path,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("expected gh repo view JSON object payload")
+        return payload
+
+    def auth_status_payload(self) -> dict[str, Any]:
+        payload = self._run_json(
+            [
+                "gh",
+                "auth",
+                "status",
+                "--json",
+                "hosts",
+            ],
+            cwd=self._repo_path,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("expected gh auth status JSON object payload")
+        return payload
 
     def list_open_issue_payloads(
         self,
@@ -160,7 +277,7 @@ class GithubTrackerClient:
         if issue_number is None:
             return None
         payload = self._run_json(
-            ["gh", "issue", "view", issue_number, "--json", fields],
+            self._with_repo(["gh", "issue", "view", issue_number, "--json", fields]),
             cwd=self._repo_path,
         )
         if not isinstance(payload, dict):

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from workflows.issue_runner.tracker import TrackerConfigError, build_tracker_client, resolve_tracker_path
+from trackers.github import github_slug_from_config, validate_github_tracker_config
 
 
 @dataclass(frozen=True)
@@ -60,12 +61,45 @@ def _validate_config(config: dict[str, Any]) -> None:
         if not repo_path.is_absolute():
             repo_path = (workflow_root / repo_path).resolve()
     try:
+        tracker_kind = str(tracker_cfg.get("kind") or "").strip()
+        tracker_client_cfg = dict(tracker_cfg)
+        if tracker_kind == "github":
+            slug = github_slug_from_config(tracker_client_cfg, repository_cfg)
+            if slug:
+                tracker_client_cfg.setdefault("github_slug", slug)
+            validate_github_tracker_config(
+                workflow_root=workflow_root,
+                tracker_cfg=tracker_client_cfg,
+                repository_cfg=repository_cfg,
+                repo_path=repo_path,
+            )
         if str(tracker_cfg.get("kind") or "").strip() == "local-json":
             resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg)
-        build_tracker_client(
+        client = build_tracker_client(
             workflow_root=workflow_root,
-            tracker_cfg=tracker_cfg,
+            tracker_cfg=tracker_client_cfg,
             repo_path=repo_path,
         )
+        if tracker_kind == "github":
+            auth_status = getattr(client, "auth_status_payload")()
+            _assert_github_auth_ok(auth_status)
+            repo_view = getattr(client, "repo_view_payload")()
+            expected_slug = github_slug_from_config(tracker_client_cfg, repository_cfg)
+            actual_slug = str(repo_view.get("nameWithOwner") or "").strip()
+            if expected_slug and actual_slug and actual_slug.lower() != expected_slug.lower():
+                raise RuntimeError(
+                    f"gh resolved repository {actual_slug!r}, expected {expected_slug!r}"
+                )
     except TrackerConfigError as exc:
         raise RuntimeError(str(exc)) from exc
+
+
+def _assert_github_auth_ok(payload: dict[str, Any]) -> None:
+    hosts = payload.get("hosts") if isinstance(payload, dict) else None
+    if not isinstance(hosts, dict):
+        raise RuntimeError("gh auth status did not return host information")
+    github_accounts = hosts.get("github.com") or []
+    if not isinstance(github_accounts, list):
+        raise RuntimeError("gh auth status returned invalid github.com account information")
+    if not any(isinstance(account, dict) and account.get("state") == "success" for account in github_accounts):
+        raise RuntimeError("gh is not authenticated for github.com; run `gh auth login`")

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import Any
 
 from workflows.issue_runner.tracker import TrackerConfigError, build_tracker_client, resolve_tracker_path
-from trackers.github import github_slug_from_config, validate_github_tracker_config
+from trackers.github import (
+    github_auth_host_from_slug,
+    github_auth_success_accounts,
+    github_name_with_owner_from_slug,
+    github_slug_from_config,
+    validate_github_tracker_config,
+)
 
 
 @dataclass(frozen=True)
@@ -81,25 +87,24 @@ def _validate_config(config: dict[str, Any]) -> None:
             repo_path=repo_path,
         )
         if tracker_kind == "github":
-            auth_status = getattr(client, "auth_status_payload")()
-            _assert_github_auth_ok(auth_status)
-            repo_view = getattr(client, "repo_view_payload")()
             expected_slug = github_slug_from_config(tracker_client_cfg, repository_cfg)
+            auth_host = github_auth_host_from_slug(expected_slug)
+            auth_status = getattr(client, "auth_status_payload")(hostname=auth_host)
+            _assert_github_auth_ok(auth_status, hostname=auth_host)
+            repo_view = getattr(client, "repo_view_payload")()
+            expected_name_with_owner = github_name_with_owner_from_slug(expected_slug)
             actual_slug = str(repo_view.get("nameWithOwner") or "").strip()
-            if expected_slug and actual_slug and actual_slug.lower() != expected_slug.lower():
+            if (
+                expected_name_with_owner
+                and actual_slug
+                and actual_slug.lower() != expected_name_with_owner.lower()
+            ):
                 raise RuntimeError(
-                    f"gh resolved repository {actual_slug!r}, expected {expected_slug!r}"
+                    f"gh resolved repository {actual_slug!r}, expected {expected_name_with_owner!r}"
                 )
     except TrackerConfigError as exc:
         raise RuntimeError(str(exc)) from exc
 
 
-def _assert_github_auth_ok(payload: dict[str, Any]) -> None:
-    hosts = payload.get("hosts") if isinstance(payload, dict) else None
-    if not isinstance(hosts, dict):
-        raise RuntimeError("gh auth status did not return host information")
-    github_accounts = hosts.get("github.com") or []
-    if not isinstance(github_accounts, list):
-        raise RuntimeError("gh auth status returned invalid github.com account information")
-    if not any(isinstance(account, dict) and account.get("state") == "success" for account in github_accounts):
-        raise RuntimeError("gh is not authenticated for github.com; run `gh auth login`")
+def _assert_github_auth_ok(payload: dict[str, Any], *, hostname: str | None) -> None:
+    github_auth_success_accounts(payload, hostname=hostname)

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -28,7 +28,12 @@ from workflows.issue_runner.tracker import (
     issue_workspace_slug,
     select_issue,
 )
-from trackers.github import github_slug_from_config
+from trackers.github import (
+    github_auth_host_from_slug,
+    github_auth_success_accounts,
+    github_name_with_owner_from_slug,
+    github_slug_from_config,
+)
 
 
 def _now_iso() -> str:
@@ -431,34 +436,52 @@ class IssueRunnerWorkspace:
     def _github_doctor_checks(self) -> list[dict[str, Any]]:
         checks: list[dict[str, Any]] = []
         try:
-            auth_payload = getattr(self.tracker_client, "auth_status_payload")()
-            hosts = auth_payload.get("hosts") if isinstance(auth_payload, dict) else None
-            accounts = hosts.get("github.com") if isinstance(hosts, dict) else None
-            if not isinstance(accounts, list) or not any(
-                isinstance(account, dict) and account.get("state") == "success"
-                for account in accounts
-            ):
-                raise RuntimeError("gh is not authenticated for github.com")
+            expected = github_slug_from_config(
+                self.config.get("tracker") or {},
+                self.config.get("repository") or {},
+            )
+            auth_host = github_auth_host_from_slug(expected)
+            auth_payload = getattr(self.tracker_client, "auth_status_payload")(hostname=auth_host)
+            resolved_host, accounts = github_auth_success_accounts(auth_payload, hostname=auth_host)
             active = next(
                 (
                     account
                     for account in accounts
-                    if isinstance(account, dict) and account.get("active") and account.get("state") == "success"
+                    if account.get("active") and account.get("state") == "success"
                 ),
                 None,
             )
             login = (active or accounts[0]).get("login") if accounts else None
-            checks.append({"name": "github-auth", "status": "pass", "detail": f"gh authenticated as {login or 'unknown'}"})
+            detail = f"gh authenticated as {login or 'unknown'}"
+            if resolved_host and resolved_host != "github.com":
+                detail = f"{detail} on {resolved_host}"
+            checks.append({"name": "github-auth", "status": "pass", "detail": detail})
         except Exception as exc:
             checks.append({"name": "github-auth", "status": "fail", "detail": str(exc)})
 
         try:
             repo_payload = getattr(self.tracker_client, "repo_view_payload")()
             resolved = str(repo_payload.get("nameWithOwner") or "").strip()
-            expected = github_slug_from_config(self.config.get("tracker") or {}, self.config.get("repository") or {})
-            if expected and resolved and resolved.lower() != expected.lower():
-                raise RuntimeError(f"gh resolved repository {resolved!r}, expected {expected!r}")
-            checks.append({"name": "github-repo", "status": "pass", "detail": resolved or (expected or "resolved")})
+            expected = github_slug_from_config(
+                self.config.get("tracker") or {},
+                self.config.get("repository") or {},
+            )
+            expected_name_with_owner = github_name_with_owner_from_slug(expected)
+            if (
+                expected_name_with_owner
+                and resolved
+                and resolved.lower() != expected_name_with_owner.lower()
+            ):
+                raise RuntimeError(
+                    f"gh resolved repository {resolved!r}, expected {expected_name_with_owner!r}"
+                )
+            checks.append(
+                {
+                    "name": "github-repo",
+                    "status": "pass",
+                    "detail": resolved or (expected_name_with_owner or "resolved"),
+                }
+            )
         except Exception as exc:
             checks.append({"name": "github-repo", "status": "fail", "detail": str(exc)})
         return checks

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -28,6 +28,7 @@ from workflows.issue_runner.tracker import (
     issue_workspace_slug,
     select_issue,
 )
+from trackers.github import github_slug_from_config
 
 
 def _now_iso() -> str:
@@ -58,6 +59,17 @@ def _repository_path_from_config(workflow_root: Path, config: dict[str, Any]) ->
     if not path.is_absolute():
         path = (workflow_root / path).resolve()
     return path
+
+
+def _tracker_config_for_client(config: dict[str, Any]) -> dict[str, Any]:
+    tracker_cfg = dict(config.get("tracker") or {})
+    if str(tracker_cfg.get("kind") or "").strip() != "github":
+        return tracker_cfg
+    repository_cfg = config.get("repository") or {}
+    slug = github_slug_from_config(tracker_cfg, repository_cfg)
+    if slug:
+        tracker_cfg.setdefault("github_slug", slug)
+    return tracker_cfg
 
 
 def _write_json(path: Path, payload: Any) -> None:
@@ -392,6 +404,10 @@ class IssueRunnerWorkspace:
         except Exception as exc:
             checks.append({"name": "tracker", "status": "fail", "detail": str(exc)})
 
+        tracker_cfg = self.config.get("tracker") or {}
+        if str(tracker_cfg.get("kind") or "").strip() == "github":
+            checks.extend(self._github_doctor_checks())
+
         try:
             self.issue_workspace_root.mkdir(parents=True, exist_ok=True)
             checks.append({"name": "workspace-root", "status": "pass", "detail": str(self.issue_workspace_root)})
@@ -411,6 +427,41 @@ class IssueRunnerWorkspace:
             "checks": checks,
             "updatedAt": _now_iso(),
         }
+
+    def _github_doctor_checks(self) -> list[dict[str, Any]]:
+        checks: list[dict[str, Any]] = []
+        try:
+            auth_payload = getattr(self.tracker_client, "auth_status_payload")()
+            hosts = auth_payload.get("hosts") if isinstance(auth_payload, dict) else None
+            accounts = hosts.get("github.com") if isinstance(hosts, dict) else None
+            if not isinstance(accounts, list) or not any(
+                isinstance(account, dict) and account.get("state") == "success"
+                for account in accounts
+            ):
+                raise RuntimeError("gh is not authenticated for github.com")
+            active = next(
+                (
+                    account
+                    for account in accounts
+                    if isinstance(account, dict) and account.get("active") and account.get("state") == "success"
+                ),
+                None,
+            )
+            login = (active or accounts[0]).get("login") if accounts else None
+            checks.append({"name": "github-auth", "status": "pass", "detail": f"gh authenticated as {login or 'unknown'}"})
+        except Exception as exc:
+            checks.append({"name": "github-auth", "status": "fail", "detail": str(exc)})
+
+        try:
+            repo_payload = getattr(self.tracker_client, "repo_view_payload")()
+            resolved = str(repo_payload.get("nameWithOwner") or "").strip()
+            expected = github_slug_from_config(self.config.get("tracker") or {}, self.config.get("repository") or {})
+            if expected and resolved and resolved.lower() != expected.lower():
+                raise RuntimeError(f"gh resolved repository {resolved!r}, expected {expected!r}")
+            checks.append({"name": "github-repo", "status": "pass", "detail": resolved or (expected or "resolved")})
+        except Exception as exc:
+            checks.append({"name": "github-repo", "status": "fail", "detail": str(exc)})
+        return checks
 
     def _runtime_diagnostics(self) -> dict[str, dict[str, Any]]:
         diagnostics: dict[str, dict[str, Any]] = {}
@@ -1732,16 +1783,17 @@ class IssueRunnerWorkspace:
         self.prompt_template = contract.prompt_template
         self.snapshot_ref.set(snapshot)
         tracker_cfg = cfg.get("tracker") or {}
+        tracker_client_cfg = _tracker_config_for_client(cfg)
         workspace_cfg = cfg.get("workspace") or {}
         storage_cfg = cfg.get("storage") or {}
         repo_path = _repository_path_from_config(self.path, cfg)
-        tracker_source_cfg = dict(tracker_cfg)
+        tracker_source_cfg = dict(tracker_client_cfg)
         if repo_path is not None and str(tracker_cfg.get("kind") or "").strip() == "github":
             tracker_source_cfg.setdefault("repo_path", str(repo_path))
         self.tracker_source = describe_tracker_source(workflow_root=self.path, tracker_cfg=tracker_source_cfg)
         self.tracker_client = build_tracker_client(
             workflow_root=self.path,
-            tracker_cfg=tracker_cfg,
+            tracker_cfg=tracker_client_cfg,
             repo_path=repo_path,
             run_json=self._run_json,
         )
@@ -1786,10 +1838,11 @@ def load_workspace_from_config(
         source_size=st.st_size,
     )
     tracker_cfg = cfg.get("tracker") or {}
+    tracker_client_cfg = _tracker_config_for_client(cfg)
     workspace_cfg = cfg.get("workspace") or {}
     storage_cfg = cfg.get("storage") or {}
     repo_path = _repository_path_from_config(root, cfg)
-    tracker_source_cfg = dict(tracker_cfg)
+    tracker_source_cfg = dict(tracker_client_cfg)
     if repo_path is not None and str(tracker_cfg.get("kind") or "").strip() == "github":
         tracker_source_cfg.setdefault("repo_path", str(repo_path))
 
@@ -1803,7 +1856,7 @@ def load_workspace_from_config(
     tracker_source = describe_tracker_source(workflow_root=root, tracker_cfg=tracker_source_cfg)
     tracker_client = build_tracker_client(
         workflow_root=root,
-        tracker_cfg=tracker_cfg,
+        tracker_cfg=tracker_client_cfg,
         repo_path=repo_path,
         run_json=run_json or _subprocess_run_json,
     )

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Day-2 commands and observability.
 - [Cheat sheet](operator/cheat-sheet.md) — quickest path to a useful answer
 - [Slash commands](operator/slash-commands.md) — every `/daedalus` and `/workflow` form
 - [HTTP status surface](operator/http-status.md) — workflow-scoped JSON + HTML endpoints
+- [GitHub smoke test](operator/github-smoke.md) — skipped-by-default live test for the supported tracker path
 
 ## Workflow docs
 

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -28,9 +28,19 @@ The harness tests should catch these regressions before review:
 
 Add tests for the next hardening slice in this order:
 
-1. GitHub issue selection, dispatch, and terminal reconciliation smoke against a
-   real test repository.
-2. `WORKFLOW*.md` bootstrap branch creation and update behavior when a repo
+1. `WORKFLOW*.md` bootstrap branch creation and update behavior when a repo
    already has one workflow contract.
-3. Codex app-server diagnostics for managed and external service modes.
-4. CLI/docs drift checks for every command shown in the install guide.
+2. Codex app-server diagnostics for managed and external service modes.
+3. CLI/docs drift checks for every command shown in the install guide.
+
+## Live GitHub Smoke
+
+The first live GitHub smoke is implemented but skipped by default:
+
+```bash
+export DAEDALUS_GITHUB_SMOKE_REPO=your-org/your-repo
+pytest tests/test_github_issue_runner_smoke.py -q
+```
+
+See [operator/github-smoke.md](operator/github-smoke.md) for setup and cleanup
+details.

--- a/docs/operator/github-smoke.md
+++ b/docs/operator/github-smoke.md
@@ -1,0 +1,36 @@
+# GitHub Smoke Test
+
+Use this only against a repository where temporary issues are acceptable. The
+test creates one labeled issue, lets `issue-runner` select and dispatch it, then
+closes the issue and verifies terminal cleanup.
+
+## Prerequisites
+
+- `gh` installed and authenticated with issue read/write access
+- a repository you can create and close issues in
+- normal Python test dependencies installed
+
+## Run
+
+```bash
+export DAEDALUS_GITHUB_SMOKE_REPO=your-org/your-repo
+pytest tests/test_github_issue_runner_smoke.py -q
+```
+
+Optional controls:
+
+```bash
+export DAEDALUS_GITHUB_SMOKE_REPO_PATH=/path/to/local/checkout
+export DAEDALUS_GITHUB_SMOKE_LABEL=daedalus-smoke
+```
+
+`DAEDALUS_GITHUB_SMOKE_REPO_PATH` only needs to exist locally. The tracker uses
+`gh --repo <owner>/<repo>`, so the path does not have to be a git checkout.
+
+## What It Proves
+
+- `tracker.kind: github` can select issues via `gh`
+- required-label filtering works against live GitHub data
+- a no-op runtime can dispatch from the selected issue
+- scheduler state records the continuation retry
+- terminal GitHub state clears retry state and removes the issue workspace

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -222,6 +222,9 @@ For the bundled generic workflow:
 /workflow issue-runner run --max-iterations 1 --json
 ```
 
+To validate the GitHub-backed tracker path against a disposable live issue, see
+[github-smoke.md](github-smoke.md).
+
 ## Plugin state
 
 Hermes plugins are opt-in. `hermes plugins install ... --enable` is the

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -16,7 +16,7 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 |---|---|---|
 | `WORKFLOW.md` loader | Partial | Supported as a repo-owned public contract. Front matter maps to the selected workflow schema; `issue-runner` is the closer generic reference surface, while `change-delivery` still carries richer GitHub-specific semantics. |
 | Typed config + hot reload | Implemented | Bundled workflows load repo-owned `WORKFLOW.md`; `issue-runner` now keeps last-known-good config on invalid reloads. |
-| Issue tracker client boundary | Partial | `issue-runner` has shared `github`, `local-json`, and Linear clients. GitHub is the first-class public tracker path; `local-json` is for fixtures/dev; Linear is experimental and deferred. |
+| Issue tracker client boundary | Partial | `issue-runner` has shared `github`, `local-json`, and Linear clients. GitHub is the first-class public tracker path and now has a skipped-by-default live smoke; `local-json` is for fixtures/dev; Linear is experimental and deferred. |
 | Workspace manager | Partial | Generic workspace root, lifecycle hooks, terminal cleanup, sanitized workspace keys, root-containment checks, managed long-running `issue-runner`, supervised `change-delivery` active iterations, worker reconciliation, and persisted scheduler state now exist. |
 | Bounded concurrency | Partial | `issue-runner` dispatches bounded async workers in the service loop and persists running-worker recovery. `change-delivery` now supervises one active worker iteration at a time, but the broader engine is still not uniformly scheduler-driven. |
 | Retry/backoff policy | Partial | `issue-runner` uses Symphony-style 1s continuation retries and 10s-based exponential failure backoff, including supervised worker completion and terminal-state retry suppression. |
@@ -37,7 +37,7 @@ Daedalus currently differs from the Symphony draft in four material ways:
 ## Recommended Next Gaps
 
 1. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
-2. Add GitHub integration smoke tests that exercise issue selection, worker dispatch, status reporting, and terminal reconciliation against a real repository.
+2. Add broader GitHub integration coverage for comments, labels, and failure recovery against a real repository.
 3. Expand harness checks for public docs, generic examples, and workflow-template drift.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -104,7 +104,7 @@ hermes daedalus scaffold-workflow \
 Then edit:
 
 - `WORKFLOW.md` or `WORKFLOW-issue-runner.md` in the repo checkout
-- nothing extra if you are using `tracker.kind: github` and the repo checkout already has `gh` auth
+- `tracker.active_states: [open]`, `tracker.terminal_states: [closed]`, and `gh` auth if you are using `tracker.kind: github`
 - `config/issues.json` if you are using `tracker.kind: local-json`
 - `tracker.endpoint`, `tracker.api_key`, and `tracker.project_slug` only if you are deliberately testing the experimental Linear adapter
 
@@ -124,6 +124,9 @@ For direct workflow operations:
 /workflow issue-runner serve
 ```
 
+`doctor` includes GitHub-specific checks for `gh auth status` and repository
+resolution when `tracker.kind: github`.
+
 If `server.port` is set in the repo-owned contract, `serve` exposes the same
 localhost JSON + HTML status surface used by `change-delivery`, but backed by
 the `issue-runner` scheduler/status/audit files instead of the lane SQLite
@@ -141,4 +144,5 @@ tables.
 - [Architecture](../architecture.md)
 - [Runtimes](../concepts/runtimes.md)
 - [Hot-reload](../concepts/hot-reload.md)
+- [GitHub smoke test](../operator/github-smoke.md)
 - [Symphony conformance](../symphony-conformance.md)

--- a/tests/test_github_issue_runner_smoke.py
+++ b/tests/test_github_issue_runner_smoke.py
@@ -1,0 +1,154 @@
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from workflows.contract import render_workflow_markdown
+
+
+def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=check, capture_output=True, text=True)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DAEDALUS_GITHUB_SMOKE_REPO"),
+    reason="set DAEDALUS_GITHUB_SMOKE_REPO=owner/repo to run the live GitHub smoke",
+)
+def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_issue(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    smoke_repo = os.environ["DAEDALUS_GITHUB_SMOKE_REPO"].strip()
+    repo_path = Path(os.environ.get("DAEDALUS_GITHUB_SMOKE_REPO_PATH") or (tmp_path / "repo")).expanduser().resolve()
+    repo_path.mkdir(parents=True, exist_ok=True)
+    label = os.environ.get("DAEDALUS_GITHUB_SMOKE_LABEL", "daedalus-smoke")
+    marker = uuid4().hex[:10]
+    title = f"Daedalus issue-runner smoke {marker}"
+    body = f"Temporary Daedalus smoke issue. Marker: {marker}"
+    issue_number: str | None = None
+
+    _run(["gh", "auth", "status"])
+    _run(
+        [
+            "gh",
+            "label",
+            "create",
+            label,
+            "--repo",
+            smoke_repo,
+            "--color",
+            "2f81f7",
+            "--description",
+            "Temporary Daedalus smoke-test label",
+        ],
+        check=False,
+    )
+
+    try:
+        created = _run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{smoke_repo}/issues",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+                "-f",
+                f"labels[]={label}",
+                "--jq",
+                ".number",
+            ]
+        )
+        issue_number = created.stdout.strip()
+        assert issue_number
+
+        workflow_root = tmp_path / "workflow"
+        workflow_root.mkdir()
+        cfg = {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": "smoke-issue-runner", "engine-owner": "hermes"},
+            "repository": {"local-path": str(repo_path), "github-slug": smoke_repo},
+            "tracker": {
+                "kind": "github",
+                "active_states": ["open"],
+                "terminal_states": ["closed"],
+                "required_labels": [label],
+            },
+            "workspace": {"root": "workspace/issues"},
+            "agent": {
+                "name": "Smoke_Agent",
+                "model": "local-smoke",
+                "runtime": "smoke",
+                "max_concurrent_agents": 1,
+            },
+            "daedalus": {
+                "runtimes": {
+                    "smoke": {
+                        "kind": "hermes-agent",
+                        "command": [
+                            sys.executable,
+                            "-c",
+                            "from pathlib import Path; import sys; print(Path(sys.argv[1]).read_text())",
+                            "{prompt_path}",
+                        ],
+                    }
+                }
+            },
+            "storage": {
+                "status": "memory/workflow-status.json",
+                "health": "memory/workflow-health.json",
+                "audit-log": "memory/workflow-audit.jsonl",
+                "scheduler": "memory/workflow-scheduler.json",
+            },
+        }
+        (workflow_root / "WORKFLOW.md").write_text(
+            render_workflow_markdown(
+                config=cfg,
+                prompt_template="Smoke issue {{ issue.identifier }}: {{ issue.title }}",
+            ),
+            encoding="utf-8",
+        )
+        workspace = load_workspace_from_config(workspace_root=workflow_root)
+
+        result = workspace.tick()
+
+        assert result["ok"] is True
+        assert result["selectedIssue"]["id"] == issue_number
+        assert Path(result["outputPath"]).read_text(encoding="utf-8")
+        scheduler = workspace._load_scheduler_state()
+        assert scheduler["retry_queue"][0]["issue_id"] == issue_number
+
+        _run(
+            [
+                "gh",
+                "issue",
+                "close",
+                issue_number,
+                "--repo",
+                smoke_repo,
+                "--comment",
+                "Closing Daedalus issue-runner smoke issue.",
+            ]
+        )
+
+        cleanup_result = None
+        for _ in range(10):
+            cleanup_result = workspace.tick()
+            cleaned = cleanup_result.get("cleanup") or []
+            if any(str(item.get("issue_id")) == issue_number for item in cleaned):
+                break
+            time.sleep(2)
+
+        assert cleanup_result is not None
+        assert any(str(item.get("issue_id")) == issue_number for item in cleanup_result.get("cleanup") or [])
+        assert not workspace._load_scheduler_state().get("retry_queue")
+    finally:
+        if issue_number:
+            _run(["gh", "issue", "close", issue_number, "--repo", smoke_repo], check=False)

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -68,7 +68,7 @@ def test_public_docs_present_github_first_path():
     assert "`github` — first-class public tracker path" in issue_runner
     assert "`local-json` — local development and test fixture path" in issue_runner
     assert "`linear` — experimental adapter" in issue_runner
-    assert "GitHub integration smoke tests" in conformance
+    assert "skipped-by-default live smoke" in conformance
     assert ("Linear integration" + " smoke tests") not in conformance
 
 

--- a/tests/test_workflows_issue_runner_github_preflight.py
+++ b/tests/test_workflows_issue_runner_github_preflight.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+
+def _github_config(repo_path: Path) -> dict:
+    return {
+        "workflow": "issue-runner",
+        "schema-version": 1,
+        "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
+        "repository": {"local-path": str(repo_path), "github-slug": "attmous/daedalus"},
+        "tracker": {
+            "kind": "github",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        "workspace": {"root": "workspace/issues"},
+        "agent": {
+            "name": "runner",
+            "model": "gpt-5.4",
+            "runtime": "default",
+            "max_concurrent_agents": 1,
+        },
+        "daedalus": {
+            "runtimes": {
+                "default": {
+                    "kind": "hermes-agent",
+                    "command": ["fake-agent", "--prompt", "{prompt_path}"],
+                }
+            }
+        },
+        "storage": {
+            "status": "memory/workflow-status.json",
+            "health": "memory/workflow-health.json",
+            "audit-log": "memory/workflow-audit.jsonl",
+        },
+    }
+
+
+def test_issue_runner_preflight_checks_github_auth_and_repo(monkeypatch, tmp_path):
+    from trackers import github as github_tracker
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    commands = []
+
+    def fake_run_json(command, cwd=None):
+        commands.append(command)
+        assert cwd == repo_path
+        if command[:3] == ["gh", "auth", "status"]:
+            return {"hosts": {"github.com": [{"state": "success", "active": True, "login": "attmous"}]}}
+        if command[:3] == ["gh", "repo", "view"]:
+            return {"nameWithOwner": "attmous/daedalus"}
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(github_tracker, "_subprocess_run_json", fake_run_json)
+
+    result = run_preflight(_github_config(repo_path))
+
+    assert result.ok is True
+    assert any(command[:3] == ["gh", "auth", "status"] for command in commands)
+    assert any(command[:3] == ["gh", "repo", "view"] for command in commands)
+
+
+def test_issue_runner_preflight_rejects_github_state_shape(tmp_path):
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    cfg = _github_config(repo_path)
+    cfg["tracker"]["active_states"] = ["todo"]
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "invalid-config"
+    assert "tracker.active_states: [open]" in str(result.error_detail)
+
+
+def test_issue_runner_doctor_reports_github_auth_and_repo(monkeypatch, tmp_path):
+    from workflows.contract import render_workflow_markdown
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    workflow_root = tmp_path / "wf"
+    workflow_root.mkdir()
+    cfg = _github_config(repo_path)
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+    def fake_run_json(command, cwd=None):
+        assert cwd == repo_path
+        if command[:3] == ["gh", "auth", "status"]:
+            return {"hosts": {"github.com": [{"state": "success", "active": True, "login": "attmous"}]}}
+        if command[:3] == ["gh", "repo", "view"]:
+            return {"nameWithOwner": "attmous/daedalus"}
+        if command[:3] == ["gh", "issue", "list"]:
+            return []
+        raise AssertionError(f"unexpected command: {command}")
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run_json=fake_run_json,
+    )
+
+    payload = workspace.doctor()
+    checks = {check["name"]: check for check in payload["checks"]}
+
+    assert payload["ok"] is True
+    assert checks["tracker"]["status"] == "pass"
+    assert checks["github-auth"]["detail"] == "gh authenticated as attmous"
+    assert checks["github-repo"]["detail"] == "attmous/daedalus"

--- a/tests/test_workflows_issue_runner_github_preflight.py
+++ b/tests/test_workflows_issue_runner_github_preflight.py
@@ -61,6 +61,42 @@ def test_issue_runner_preflight_checks_github_auth_and_repo(monkeypatch, tmp_pat
     assert any(command[:3] == ["gh", "repo", "view"] for command in commands)
 
 
+def test_issue_runner_preflight_checks_auth_for_configured_github_host(monkeypatch, tmp_path):
+    from trackers import github as github_tracker
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    commands = []
+    cfg = _github_config(repo_path)
+    cfg["repository"]["github-slug"] = "github.example.com/attmous/daedalus"
+
+    def fake_run_json(command, cwd=None):
+        commands.append(command)
+        assert cwd == repo_path
+        if command[:3] == ["gh", "auth", "status"]:
+            assert command[3:5] == ["--hostname", "github.example.com"]
+            return {
+                "hosts": {
+                    "github.example.com": [
+                        {"state": "success", "active": True, "login": "enterprise-user"}
+                    ]
+                }
+            }
+        if command[:3] == ["gh", "repo", "view"]:
+            assert command[3] == "github.example.com/attmous/daedalus"
+            return {"nameWithOwner": "attmous/daedalus"}
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(github_tracker, "_subprocess_run_json", fake_run_json)
+
+    result = run_preflight(cfg)
+
+    assert result.ok is True
+    assert any(command[:3] == ["gh", "auth", "status"] for command in commands)
+    assert any(command[:3] == ["gh", "repo", "view"] for command in commands)
+
+
 def test_issue_runner_preflight_rejects_github_state_shape(tmp_path):
     from workflows.issue_runner.preflight import run_preflight
 
@@ -111,4 +147,50 @@ def test_issue_runner_doctor_reports_github_auth_and_repo(monkeypatch, tmp_path)
     assert payload["ok"] is True
     assert checks["tracker"]["status"] == "pass"
     assert checks["github-auth"]["detail"] == "gh authenticated as attmous"
+    assert checks["github-repo"]["detail"] == "attmous/daedalus"
+
+
+def test_issue_runner_doctor_checks_auth_for_configured_github_host(monkeypatch, tmp_path):
+    from workflows.contract import render_workflow_markdown
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    workflow_root = tmp_path / "wf"
+    workflow_root.mkdir()
+    cfg = _github_config(repo_path)
+    cfg["repository"]["github-slug"] = "github.example.com/attmous/daedalus"
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+    def fake_run_json(command, cwd=None):
+        assert cwd == repo_path
+        if command[:3] == ["gh", "auth", "status"]:
+            assert command[3:5] == ["--hostname", "github.example.com"]
+            return {
+                "hosts": {
+                    "github.example.com": [
+                        {"state": "success", "active": True, "login": "enterprise-user"}
+                    ]
+                }
+            }
+        if command[:3] == ["gh", "repo", "view"]:
+            assert command[3] == "github.example.com/attmous/daedalus"
+            return {"nameWithOwner": "attmous/daedalus"}
+        if command[:3] == ["gh", "issue", "list"]:
+            return []
+        raise AssertionError(f"unexpected command: {command}")
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run_json=fake_run_json,
+    )
+
+    payload = workspace.doctor()
+    checks = {check["name"]: check for check in payload["checks"]}
+
+    assert payload["ok"] is True
+    assert checks["github-auth"]["detail"] == "gh authenticated as enterprise-user on github.example.com"
     assert checks["github-repo"]["detail"] == "attmous/daedalus"

--- a/tests/test_workflows_issue_runner_tracker.py
+++ b/tests/test_workflows_issue_runner_tracker.py
@@ -310,3 +310,46 @@ def test_github_tracker_client_requires_repo_path(tmp_path):
                 "kind": "github",
             },
         )
+
+
+def test_github_tracker_client_can_use_repo_slug_without_checkout(tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    commands = []
+    open_issue = {
+        "number": 42,
+        "title": "Slug-backed issue",
+        "body": "Run through --repo.",
+        "url": "https://github.com/attmous/daedalus/issues/42",
+        "labels": [],
+        "createdAt": "2026-04-30T00:00:00Z",
+        "updatedAt": "2026-04-30T01:00:00Z",
+        "state": "OPEN",
+    }
+
+    def fake_run_json(command, cwd=None):
+        commands.append(command)
+        assert cwd is None
+        assert command[-2:] == ["--repo", "attmous/daedalus"]
+        if command[:3] == ["gh", "issue", "list"]:
+            return [open_issue]
+        if command[:3] == ["gh", "issue", "view"]:
+            return open_issue
+        raise AssertionError(f"unexpected command: {command}")
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "github",
+            "github_slug": "attmous/daedalus",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        run_json=fake_run_json,
+    )
+
+    assert client.repo_path is None
+    assert client.repo_slug == "attmous/daedalus"
+    assert client.list_candidates()[0]["id"] == "42"
+    assert client.refresh(["42"])["42"]["title"] == "Slug-backed issue"
+    assert any(command[:3] == ["gh", "issue", "list"] for command in commands)

--- a/tests/test_workflows_issue_runner_tracker.py
+++ b/tests/test_workflows_issue_runner_tracker.py
@@ -353,3 +353,43 @@ def test_github_tracker_client_can_use_repo_slug_without_checkout(tmp_path):
     assert client.list_candidates()[0]["id"] == "42"
     assert client.refresh(["42"])["42"]["title"] == "Slug-backed issue"
     assert any(command[:3] == ["gh", "issue", "list"] for command in commands)
+
+
+def test_github_tracker_client_accepts_host_qualified_repo_slug_without_checkout(tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    commands = []
+    open_issue = {
+        "number": 42,
+        "title": "Enterprise issue",
+        "body": "Run through a host-qualified --repo.",
+        "url": "https://github.example.com/attmous/daedalus/issues/42",
+        "labels": [],
+        "createdAt": "2026-04-30T00:00:00Z",
+        "updatedAt": "2026-04-30T01:00:00Z",
+        "state": "OPEN",
+    }
+
+    def fake_run_json(command, cwd=None):
+        commands.append(command)
+        assert cwd is None
+        assert command[-2:] == ["--repo", "github.example.com/attmous/daedalus"]
+        if command[:3] == ["gh", "issue", "list"]:
+            return [open_issue]
+        raise AssertionError(f"unexpected command: {command}")
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "github",
+            "github_slug": "github.example.com/attmous/daedalus",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        run_json=fake_run_json,
+    )
+
+    assert client.repo_path is None
+    assert client.repo_slug == "github.example.com/attmous/daedalus"
+    assert client.list_candidates()[0]["title"] == "Enterprise issue"
+    assert any(command[:3] == ["gh", "issue", "list"] for command in commands)


### PR DESCRIPTION
## Summary

- Add GitHub slug-backed tracker operation so issue-runner can use `gh --repo <owner>/<repo>` while still supporting local checkouts.
- Add issue-runner GitHub preflight and doctor checks for state shape, `gh auth status`, and repository resolution.
- Add a skipped-by-default live GitHub smoke that creates a temporary issue, dispatches it through issue-runner, closes it, and verifies terminal cleanup.
- Document the smoke path and update harness/conformance docs.

## Validation

- `pytest tests/test_workflows_issue_runner_tracker.py tests/test_workflows_issue_runner_github_preflight.py tests/test_github_issue_runner_smoke.py tests/test_public_harness_checks.py -q`
- `pytest -q`
- `git diff --check`