### PR TITLE
[codex] harden workflow bootstrap promotion

### DIFF
--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -1734,19 +1734,27 @@ def _prepare_repo_contract_paths(
         return named_path, []
 
     if default_path.exists():
-        existing_contract = load_workflow_contract_file(default_path)
+        try:
+            existing_contract = load_workflow_contract_file(default_path)
+        except (WorkflowContractError, OSError, UnicodeDecodeError) as exc:
+            raise DaedalusCommandError(
+                f"{default_path} exists but is not a Daedalus workflow contract; "
+                "expected YAML front matter with a top-level `workflow:` field"
+            ) from exc
         existing_workflow = str(existing_contract.config.get("workflow") or "").strip()
         if existing_workflow == workflow_name:
             return default_path, []
         if not existing_workflow:
             raise DaedalusCommandError(
-                f"{default_path} exists but does not declare a workflow name"
+                f"{default_path} exists but is not a Daedalus workflow contract; "
+                "expected YAML front matter with a top-level `workflow:` field"
             )
         migrated_path = workflow_named_markdown_path(repo_root, existing_workflow)
-        if migrated_path.exists() and not force:
+        if migrated_path.exists():
             raise DaedalusCommandError(
                 f"cannot promote {default_path.name} into multi-workflow form because "
-                f"{migrated_path.name} already exists (pass --force to overwrite)"
+                f"{migrated_path.name} already exists; Daedalus will not overwrite "
+                "repo-owned workflow contracts"
             )
         return named_path, [(default_path, migrated_path)]
 
@@ -1796,6 +1804,21 @@ def _ensure_bootstrap_branch(*, repo_root: Path, workflow_name: str) -> str:
     return branch_name
 
 
+def _git_path_is_tracked(*, repo_root: Path, path: Path) -> bool:
+    try:
+        relpath = str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return False
+    completed = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", relpath],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
 def _commit_bootstrap_contract(
     *,
     repo_root: Path,
@@ -1803,7 +1826,16 @@ def _commit_bootstrap_contract(
     paths: list[Path],
 ) -> dict[str, Any]:
     branch_name = _ensure_bootstrap_branch(repo_root=repo_root, workflow_name=workflow_name)
-    relpaths = [str(path.resolve().relative_to(repo_root.resolve())) for path in paths]
+    relpaths = []
+    for path in paths:
+        resolved = path.resolve()
+        try:
+            relpath = str(resolved.relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise DaedalusCommandError(f"cannot commit path outside repo root: {resolved}") from exc
+        if resolved.exists() or _git_path_is_tracked(repo_root=repo_root, path=resolved):
+            relpaths.append(relpath)
+    relpaths = sorted(set(relpaths))
     subprocess.run(
         ["git", "add", "--", *relpaths],
         cwd=str(repo_root),
@@ -1820,6 +1852,7 @@ def _commit_bootstrap_contract(
     )
     committed = False
     commit_sha = None
+    commit_message = f"Add {workflow_name} workflow contract"
     if status.stdout.strip():
         subprocess.run(
             [
@@ -1830,7 +1863,7 @@ def _commit_bootstrap_contract(
                 "user.email=daedalus@local",
                 "commit",
                 "-m",
-                f"Add {workflow_name} workflow contract",
+                commit_message,
             ],
             cwd=str(repo_root),
             check=True,
@@ -1843,6 +1876,7 @@ def _commit_bootstrap_contract(
         "branch": branch_name,
         "committed": committed,
         "commit_sha": commit_sha,
+        "commit_message": commit_message if committed else None,
         "paths": [str(path) for path in paths],
     }
 
@@ -1894,7 +1928,11 @@ def bootstrap_workflow_root(
     commit_result = _commit_bootstrap_contract(
         repo_root=repo_root,
         workflow_name=workflow_name,
-        paths=[Path(result["contract_path"]), *[Path(path) for path in result.get("renamed_contract_paths") or []]],
+        paths=[
+            Path(result["contract_path"]),
+            *[Path(path) for path in result.get("renamed_contract_paths") or []],
+            *[Path(path) for path in result.get("renamed_contract_source_paths") or []],
+        ],
     )
 
     result.update(
@@ -1908,6 +1946,7 @@ def bootstrap_workflow_root(
             "git_branch": commit_result["branch"],
             "git_committed": commit_result["committed"],
             "git_commit_sha": commit_result["commit_sha"],
+            "git_commit_message": commit_result["commit_message"],
         }
     )
     return result
@@ -1992,12 +2031,12 @@ def scaffold_workflow_root(
         path.mkdir(parents=True, exist_ok=True)
 
     renamed_contract_paths: list[str] = []
+    renamed_contract_source_paths: list[str] = []
     for source_path, target_path in rename_pairs:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        if target_path.exists() and force:
-            target_path.unlink()
         source_path.replace(target_path)
         renamed_contract_paths.append(str(target_path))
+        renamed_contract_source_paths.append(str(source_path))
 
     contract_path.write_text(
         render_workflow_markdown(config=config, prompt_template=workflow_policy),
@@ -2024,6 +2063,7 @@ def scaffold_workflow_root(
         "force": force,
         "workflow_contract_pointer_path": str(workflow_contract_pointer_path(root)),
         "renamed_contract_paths": renamed_contract_paths,
+        "renamed_contract_source_paths": renamed_contract_source_paths,
     }
 
 

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -20,6 +20,8 @@ The harness tests should catch these regressions before review:
 - public docs must describe the GitHub-first path clearly
 - public examples must use generic placeholders like `your-org/your-repo`
 - bundled workflow templates must match their public docs copies
+- bootstrap must safely promote `WORKFLOW.md` to `WORKFLOW-<workflow>.md`
+  without overwriting existing named contracts
 - project-specific playground names must not leak outside `daedalus/projects/**`
 - installation docs must keep the landing-page quick start short and link to
   detailed operator docs
@@ -30,7 +32,5 @@ Add tests for the next hardening slice in this order:
 
 1. GitHub issue selection, dispatch, and terminal reconciliation smoke against a
    real test repository.
-2. `WORKFLOW*.md` bootstrap branch creation and update behavior when a repo
-   already has one workflow contract.
-3. Codex app-server diagnostics for managed and external service modes.
-4. CLI/docs drift checks for every command shown in the install guide.
+2. Codex app-server diagnostics for managed and external service modes.
+3. CLI/docs drift checks for every command shown in the install guide.

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -74,9 +74,9 @@ workflow instead, run `hermes daedalus bootstrap --workflow issue-runner`.
 - detects the git repo root from the current checkout
 - derives `github-slug` from `origin`
 - creates the supported instance layout below
-- writes the repo-owned workflow contract
+- writes or promotes the repo-owned workflow contract
 - creates a dedicated bootstrap branch
-- commits the workflow contract file
+- commits the workflow contract changes
 - writes `./.hermes/daedalus/workflow-root` in the repo checkout so later
   Daedalus commands can resolve the workflow root automatically
 
@@ -123,12 +123,24 @@ to:
 /path/to/repo/WORKFLOW-issue-runner.md
 ```
 
+Promotion is fail-safe. If `WORKFLOW.md` exists but is not a Daedalus contract,
+bootstrap stops and leaves the file unchanged. If a target named contract
+already exists, bootstrap also stops instead of overwriting user edits.
+
 ## Configure the workflow
 
-Edit:
+Edit the path printed by `bootstrap` as `edit next`. For a repo with one
+workflow this is usually:
 
 ```text
 /path/to/repo/WORKFLOW.md
+```
+
+For a repo with multiple workflows, edit the workflow-specific file, for
+example:
+
+```text
+/path/to/repo/WORKFLOW-issue-runner.md
 ```
 
 At minimum, set:

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -9,6 +9,8 @@ These are the surfaces we should treat as `v1` public contract:
 - repo-owned workflow contracts:
   - `WORKFLOW.md` when a repo carries one workflow
   - `WORKFLOW-<workflow>.md` when a repo carries multiple workflows
+  - bootstrap promotion from `WORKFLOW.md` to named contracts must not
+    overwrite existing named contracts
 - legacy `config/workflow.yaml` loading for existing instances
 - `hermes plugins install attmous/daedalus --enable`
 - the `hermes_agent.plugins` entry point name `daedalus`

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -16,3 +16,14 @@ its own lifecycle, prompts, gates, and operator commands.
 - Generic docs such as [architecture](../architecture.md), [public contract](../public-contract.md), [security](../security.md), and the engine-level concept docs describe Daedalus itself.
 - Workflow docs describe the lifecycle and contract details that belong to one workflow package.
 - If a doc is mostly about GitHub review gates, PR publish/merge stages, or reviewer roles, it belongs to `change-delivery`, not to the generic engine story.
+
+## Repo Contract Naming
+
+Daedalus uses `WORKFLOW.md` when a repository carries one workflow. When you
+bootstrap a second workflow, Daedalus promotes the existing default contract to
+`WORKFLOW-<existing-workflow>.md` and writes the new contract to
+`WORKFLOW-<new-workflow>.md`.
+
+Bootstrap does not overwrite existing named workflow contracts. If
+`WORKFLOW.md` is a non-Daedalus file, rename it manually or choose a different
+repo before running `hermes daedalus bootstrap`.

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from workflows.contract import load_workflow_contract_file
+from workflows.contract import load_workflow_contract_file, render_workflow_markdown
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
@@ -115,6 +115,130 @@ def test_bootstrap_issue_runner_recommends_service_up(tmp_path, monkeypatch):
 
     assert result["next_command"] == "hermes daedalus service-up"
     assert result["git_branch"] == "daedalus/bootstrap-issue-runner"
+
+
+def test_bootstrap_second_workflow_promotes_default_contract_without_clobbering(tmp_path, monkeypatch):
+    tools = _tools()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@github.com:attmous/daedalus.git")
+
+    first = tools.bootstrap_workflow_root(
+        repo_path=repo_root,
+        workflow_name="change-delivery",
+        workflow_root=None,
+        github_slug=None,
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=False,
+    )
+    assert Path(first["contract_path"]) == repo_root / "WORKFLOW.md"
+
+    second = tools.bootstrap_workflow_root(
+        repo_path=repo_root,
+        workflow_name="issue-runner",
+        workflow_root=None,
+        github_slug=None,
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=False,
+    )
+
+    default_path = repo_root / "WORKFLOW.md"
+    change_delivery_path = repo_root / "WORKFLOW-change-delivery.md"
+    issue_runner_path = repo_root / "WORKFLOW-issue-runner.md"
+    issue_root = home / ".hermes" / "workflows" / "attmous-daedalus-issue-runner"
+
+    assert not default_path.exists()
+    assert change_delivery_path.exists()
+    assert issue_runner_path.exists()
+    assert load_workflow_contract_file(change_delivery_path).config["workflow"] == "change-delivery"
+    assert load_workflow_contract_file(issue_runner_path).config["workflow"] == "issue-runner"
+    assert second["contract_path"] == str(issue_runner_path)
+    assert second["next_edit_path"] == str(issue_runner_path)
+    assert second["renamed_contract_paths"] == [str(change_delivery_path)]
+    assert second["renamed_contract_source_paths"] == [str(default_path)]
+    assert second["git_branch"] == "daedalus/bootstrap-issue-runner"
+    assert second["git_commit_message"] == "Add issue-runner workflow contract"
+    assert (issue_root / "config" / "workflow-contract-path").read_text(encoding="utf-8").strip() == str(issue_runner_path.resolve())
+
+    show = subprocess.run(
+        ["git", "show", "--name-status", "--format=%s", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "Add issue-runner workflow contract" in show
+    assert (
+        "D\tWORKFLOW.md" in show
+        or "R100\tWORKFLOW.md\tWORKFLOW-change-delivery.md" in show
+    )
+    assert "A\tWORKFLOW-issue-runner.md" in show
+
+
+def test_bootstrap_rejects_non_daedalus_workflow_md_without_changes(tmp_path, monkeypatch):
+    tools = _tools()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@github.com:attmous/daedalus.git")
+    contract_path = repo_root / "WORKFLOW.md"
+    contract_path.write_text("# Existing project workflow\n\nDo not overwrite me.\n", encoding="utf-8")
+
+    with pytest.raises(tools.DaedalusCommandError) as exc:
+        tools.bootstrap_workflow_root(
+            repo_path=repo_root,
+            workflow_name="issue-runner",
+            workflow_root=None,
+            github_slug=None,
+            active_lane_label="active-lane",
+            engine_owner="hermes",
+            force=False,
+        )
+
+    assert "not a Daedalus workflow contract" in str(exc.value)
+    assert contract_path.read_text(encoding="utf-8") == "# Existing project workflow\n\nDo not overwrite me.\n"
+    assert not (repo_root / "WORKFLOW-issue-runner.md").exists()
+
+
+def test_bootstrap_promotion_refuses_existing_named_target_even_with_force(tmp_path, monkeypatch):
+    tools = _tools()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@github.com:attmous/daedalus.git")
+    default_cfg = {"workflow": "change-delivery", "schema-version": 1}
+    (repo_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=default_cfg, prompt_template="Original default."),
+        encoding="utf-8",
+    )
+    target_path = repo_root / "WORKFLOW-change-delivery.md"
+    target_text = render_workflow_markdown(config=default_cfg, prompt_template="Existing named target.")
+    target_path.write_text(target_text, encoding="utf-8")
+
+    with pytest.raises(tools.DaedalusCommandError) as exc:
+        tools.bootstrap_workflow_root(
+            repo_path=repo_root,
+            workflow_name="issue-runner",
+            workflow_root=None,
+            github_slug=None,
+            active_lane_label="active-lane",
+            engine_owner="hermes",
+            force=True,
+        )
+
+    assert "will not overwrite repo-owned workflow contracts" in str(exc.value)
+    assert (repo_root / "WORKFLOW.md").exists()
+    assert target_path.read_text(encoding="utf-8") == target_text
+    assert not (repo_root / "WORKFLOW-issue-runner.md").exists()
 
 
 def test_bootstrap_workflow_requires_git_repo(tmp_path):


### PR DESCRIPTION
## Summary

- Harden bootstrap promotion from `WORKFLOW.md` to `WORKFLOW-<workflow>.md` for multi-workflow repos.
- Reject non-Daedalus `WORKFLOW.md` files and existing named target contracts without overwriting user edits, even with `--force`.
- Stage tracked default-contract deletion/rename during bootstrap commits and expose the commit message in the bootstrap result.
- Document single-workflow vs multi-workflow contract naming and fail-safe promotion behavior.

## Validation

- `pytest tests/test_tools_bootstrap_workflow.py tests/test_tools_scaffold_workflow.py tests/test_public_onboarding_smoke.py tests/test_public_harness_checks.py -q`
- `pytest -q`
- `git diff --check`