### PR TITLE
[codex] add codex app-server smoke harness

### DIFF
--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -1060,10 +1060,10 @@ class CodexAppServerRuntime:
         return f"codex-app-server exited with code {returncode}"
 
     def _coerce_usage(self, payload: dict[str, Any], *, current: dict[str, int]) -> dict[str, int]:
-        if isinstance(payload.get("total"), dict):
-            payload = payload["total"]
-        elif isinstance(payload.get("last"), dict):
+        if isinstance(payload.get("last"), dict):
             payload = payload["last"]
+        elif isinstance(payload.get("total"), dict):
+            payload = payload["total"]
 
         input_tokens = payload.get("input_tokens")
         if input_tokens is None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Day-2 commands and observability.
 - [Slash commands](operator/slash-commands.md) — every `/daedalus` and `/workflow` form
 - [HTTP status surface](operator/http-status.md) — workflow-scoped JSON + HTML endpoints
 - [GitHub smoke test](operator/github-smoke.md) — skipped-by-default live test for the supported tracker path
+- [Codex app-server smoke tests](operator/codex-app-server-smoke.md) — fake CI harness and opt-in real runtime smoke
 
 ## Workflow docs
 

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -152,8 +152,11 @@ app-server when it exposes a socket transport. Setting `keep_alive: true` with
 managed stdio mode is invalid and fails config loading.
 
 It maps `thread/tokenUsage/updated` into Daedalus token totals and
-`account/rateLimits/updated` into the latest rate-limit snapshot. It rejects
-non-interactive approval requests so an unattended service does not hang.
+`account/rateLimits/updated` into the latest rate-limit snapshot. When Codex
+emits both `tokenUsage.last` and cumulative `tokenUsage.total`, Daedalus records
+`last` as the per-turn delta so resumed threads do not double-count cumulative
+totals. It rejects non-interactive approval requests so an unattended service
+does not hang.
 Bundled workflows persist work-item thread mappings in scheduler state
 (`issue-runner`: `issue_id -> thread_id`; `change-delivery`:
 `lane:<issue-number> -> thread_id`) and resume the existing Codex thread on

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -27,6 +27,8 @@ The harness tests should catch these regressions before review:
   detailed operator docs
 - Codex app-server tests must cover fake protocol behavior in CI and keep the
   real app-server smoke opt-in
+- Issue-runner cleanup tests must prove `before_remove` runs before terminal
+  workspaces are deleted
 
 ## Next Checks
 
@@ -35,7 +37,7 @@ Add tests for the next hardening slice in this order:
 1. CLI/docs drift checks for every command shown in the install guide.
 2. End-to-end `change-delivery` Codex app-server smoke around a real active
    lane, PR update, and review loop.
-3. External WebSocket auth smoke using a local token-protected listener.
+3. Live GitHub recovery coverage for labels, comments, and failure replay.
 
 ## Live GitHub Smoke
 

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -25,15 +25,17 @@ The harness tests should catch these regressions before review:
 - project-specific playground names must not leak outside `daedalus/projects/**`
 - installation docs must keep the landing-page quick start short and link to
   detailed operator docs
+- Codex app-server tests must cover fake protocol behavior in CI and keep the
+  real app-server smoke opt-in
 
 ## Next Checks
 
 Add tests for the next hardening slice in this order:
 
-1. `WORKFLOW*.md` bootstrap branch creation and update behavior when a repo
-   already has one workflow contract.
-2. Codex app-server diagnostics for managed and external service modes.
-3. CLI/docs drift checks for every command shown in the install guide.
+1. CLI/docs drift checks for every command shown in the install guide.
+2. End-to-end `change-delivery` Codex app-server smoke around a real active
+   lane, PR update, and review loop.
+3. External WebSocket auth smoke using a local token-protected listener.
 
 ## Live GitHub Smoke
 
@@ -46,3 +48,17 @@ pytest tests/test_github_issue_runner_smoke.py -q
 
 See [operator/github-smoke.md](operator/github-smoke.md) for setup and cleanup
 details.
+
+## Codex app-server Smoke
+
+The Codex app-server protocol harness runs in normal CI with a fake app-server.
+The real app-server smoke is skipped by default:
+
+```bash
+DAEDALUS_REAL_CODEX_APP_SERVER=1 \
+pytest tests/test_runtimes_codex_app_server.py \
+  -k real_smoke_start_and_resume -q -s
+```
+
+See [operator/codex-app-server-smoke.md](operator/codex-app-server-smoke.md)
+for the fake/real split and token accounting rule.

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -49,6 +49,7 @@
 |:---|:---|:---|
 | [**Slash Commands**](./slash-commands.md) | Complete catalog of `/daedalus` commands plus workflow-specific `/workflow <name> ...` surfaces for both bundled workflows. | ...you need to check what's happening or poke the system into action. |
 | [**HTTP Status Surface**](./http-status.md) | Optional localhost HTTP server (`:8765`) exposing JSON health snapshots for dashboards and external monitoring. | ...you want to monitor Daedalus without SSHing into the box. |
+| [**Codex app-server Smoke Tests**](./codex-app-server-smoke.md) | Fake CI harness and opt-in real Codex app-server smoke for start/resume behavior. | ...you changed Codex runtime/service behavior or want local production confidence. |
 
 **The narrative arc:** *Check status* → *Watch live* → *Diagnose* → *Fix* → *Confirm*.
 

--- a/docs/operator/codex-app-server-smoke.md
+++ b/docs/operator/codex-app-server-smoke.md
@@ -15,8 +15,8 @@ pytest tests/test_runtimes_codex_app_server.py \
 ```
 
 This verifies JSON-RPC start/resume, WebSocket reuse, cancellation,
-read/stall timeout behavior, token/rate-limit mapping, and workflow scheduler
-thread persistence.
+read/stall timeout behavior, token/rate-limit mapping, external WebSocket auth,
+malformed protocol failures, and workflow scheduler thread persistence.
 
 ## Real Local Smoke
 

--- a/docs/operator/codex-app-server-smoke.md
+++ b/docs/operator/codex-app-server-smoke.md
@@ -1,0 +1,52 @@
+# Codex app-server Smoke Tests
+
+Daedalus has two Codex app-server confidence layers.
+
+## CI Fake Harness
+
+The default tests use a deterministic fake app-server. They do not require a
+Codex install, model quota, or network access, and they can force protocol
+events that are hard to reproduce with a real model.
+
+```bash
+pytest tests/test_runtimes_codex_app_server.py \
+  tests/test_workflows_issue_runner_workspace.py \
+  -k codex
+```
+
+This verifies JSON-RPC start/resume, WebSocket reuse, cancellation,
+read/stall timeout behavior, token/rate-limit mapping, and workflow scheduler
+thread persistence.
+
+## Real Local Smoke
+
+Run the real smoke only on a machine with a working `codex` CLI and app-server
+auth. It starts a real `codex app-server` subprocess, sends a tiny prompt,
+persists the returned thread id, then resumes the same thread for a second
+tiny prompt.
+
+```bash
+DAEDALUS_REAL_CODEX_APP_SERVER=1 \
+pytest tests/test_runtimes_codex_app_server.py \
+  -k real_smoke_start_and_resume -q -s
+```
+
+Optional model override:
+
+```bash
+DAEDALUS_REAL_CODEX_MODEL=gpt-5.4-mini \
+DAEDALUS_REAL_CODEX_APP_SERVER=1 \
+pytest tests/test_runtimes_codex_app_server.py \
+  -k real_smoke_start_and_resume -q -s
+```
+
+Keep this test opt-in. It depends on local Codex installation, account state,
+quota, model availability, and live runtime timing. Use it before production
+changes to Codex runtime/service behavior, not as a required CI gate.
+
+## Token Accounting Rule
+
+When Codex emits both `tokenUsage.last` and cumulative `tokenUsage.total`,
+Daedalus records `last` as the per-turn delta for workflow totals. If only
+`total` is available, Daedalus uses that value. This avoids double-counting
+cumulative thread totals across resumed turns.

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -216,9 +216,11 @@ def _write_fake_cancellable_app_server(path: Path, requests_path: Path) -> None:
 
 
 class _FakeWebSocketAppServer:
-    def __init__(self):
+    def __init__(self, *, required_auth_token: str | None = None):
         self.requests: list[dict] = []
+        self.websocket_authorizations: list[str | None] = []
         self.websocket_connections = 0
+        self.required_auth_token = required_auth_token
         self._stop = threading.Event()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -260,6 +262,11 @@ class _FakeWebSocketAppServer:
                 return
             if headers.get("upgrade", "").lower() != "websocket":
                 conn.sendall(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+                return
+            authorization = headers.get("authorization")
+            self.websocket_authorizations.append(authorization)
+            if self.required_auth_token and authorization != f"Bearer {self.required_auth_token}":
+                conn.sendall(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n")
                 return
             self.websocket_connections += 1
             key = headers["sec-websocket-key"]
@@ -809,6 +816,41 @@ def test_codex_app_server_runtime_connects_to_external_websocket(tmp_path):
         "type": "workspaceWrite",
         "writableRoots": [str(tmp_path)],
     }
+
+
+def test_codex_app_server_runtime_sends_external_websocket_auth_token(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakeWebSocketAppServer(required_auth_token="secret-token") as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "ws_token": "secret-token",
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+
+        result = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-AUTH",
+            prompt="Do the thing",
+            model="gpt-5.5",
+        )
+
+    assert result.output == "ws ok\n"
+    assert result.thread_id == "thread-ws"
+    assert server.websocket_authorizations == ["Bearer secret-token"]
+    assert [item.get("method") for item in server.requests] == [
+        "initialize",
+        "initialized",
+        "thread/start",
+        "turn/start",
+    ]
 
 
 def test_codex_app_server_runtime_reuses_external_websocket_by_default(tmp_path):

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -1,6 +1,8 @@
 import base64
 import hashlib
 import json
+import os
+import shutil
 import socket
 import sys
 import threading
@@ -97,6 +99,31 @@ def _write_fake_resume_rejecting_app_server(path: Path, requests_path: Path) -> 
                 "        break",
                 "    elif method == 'thread/start':",
                 "        emit({'id': request_id, 'result': {'thread': {'id': 'unexpected-thread'}}})",
+                "        break",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_fake_malformed_app_server(path: Path, requests_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                f"requests_path = {str(requests_path)!r}",
+                "",
+                "def record(payload):",
+                "    with open(requests_path, 'a', encoding='utf-8') as fh:",
+                "        fh.write(json.dumps(payload) + '\\n')",
+                "",
+                "for line in sys.stdin:",
+                "    payload = json.loads(line)",
+                "    record(payload)",
+                "    if payload.get('method') == 'initialize':",
+                "        print('not-json-from-app-server', flush=True)",
                 "        break",
             ]
         )
@@ -348,6 +375,8 @@ class _FakePersistentWebSocketAppServer(_FakeWebSocketAppServer):
     def _run_jsonrpc(self, conn: socket.socket):
         thread_id = "thread-warm"
         turn_count = 0
+        cumulative_input_tokens = 0
+        cumulative_output_tokens = 0
         while True:
             payload = self._read_ws_text(conn)
             if payload is None:
@@ -369,6 +398,10 @@ class _FakePersistentWebSocketAppServer(_FakeWebSocketAppServer):
                 self._send_ws_json(conn, {"id": request_id, "result": {"thread": thread}})
             elif method == "turn/start":
                 turn_count += 1
+                input_tokens = turn_count
+                output_tokens = turn_count + 1
+                cumulative_input_tokens += input_tokens
+                cumulative_output_tokens += output_tokens
                 turn = {"id": f"turn-warm-{turn_count}", "status": "running", "items": []}
                 self._send_ws_json(conn, {"id": request_id, "result": {"turn": turn}})
                 self._send_ws_json(
@@ -385,6 +418,31 @@ class _FakePersistentWebSocketAppServer(_FakeWebSocketAppServer):
                             "itemId": f"item-{turn_count}",
                             "delta": f"warm {turn_count}",
                         },
+                    },
+                )
+                item = {"threadId": thread_id, "turnId": turn["id"], "itemId": f"item-{turn_count}"}
+                last_usage = {
+                    "inputTokens": input_tokens,
+                    "outputTokens": output_tokens,
+                    "totalTokens": input_tokens + output_tokens,
+                }
+                total_usage = {
+                    "inputTokens": cumulative_input_tokens,
+                    "outputTokens": cumulative_output_tokens,
+                    "totalTokens": cumulative_input_tokens + cumulative_output_tokens,
+                }
+                self._send_ws_json(
+                    conn,
+                    {
+                        "method": "thread/tokenUsage/updated",
+                        "params": {**item, "tokenUsage": {"last": last_usage, "total": total_usage}},
+                    },
+                )
+                self._send_ws_json(
+                    conn,
+                    {
+                        "method": "account/rateLimits/updated",
+                        "params": {"rateLimits": {"requests_remaining": 100 - turn_count}},
                     },
                 )
                 completed = {"id": turn["id"], "status": "completed", "items": []}
@@ -429,7 +487,7 @@ def test_codex_app_server_runtime_speaks_jsonrpc_and_maps_metrics(tmp_path):
     assert result.turn_id == "turn-1"
     assert result.turn_count == 1
     assert result.last_event == "turn/completed"
-    assert result.tokens == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+    assert result.tokens == {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
     assert result.rate_limits == {"limitName": "primary", "requests_remaining": 99}
 
     requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
@@ -526,6 +584,38 @@ def test_codex_app_server_runtime_does_not_fallback_when_resume_fails(tmp_path):
     assert "thread/resume" in methods
     assert "thread/start" not in methods
     assert "turn/start" not in methods
+
+
+def test_codex_app_server_runtime_surfaces_malformed_stdout(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    server = tmp_path / "fake_malformed_app_server.py"
+    requests_path = tmp_path / "requests.jsonl"
+    _write_fake_malformed_app_server(server, requests_path)
+
+    runtime = CodexAppServerRuntime(
+        {
+            "command": [sys.executable, str(server)],
+            "approval_policy": "never",
+            "turn_timeout_ms": 5000,
+            "read_timeout_ms": 1000,
+            "stall_timeout_ms": 5000,
+        },
+        run=None,
+    )
+
+    with pytest.raises(CodexAppServerError, match="non-JSON stdout"):
+        runtime.run_prompt_result(
+            worktree=worktree,
+            session_name="ISSUE-BAD-PROTOCOL",
+            prompt="Do the thing",
+            model="gpt-5.5",
+        )
+
+    requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
+    assert [item.get("method") for item in requests] == ["initialize"]
 
 
 def test_codex_app_server_runtime_allows_quiet_period_longer_than_read_timeout(tmp_path):
@@ -766,6 +856,52 @@ def test_codex_app_server_runtime_reuses_external_websocket_by_default(tmp_path)
     assert second.output == "warm 2\n"
 
 
+def test_codex_app_server_runtime_uses_last_token_usage_as_turn_delta(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakePersistentWebSocketAppServer() as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "keep_alive": True,
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 5000,
+            },
+            run=None,
+        )
+        try:
+            first = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="First",
+                model="gpt-5.5",
+            )
+            runtime.ensure_session(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                model="gpt-5.5",
+                resume_session_id=first.thread_id,
+            )
+            second = runtime.run_prompt_result(
+                worktree=tmp_path,
+                session_name="ISSUE-1",
+                prompt="Second",
+                model="gpt-5.5",
+            )
+        finally:
+            runtime.close()
+
+    methods = [item.get("method") for item in server.requests]
+    assert methods.count("thread/start") == 1
+    assert methods.count("thread/resume") == 1
+    assert first.tokens == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+    assert second.tokens == {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+    assert second.rate_limits == {"requests_remaining": 98}
+
+
 def test_codex_app_server_runtime_reuses_external_websocket_when_keep_alive(tmp_path):
     from runtimes.codex_app_server import CodexAppServerRuntime
 
@@ -936,3 +1072,60 @@ def test_codex_app_server_runtime_reconnects_when_warm_websocket_closes(tmp_path
     assert methods.count("turn/start") == 2
     assert first.output == "ws ok\n"
     assert second.output == "ws ok\n"
+
+
+@pytest.mark.skipif(
+    os.environ.get("DAEDALUS_REAL_CODEX_APP_SERVER") != "1",
+    reason="set DAEDALUS_REAL_CODEX_APP_SERVER=1 to run the real Codex app-server smoke",
+)
+def test_codex_app_server_runtime_real_smoke_start_and_resume(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    if shutil.which("codex") is None:
+        pytest.skip("codex CLI is not installed")
+
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    model = os.environ.get("DAEDALUS_REAL_CODEX_MODEL", "")
+    runtime = CodexAppServerRuntime(
+        {
+            "command": "codex app-server",
+            "approval_policy": "never",
+            "thread_sandbox": "workspace-write",
+            "turn_sandbox_policy": "workspace-write",
+            "turn_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_TURN_TIMEOUT_MS", "180000")),
+            "read_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_READ_TIMEOUT_MS", "5000")),
+            "stall_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_STALL_TIMEOUT_MS", "60000")),
+            "ephemeral": False,
+        },
+        run=None,
+    )
+
+    first = runtime.run_prompt_result(
+        worktree=worktree,
+        session_name="REAL-CODEX-SMOKE",
+        prompt="Reply with exactly this text: DAE-OK-1",
+        model=model,
+    )
+    assert first.thread_id
+    assert first.turn_id
+    assert first.last_event == "turn/completed"
+    assert first.output.strip()
+
+    runtime.ensure_session(
+        worktree=worktree,
+        session_name="REAL-CODEX-SMOKE",
+        model=model,
+        resume_session_id=first.thread_id,
+    )
+    second = runtime.run_prompt_result(
+        worktree=worktree,
+        session_name="REAL-CODEX-SMOKE",
+        prompt="Reply with exactly this text: DAE-OK-2",
+        model=model,
+    )
+
+    assert second.thread_id == first.thread_id
+    assert second.turn_id
+    assert second.last_event == "turn/completed"
+    assert second.output.strip()

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -207,10 +207,12 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     stale_terminal_workspace = workflow_root / "workspace" / "issues" / "ISSUE-2"
     stale_terminal_workspace.mkdir(parents=True)
     (stale_terminal_workspace / "stale.txt").write_text("stale\n", encoding="utf-8")
+    hook_calls = []
 
     def fake_run(command, *, cwd=None, timeout=None, env=None):
         if command[:2] == ["bash", "-lc"] and cwd is not None:
             script = command[2]
+            hook_calls.append({"script": script, "cwd": Path(cwd), "env": dict(env or {})})
             if "created.txt" in script:
                 (cwd / "created.txt").write_text("created\n", encoding="utf-8")
             if "before.txt" in script:
@@ -250,6 +252,10 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     assert (issue_workspace / "created.txt").exists()
     assert (issue_workspace / "before.txt").exists()
     assert (issue_workspace / "after.txt").exists()
+    before_remove_calls = [call for call in hook_calls if "removing.txt" in call["script"]]
+    assert len(before_remove_calls) == 1
+    assert before_remove_calls[0]["cwd"] == stale_terminal_workspace
+    assert before_remove_calls[0]["env"]["ISSUE_ID"] == "ISSUE-2"
     assert not (workflow_root / "workspace" / "issues" / "ISSUE-2").exists()
     status = workspace.build_status()
     assert status["selectedIssue"]["id"] == "ISSUE-1"

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -390,6 +390,10 @@ def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
 
     second = reloaded.tick()
     assert second["ok"] is True
+    scheduler = reloaded.build_status()["scheduler"]
+    assert scheduler["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert scheduler["codex_totals"]["total_tokens"] == 36
+    assert scheduler["codex_totals"]["turn_count"] == 2
 
     requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
     methods = [item.get("method") for item in requests]


### PR DESCRIPTION
## Summary

Adds a stronger Codex app-server smoke harness around the runtime and workflow scheduler behavior.

This PR updates Codex token accounting to prefer `tokenUsage.last` as the per-turn delta when Codex also emits cumulative `tokenUsage.total`, preventing double-counting across resumed threads. The fake app-server harness now verifies start/resume behavior, cumulative-vs-last token usage, rate-limit propagation, malformed protocol output, external WebSocket bearer auth, and issue-runner scheduler thread/totals persistence.

It also adds an opt-in real Codex app-server smoke test gated by `DAEDALUS_REAL_CODEX_APP_SERVER=1`, plus operator docs explaining when to use the fake CI harness versus the real local smoke. The issue-runner cleanup coverage now asserts terminal cleanup invokes `before_remove` before deleting the workspace.

## Operator impact

CI remains deterministic and does not require Codex auth or quota. Operators and maintainers can run the real smoke locally before production changes to Codex runtime/service behavior.

## Validation

- `pytest tests/test_runtimes_codex_app_server.py tests/test_workflows_issue_runner_workspace.py -q` (`31 passed, 1 skipped`)
- `pytest` (`819 passed, 8 skipped`)