### PR TITLE
[codex] add codex app-server doctor

### DIFF
--- a/daedalus/tools.py
+++ b/daedalus/tools.py
@@ -1,6 +1,7 @@
 import argparse
 import http.client
 import importlib.util
+import ipaddress
 import io
 import json
 import os
@@ -939,6 +940,400 @@ def codex_app_server_status(
         "active_check": active,
         "enabled_check": enabled,
         "show": show,
+    }
+
+
+def _codex_app_server_unit_tokens(unit_path: Path) -> list[str]:
+    if not unit_path.exists():
+        return []
+    try:
+        text = unit_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    for line in text.splitlines():
+        if line.startswith("ExecStart="):
+            try:
+                return shlex.split(line.split("=", 1)[1])
+            except ValueError:
+                return []
+    return []
+
+
+def _codex_app_server_token_value(tokens: list[str], flag: str) -> str | None:
+    try:
+        index = tokens.index(flag)
+    except ValueError:
+        return None
+    if index + 1 >= len(tokens):
+        return None
+    return tokens[index + 1]
+
+
+def _codex_app_server_listen_from_unit(unit_path: Path) -> str | None:
+    tokens = _codex_app_server_unit_tokens(unit_path)
+    return _codex_app_server_token_value(tokens, "--listen")
+
+
+def _codex_app_server_auth_summary_from_unit(unit_path: Path) -> dict[str, Any] | None:
+    tokens = _codex_app_server_unit_tokens(unit_path)
+    auth_mode = _codex_app_server_token_value(tokens, "--ws-auth")
+    if not auth_mode:
+        return None
+    summary: dict[str, Any] = {"mode": auth_mode, "source": "unit"}
+    token_file = _codex_app_server_token_value(tokens, "--ws-token-file")
+    token_sha256 = _codex_app_server_token_value(tokens, "--ws-token-sha256")
+    shared_secret_file = _codex_app_server_token_value(tokens, "--ws-shared-secret-file")
+    issuer = _codex_app_server_token_value(tokens, "--ws-issuer")
+    audience = _codex_app_server_token_value(tokens, "--ws-audience")
+    max_skew = _codex_app_server_token_value(tokens, "--ws-max-clock-skew-seconds")
+    if token_file:
+        summary["token_file"] = token_file
+    if token_sha256:
+        summary["token_sha256"] = token_sha256
+    if shared_secret_file:
+        summary["shared_secret_file"] = shared_secret_file
+    if issuer:
+        summary["issuer"] = issuer
+    if audience:
+        summary["audience"] = audience
+    if max_skew:
+        try:
+            summary["max_clock_skew_seconds"] = int(max_skew)
+        except ValueError:
+            summary["max_clock_skew_seconds"] = max_skew
+    return summary
+
+
+def _codex_app_server_endpoint_is_loopback(endpoint: str) -> bool:
+    hostname = urlparse(str(endpoint or "")).hostname
+    if not hostname:
+        return False
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _codex_app_server_scheduler_path(workflow_root: Path) -> Path:
+    configured_path: str | None = None
+    try:
+        contract = load_workflow_contract(workflow_root)
+        storage = contract.config.get("storage") if isinstance(contract.config, dict) else None
+        if isinstance(storage, dict):
+            configured_path = storage.get("scheduler") or storage.get("scheduler-path")
+    except Exception:
+        configured_path = None
+    raw_path = str(configured_path or "memory/workflow-scheduler.json")
+    path = Path(raw_path)
+    return path if path.is_absolute() else workflow_root / path
+
+
+def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
+    scheduler_path = _codex_app_server_scheduler_path(workflow_root)
+    if not scheduler_path.exists():
+        return {
+            "ok": True,
+            "path": str(scheduler_path),
+            "exists": False,
+            "threads": [],
+            "totals": {},
+            "invalid_thread_count": 0,
+            "error": None,
+        }
+    try:
+        scheduler = json.loads(scheduler_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "ok": False,
+            "path": str(scheduler_path),
+            "exists": True,
+            "threads": [],
+            "totals": {},
+            "invalid_thread_count": 0,
+            "error": str(exc),
+        }
+    raw_threads = scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}
+    threads: list[dict[str, Any]] = []
+    invalid_thread_count = 0
+    if isinstance(raw_threads, dict):
+        for issue_id, raw_entry in sorted(raw_threads.items(), key=lambda item: str(item[0])):
+            if not isinstance(raw_entry, dict):
+                invalid_thread_count += 1
+                continue
+            thread_id = raw_entry.get("thread_id") or raw_entry.get("threadId")
+            if not str(thread_id or "").strip():
+                invalid_thread_count += 1
+            issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+            threads.append(
+                {
+                    "issue_id": raw_entry.get("issue_id") or issue_id,
+                    "issue_number": issue_number,
+                    "identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
+                    "session_name": raw_entry.get("session_name") or raw_entry.get("sessionName"),
+                    "runtime_name": raw_entry.get("runtime_name") or raw_entry.get("runtimeName"),
+                    "runtime_kind": raw_entry.get("runtime_kind") or raw_entry.get("runtimeKind"),
+                    "thread_id": thread_id,
+                    "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                    "status": raw_entry.get("status"),
+                    "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
+                    "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
+                    "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+                }
+            )
+    totals = scheduler.get("codex_totals") or scheduler.get("codexTotals") or {}
+    return {
+        "ok": invalid_thread_count == 0,
+        "path": str(scheduler_path),
+        "exists": True,
+        "threads": threads,
+        "totals": totals if isinstance(totals, dict) else {},
+        "invalid_thread_count": invalid_thread_count,
+        "error": None,
+    }
+
+
+def _codex_app_server_doctor_check(
+    name: str,
+    status: str,
+    detail: str,
+    *,
+    severity: str = "critical",
+    remedy: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "name": name,
+        "status": status,
+        "severity": severity,
+        "detail": detail,
+    }
+    if remedy:
+        payload["remedy"] = remedy
+    return payload
+
+
+def _codex_app_server_secret_paths(auth_summary: dict[str, Any] | None) -> list[str]:
+    if not auth_summary:
+        return []
+    paths = []
+    for key in ("token_file", "shared_secret_file"):
+        value = str(auth_summary.get(key) or "").strip()
+        if value:
+            paths.append(value)
+    return paths
+
+
+def codex_app_server_doctor(
+    *,
+    workflow_root: Path,
+    mode: str = "managed",
+    service_name: str | None = None,
+    endpoint: str | None = None,
+    healthcheck_path: str = DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH,
+    ws_token_file: str | None = None,
+    ws_token_sha256: str | None = None,
+    ws_shared_secret_file: str | None = None,
+    ws_issuer: str | None = None,
+    ws_audience: str | None = None,
+    ws_max_clock_skew_seconds: int | None = None,
+) -> dict[str, Any]:
+    if mode not in {"managed", "external"}:
+        raise DaedalusCommandError("--mode must be managed or external")
+
+    resolved_service_name = _codex_app_server_service_name(
+        workflow_root=workflow_root,
+        service_name=service_name,
+    )
+    unit_path = _codex_app_server_unit_path(resolved_service_name)
+    effective_endpoint = str(endpoint or "").strip()
+    if not effective_endpoint and mode == "managed":
+        effective_endpoint = _codex_app_server_listen_from_unit(unit_path) or DEFAULT_CODEX_APP_SERVER_LISTEN
+    if not effective_endpoint:
+        effective_endpoint = DEFAULT_CODEX_APP_SERVER_LISTEN
+
+    _auth_args, cli_auth_summary = _codex_app_server_ws_auth_args(
+        ws_token_file=ws_token_file,
+        ws_token_sha256=ws_token_sha256,
+        ws_shared_secret_file=ws_shared_secret_file,
+        ws_issuer=ws_issuer,
+        ws_audience=ws_audience,
+        ws_max_clock_skew_seconds=ws_max_clock_skew_seconds,
+    )
+    unit_auth_summary = _codex_app_server_auth_summary_from_unit(unit_path) if mode == "managed" else None
+    auth_summary = cli_auth_summary or unit_auth_summary
+    if auth_summary and auth_summary is cli_auth_summary:
+        auth_summary = {**auth_summary, "source": "cli"}
+
+    checks: list[dict[str, Any]] = []
+    status_result: dict[str, Any] | None = None
+    if mode == "managed":
+        status_result = codex_app_server_status(
+            workflow_root=workflow_root,
+            service_name=resolved_service_name,
+            endpoint=effective_endpoint,
+            healthcheck_path=healthcheck_path,
+        )
+        checks.append(
+            _codex_app_server_doctor_check(
+                "managed-unit-file",
+                "pass" if unit_path.exists() else "fail",
+                str(unit_path),
+                remedy="run `hermes daedalus codex-app-server install` or `up`",
+            )
+        )
+        active = str(status_result.get("active") or "unknown")
+        checks.append(
+            _codex_app_server_doctor_check(
+                "managed-service-active",
+                "pass" if active == "active" else "fail",
+                active,
+                remedy="run `hermes daedalus codex-app-server up` or inspect `logs`",
+            )
+        )
+        enabled = str(status_result.get("enabled") or "unknown")
+        checks.append(
+            _codex_app_server_doctor_check(
+                "managed-service-enabled",
+                "pass" if enabled == "enabled" else "warn",
+                enabled,
+                severity="warning",
+                remedy="run `hermes daedalus codex-app-server up` if the listener should start on login",
+            )
+        )
+        ready = status_result.get("ready") or {}
+    else:
+        ready = _codex_app_server_readyz(endpoint=effective_endpoint, healthcheck_path=healthcheck_path)
+        checks.append(
+            _codex_app_server_doctor_check(
+                "managed-unit-file",
+                "skip",
+                "external mode uses a listener started outside Daedalus",
+                severity="info",
+            )
+        )
+
+    parsed_endpoint = urlparse(effective_endpoint)
+    endpoint_shape_ok = parsed_endpoint.scheme == "ws" and bool(parsed_endpoint.hostname) and bool(parsed_endpoint.port)
+    checks.append(
+        _codex_app_server_doctor_check(
+            "endpoint-shape",
+            "pass" if endpoint_shape_ok else "fail",
+            effective_endpoint,
+            remedy="use a ws://host:port endpoint such as ws://127.0.0.1:4500",
+        )
+    )
+
+    if ready.get("ok") is True:
+        checks.append(_codex_app_server_doctor_check("readyz", "pass", f"{effective_endpoint}{healthcheck_path}"))
+    elif ready.get("checked") is False:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "readyz",
+                "warn",
+                str(ready.get("reason") or "readiness probe was skipped"),
+                severity="warning",
+            )
+        )
+    else:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "readyz",
+                "fail",
+                str(ready.get("reason") or "readiness probe failed"),
+                remedy="start the listener or inspect `hermes daedalus codex-app-server logs`",
+            )
+        )
+
+    missing_secret_paths = [path for path in _codex_app_server_secret_paths(auth_summary) if not Path(path).exists()]
+    if missing_secret_paths:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "websocket-auth",
+                "fail",
+                "missing secret file(s): " + ", ".join(missing_secret_paths),
+                remedy="create the configured secret files or reinstall the Codex app-server unit with valid auth flags",
+            )
+        )
+    elif auth_summary:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "websocket-auth",
+                "pass",
+                f"{auth_summary.get('mode')} from {auth_summary.get('source', 'config')}",
+            )
+        )
+    elif _codex_app_server_endpoint_is_loopback(effective_endpoint):
+        checks.append(
+            _codex_app_server_doctor_check(
+                "websocket-auth",
+                "pass",
+                "loopback endpoint does not require WebSocket auth",
+            )
+        )
+    else:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "websocket-auth",
+                "fail",
+                "non-loopback endpoint has no declared WebSocket auth",
+                remedy="use --ws-token-file, --ws-token-sha256, or --ws-shared-secret-file",
+            )
+        )
+
+    scheduler = _load_codex_scheduler_snapshot(workflow_root)
+    if scheduler.get("error"):
+        checks.append(
+            _codex_app_server_doctor_check(
+                "scheduler-thread-map",
+                "fail",
+                f"{scheduler.get('path')}: {scheduler.get('error')}",
+                remedy="repair or remove the scheduler JSON state file",
+            )
+        )
+    elif not scheduler.get("exists"):
+        checks.append(
+            _codex_app_server_doctor_check(
+                "scheduler-thread-map",
+                "warn",
+                f"{scheduler.get('path')} does not exist yet",
+                severity="warning",
+            )
+        )
+    elif scheduler.get("invalid_thread_count"):
+        checks.append(
+            _codex_app_server_doctor_check(
+                "scheduler-thread-map",
+                "fail",
+                f"{scheduler.get('invalid_thread_count')} Codex thread mapping(s) are missing thread_id",
+                remedy="let the workflow retry the affected work item or clear the invalid mapping",
+            )
+        )
+    else:
+        checks.append(
+            _codex_app_server_doctor_check(
+                "scheduler-thread-map",
+                "pass",
+                f"{len(scheduler.get('threads') or [])} Codex thread mapping(s)",
+            )
+        )
+
+    ok = all(check.get("status") != "fail" for check in checks)
+    return {
+        "ok": ok,
+        "action": "doctor",
+        "mode": mode,
+        "workflow_root": str(workflow_root),
+        "service_name": resolved_service_name,
+        "unit_path": str(unit_path),
+        "endpoint": effective_endpoint,
+        "healthcheck_path": healthcheck_path,
+        "ws_auth": auth_summary,
+        "status": status_result,
+        "ready": ready,
+        "scheduler": scheduler,
+        "threads": scheduler.get("threads") or [],
+        "checks": checks,
     }
 
 
@@ -2640,6 +3035,22 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     )
     codex_status_cmd.set_defaults(func=run_cli_command)
 
+    codex_doctor_cmd = codex_sub.add_parser("doctor", help="Run actionable Codex app-server diagnostics.")
+    codex_doctor_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    codex_doctor_cmd.add_argument("--mode", choices=["managed", "external"], default="managed")
+    codex_doctor_cmd.add_argument("--service-name")
+    codex_doctor_cmd.add_argument("--endpoint")
+    codex_doctor_cmd.add_argument("--healthcheck-path", default=DEFAULT_CODEX_APP_SERVER_HEALTHCHECK_PATH)
+    _add_codex_app_server_auth_args(codex_doctor_cmd)
+    codex_doctor_cmd.add_argument("--json", action="store_true")
+    codex_doctor_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    codex_doctor_cmd.set_defaults(func=run_cli_command)
+
     codex_down_cmd = codex_sub.add_parser("down", help="Stop and disable the Codex app-server user unit.")
     codex_down_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     codex_down_cmd.add_argument("--service-name")
@@ -2910,6 +3321,20 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
                 endpoint=args.endpoint,
                 healthcheck_path=args.healthcheck_path,
             )
+        if action == "doctor":
+            return codex_app_server_doctor(
+                workflow_root=workflow_root,
+                mode=args.mode,
+                service_name=args.service_name,
+                endpoint=args.endpoint,
+                healthcheck_path=args.healthcheck_path,
+                ws_token_file=args.ws_token_file,
+                ws_token_sha256=args.ws_token_sha256,
+                ws_shared_secret_file=args.ws_shared_secret_file,
+                ws_issuer=args.ws_issuer,
+                ws_audience=args.ws_audience,
+                ws_max_clock_skew_seconds=args.ws_max_clock_skew_seconds,
+            )
         if action == "down":
             return codex_app_server_down(
                 workflow_root=workflow_root,
@@ -3122,6 +3547,18 @@ def render_result(
                 f"codex-app-server service={result.get('service_name')} "
                 f"installed={result.get('installed')} active={result.get('active')} "
                 f"enabled={result.get('enabled')} ready={ready.get('ok')}"
+            )
+        if action == "doctor":
+            failed = [check for check in result.get("checks") or [] if check.get("status") == "fail"]
+            warned = [check for check in result.get("checks") or [] if check.get("status") == "warn"]
+            first_problem = failed[0] if failed else (warned[0] if warned else None)
+            suffix = ""
+            if first_problem:
+                suffix = f" first_problem={first_problem.get('name')}:{first_problem.get('detail')}"
+            return (
+                f"codex-app-server doctor ok={result.get('ok')} mode={result.get('mode')} "
+                f"endpoint={result.get('endpoint')} failures={len(failed)} warnings={len(warned)}"
+                f"{suffix}"
             )
     if command == "ingest-live":
         return f"ingested lane={result.get('lane_id')} actor={result.get('actor_id')}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Day-2 commands and observability.
 
 - [Cheat sheet](operator/cheat-sheet.md) — quickest path to a useful answer
 - [Slash commands](operator/slash-commands.md) — every `/daedalus` and `/workflow` form
+- [Codex app-server operations](operator/codex-app-server.md) — managed/external listener diagnostics
 - [HTTP status surface](operator/http-status.md) — workflow-scoped JSON + HTML endpoints
 - [GitHub smoke test](operator/github-smoke.md) — skipped-by-default live test for the supported tracker path
 

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -98,6 +98,7 @@ user service:
 hermes daedalus codex-app-server install
 hermes daedalus codex-app-server up
 hermes daedalus codex-app-server status
+hermes daedalus codex-app-server doctor
 hermes daedalus codex-app-server logs
 ```
 
@@ -126,6 +127,8 @@ hermes daedalus codex-app-server up \
 Client-side runtime config can then use `ws_token_file` or `ws_token_env` so
 Daedalus presents `Authorization: Bearer <token>` during the WebSocket
 handshake. `status` includes both systemd state and a `GET /readyz` probe.
+`doctor` adds managed/external diagnostics, auth validation, and persisted
+Codex thread mappings from workflow scheduler state.
 
 Then configure Daedalus for external mode:
 

--- a/docs/operator/codex-app-server.md
+++ b/docs/operator/codex-app-server.md
@@ -1,0 +1,63 @@
+# Codex app-server Operations
+
+Daedalus can use Codex app-server in two service shapes.
+
+## Managed Mode
+
+Managed mode means Daedalus owns a systemd user unit for the shared listener.
+Use this when the workflow host should start the listener automatically.
+
+```bash
+hermes daedalus codex-app-server up
+hermes daedalus codex-app-server doctor
+```
+
+The default listener is `ws://127.0.0.1:4500`. If the unit was installed with a
+different `--listen` value, `doctor` reads it from the unit file.
+
+Use logs when the service is installed but not active:
+
+```bash
+hermes daedalus codex-app-server logs --lines 100
+```
+
+## External Mode
+
+External mode means another process owns the listener. Daedalus only connects
+to its WebSocket endpoint.
+
+```bash
+hermes daedalus codex-app-server doctor \
+  --mode external \
+  --endpoint ws://127.0.0.1:4500
+```
+
+External mode skips systemd checks and validates endpoint shape, `GET /readyz`,
+WebSocket auth posture, and durable thread mappings.
+
+## Auth Checks
+
+Loopback listeners do not require WebSocket auth. Non-loopback listeners should
+declare one auth mode:
+
+```bash
+hermes daedalus codex-app-server up \
+  --ws-token-file /absolute/path/to/codex-app-server.token
+```
+
+`doctor` fails if a non-loopback endpoint has no declared auth, or if the
+configured token/shared-secret file is missing.
+
+## Thread Mapping Checks
+
+Daedalus persists Codex `issue_id -> thread_id` mappings in the workflow
+scheduler state, normally:
+
+```text
+<workflow-root>/memory/workflow-scheduler.json
+```
+
+`doctor --json` surfaces those mappings with issue id, identifier, session
+name, thread id, turn id, status, cancellation state, and update time. Missing
+thread ids are treated as broken state because future ticks cannot resume the
+right Codex thread.

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -179,10 +179,12 @@ hermes daedalus codex-app-server up
 ```
 
 Then point the workflow runtime at `ws://127.0.0.1:4500`.
-Use `hermes daedalus codex-app-server status`, `restart`, and `logs` for
-operator checks. If the listener is not loopback-only, pass one of the supported
-auth flags during `install` or `up`, for example
-`--ws-token-file /absolute/path/to/token`.
+Use `hermes daedalus codex-app-server doctor` for the full operator check:
+managed service state, readiness, auth posture, and persisted Codex thread
+mappings. If the listener is not loopback-only, pass one of the supported auth
+flags during `install` or `up`, for example `--ws-token-file
+/absolute/path/to/token`. See [Codex app-server operations](codex-app-server.md)
+for external-mode diagnostics and troubleshooting.
 
 ## Manual low-level path
 

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -165,6 +165,7 @@ Daedalus service
 | `/daedalus codex-app-server install` | Write the shared Codex app-server user unit |
 | `/daedalus codex-app-server up` | Install, enable, and start the shared Codex app-server |
 | `/daedalus codex-app-server status` | Show unit status plus `GET /readyz` readiness |
+| `/daedalus codex-app-server doctor` | Diagnose managed/external listener health, auth posture, and Codex thread mappings |
 | `/daedalus codex-app-server restart` | Restart the Codex app-server unit |
 | `/daedalus codex-app-server logs` | Last N Codex app-server journal entries |
 | `/daedalus codex-app-server down` | Stop and disable Codex app-server |

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -179,6 +179,139 @@ def test_codex_app_server_status_includes_ready_probe(tmp_path, monkeypatch):
     assert result["ready"]["endpoint"] == "ws://127.0.0.1:4500"
 
 
+def test_codex_app_server_doctor_reports_managed_health_and_threads(tmp_path, monkeypatch):
+    tools = load_tools()
+    systemd_dir = tmp_path / "systemd"
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_dir))
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    (workflow_root / "memory").mkdir()
+    (workflow_root / "memory" / "workflow-scheduler.json").write_text(
+        json.dumps(
+            {
+                "codex_threads": {
+                    "ISSUE-1": {
+                        "issue_id": "ISSUE-1",
+                        "identifier": "DAE-1",
+                        "session_name": "issue-1",
+                        "runtime_kind": "codex-app-server",
+                        "thread_id": "thread-1",
+                        "turn_id": "turn-1",
+                        "updated_at": "2026-04-30T00:00:00Z",
+                    }
+                },
+                "codex_totals": {"total_tokens": 42, "turn_count": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    token_file = tmp_path / "codex.token"
+    token_file.write_text("secret", encoding="utf-8")
+    service_name = tools._codex_app_server_service_name(workflow_root=workflow_root)
+    unit_path = systemd_dir / service_name
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(
+        tools._render_codex_app_server_unit(
+            listen="ws://127.0.0.1:4600",
+            codex_command="codex",
+            ws_token_file=str(token_file),
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_systemctl(*args):
+        if args[0] == "is-active":
+            stdout = "active"
+        elif args[0] == "is-enabled":
+            stdout = "enabled"
+        elif args[0] == "show":
+            stdout = "ActiveState=active\nSubState=running\nUnitFileState=enabled"
+        else:
+            stdout = ""
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "command": ["systemctl", "--user", *args],
+        }
+
+    monkeypatch.setattr(tools, "_run_systemctl", fake_systemctl)
+    monkeypatch.setattr(tools, "_codex_app_server_readyz", lambda **kwargs: {"ok": True, "checked": True, **kwargs})
+
+    result = tools.codex_app_server_doctor(workflow_root=workflow_root)
+
+    checks = {check["name"]: check for check in result["checks"]}
+    assert result["ok"] is True
+    assert result["endpoint"] == "ws://127.0.0.1:4600"
+    assert checks["managed-unit-file"]["status"] == "pass"
+    assert checks["managed-service-active"]["status"] == "pass"
+    assert checks["websocket-auth"]["status"] == "pass"
+    assert checks["scheduler-thread-map"]["status"] == "pass"
+    assert result["threads"][0]["thread_id"] == "thread-1"
+    assert result["scheduler"]["totals"]["total_tokens"] == 42
+
+
+def test_codex_app_server_doctor_external_requires_auth_for_non_loopback(tmp_path, monkeypatch):
+    tools = load_tools()
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(tmp_path / "systemd"))
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    monkeypatch.setattr(tools, "_codex_app_server_readyz", lambda **kwargs: {"ok": True, "checked": True, **kwargs})
+
+    result = tools.codex_app_server_doctor(
+        workflow_root=workflow_root,
+        mode="external",
+        endpoint="ws://example.com:4500",
+    )
+
+    checks = {check["name"]: check for check in result["checks"]}
+    assert result["ok"] is False
+    assert checks["managed-unit-file"]["status"] == "skip"
+    assert checks["readyz"]["status"] == "pass"
+    assert checks["websocket-auth"]["status"] == "fail"
+
+
+def test_codex_app_server_doctor_json_dispatch(tmp_path, monkeypatch):
+    tools = load_tools()
+    systemd_dir = tmp_path / "systemd"
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_dir))
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    service_name = tools._codex_app_server_service_name(workflow_root=workflow_root)
+    unit_path = systemd_dir / service_name
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(
+        tools._render_codex_app_server_unit(listen="ws://127.0.0.1:4500", codex_command="codex"),
+        encoding="utf-8",
+    )
+
+    def fake_systemctl(*args):
+        stdout = ""
+        if args[0] == "is-active":
+            stdout = "active"
+        elif args[0] == "is-enabled":
+            stdout = "enabled"
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "command": ["systemctl", "--user", *args],
+        }
+
+    monkeypatch.setattr(tools, "_run_systemctl", fake_systemctl)
+    monkeypatch.setattr(tools, "_codex_app_server_readyz", lambda **kwargs: {"ok": True, "checked": True, **kwargs})
+
+    output = tools.execute_raw_args(f"codex-app-server doctor --workflow-root {workflow_root} --json")
+    payload = json.loads(output)
+
+    assert payload["action"] == "doctor"
+    assert payload["ok"] is True
+    assert payload["mode"] == "managed"
+    assert any(check["name"] == "scheduler-thread-map" for check in payload["checks"])
+
+
 def test_codex_app_server_restart_and_logs(tmp_path, monkeypatch):
     tools = load_tools()
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"


### PR DESCRIPTION
## Summary

Adds an operator-facing `hermes daedalus codex-app-server doctor` command for diagnosing Codex app-server setups.

The command supports managed and external modes, validates systemd unit state when Daedalus owns the listener, probes `GET /readyz`, checks WebSocket auth posture, and surfaces persisted Codex `issue_id -> thread_id` mappings from workflow scheduler state.

## Operator impact

Operators get one command for the common Codex app-server failure modes instead of stitching together `status`, `logs`, scheduler JSON, and auth inspection manually. The docs now describe managed vs external mode and when non-loopback listeners must declare auth.

## Validation

- `pytest tests/test_systemd_template_units.py`
- `pytest tests/test_systemd_template_units.py tests/test_runtimes_codex_app_server.py tests/test_daedalus_watch_sources.py tests/test_status_server.py`
- `pytest` (`819 passed, 7 skipped`)