### PR TITLE
[codex] add release readiness scorecard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Entry point for everything that won't fit on the [project landing page](../READM
 - **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
 - **[symphony-conformance.md](symphony-conformance.md)** — where Daedalus matches the current Symphony draft, and where it still differs.
 - **[harness-engineering.md](harness-engineering.md)** — repo-level checks that keep the public surface generic, GitHub-first, and template-safe.
+- **[release-readiness.md](release-readiness.md)** — public-beta scorecard, launch gates, and next hardening slice.
 - **[security.md](security.md)** — the trust model, shell/network posture, and secret-handling expectations.
 
 ## Concepts
@@ -58,6 +59,7 @@ docs/
 ├── public-contract.md       stable public surfaces for the first release
 ├── symphony-conformance.md  current spec alignment vs. remaining gaps
 ├── harness-engineering.md   public-readiness checks and guardrails
+├── release-readiness.md     launch scorecard and hardening gates
 ├── security.md              trust model + execution posture
 │
 ├── concepts/                "what does X mean" — one file per abstraction

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -18,6 +18,7 @@ The public release is GitHub-first:
 The harness tests should catch these regressions before review:
 
 - public docs must describe the GitHub-first path clearly
+- release readiness must keep the public-beta posture and launch gates explicit
 - public examples must use generic placeholders like `your-org/your-repo`
 - bundled workflow templates must match their public docs copies
 - bootstrap must safely promote `WORKFLOW.md` to `WORKFLOW-<workflow>.md`
@@ -38,6 +39,15 @@ Add tests for the next hardening slice in this order:
 2. End-to-end `change-delivery` Codex app-server smoke around a real active
    lane, PR update, and review loop.
 3. Live GitHub recovery coverage for labels, comments, and failure replay.
+
+## Harness Principles
+
+- Keep repository knowledge discoverable in `docs/`, bundled templates, and
+  `AGENTS.md` rather than relying on chat history.
+- Turn repeated review comments into structural checks or docs updates.
+- Prefer small, explicit guardrails over broad lint rules that hide the fix.
+- Keep public examples generic and keep deployment-specific material private.
+- Treat opt-in smoke tests as evidence paths, not as default CI requirements.
 
 ## Live GitHub Smoke
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,0 +1,64 @@
+# Release Readiness
+
+This scorecard tracks what must stay true before Daedalus is presented as a
+community-ready SDLC workflow engine. It is intentionally mechanical: every item
+should be backed by documentation, tests, or an operator smoke path.
+
+## Current Position
+
+- Overall posture: **public beta candidate**, not a strict Symphony
+  implementation.
+- Reference workflow: `issue-runner`.
+- Flagship workflow: `change-delivery`.
+- First-class tracker: GitHub.
+- Experimental tracker: Linear.
+- Preferred contract: repo-owned `WORKFLOW.md` or `WORKFLOW-<workflow>.md`.
+
+## Symphony Alignment
+
+| Area | Status | Evidence |
+|---|---|---|
+| Repo-owned workflow contract | Strong | `WORKFLOW*.md` loader, bootstrap, examples, template drift tests |
+| Tracker abstraction | Good | Shared GitHub, local JSON, and experimental Linear clients |
+| Long-running scheduler | Good | `issue-runner run`, worker supervision, retries, persisted scheduler state |
+| Workspace lifecycle | Good | Sanitized issue workspaces, hooks, terminal cleanup, root containment |
+| Codex app-server | Good | Managed stdio, external WebSocket, thread resume, token/rate-limit metrics |
+| Observability | Good | `/daedalus watch`, status, HTTP state, JSONL audit events |
+| strict Symphony contract | Partial | Daedalus still requires extension fields outside the core Symphony blocks |
+| Cross-workflow uniformity | Partial | `issue-runner` is cleaner; `change-delivery` remains intentionally opinionated |
+
+## Harness Engineering Alignment
+
+| Area | Status | Evidence |
+|---|---|---|
+| Repo knowledge as system of record | Strong | Architecture, workflow, operator, security, and conformance docs |
+| Public-surface guardrails | Strong | Generic examples, placeholder-only `projects/`, packaging checks |
+| Agent-legible workflows | Good | Workflow docs link the default templates and operator paths |
+| Custom structural checks | Good | Public harness tests and workflow-template drift checks |
+| Live integration evidence | Partial | GitHub and real Codex app-server smoke tests are opt-in |
+| Recurring cleanup discipline | Partial | Guardrails exist, but no scheduled quality task yet |
+
+## Gates Before Community Launch
+
+1. Keep `daedalus/projects/` placeholder-only in the public repository.
+2. Keep README quick start short and route details to `docs/operator/installation.md`.
+3. Keep `issue-runner` as the Symphony-shaped reference workflow.
+4. Keep GitHub as the documented first-class tracker until live coverage expands.
+5. Keep Linear documented as experimental until it has first-class operator docs.
+6. Keep workflow examples synchronized with packaged templates.
+7. Keep Codex app-server real-runtime tests opt-in and fake protocol tests in CI.
+8. Add live GitHub coverage for comments, labels, and failure recovery before
+   calling GitHub automation production-grade.
+9. Add an end-to-end `change-delivery` Codex app-server smoke before calling the
+   flagship workflow app-server-complete.
+10. Add scheduled cleanup or scorecard refresh work before claiming mature
+    harness-engineering discipline.
+
+## Next Hardening Slice
+
+The highest-leverage next implementation slice is live integration evidence:
+
+1. Extend the GitHub smoke to cover issue comments, labels, and retry/failure
+   recovery.
+2. Add a skipped-by-default `change-delivery` Codex app-server end-to-end smoke.
+3. Add docs/CLI drift checks for commands shown in operator docs.

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -2,7 +2,10 @@
 
 This note tracks Daedalus against the public `openai/symphony` draft spec as reviewed on **April 30, 2026**.
 
-The short version: Daedalus is already **Symphony-aligned** in architecture, but only **partially Symphony-compatible** at the contract and integration boundaries.
+The short version: Daedalus is already **Symphony-aligned** in architecture, but
+only **partially Symphony-compatible** at the contract and integration
+boundaries. The target is to make `issue-runner` the strict reference surface
+and keep `change-delivery` as the opinionated GitHub SDLC workflow.
 
 ## Positioning
 
@@ -25,6 +28,17 @@ The short version: Daedalus is already **Symphony-aligned** in architecture, but
 | Trust/safety posture | Implemented | See [security.md](security.md). |
 | Terminal workspace cleanup | Partial | Terminal lane states exist; full Symphony-style cleanup semantics still need explicit policy. |
 
+## Compatibility Target
+
+`issue-runner` is the workflow that should converge toward strict Symphony
+compatibility. Its public contract should keep the Symphony-shaped keys
+(`tracker`, `polling`, `workspace`, `hooks`, `agent`, `codex`) as the operator
+surface and move Daedalus-specific implementation details under `daedalus:`.
+
+`change-delivery` should not be forced into that shape. It is the richer
+workflow with GitHub lane policy, review gates, PR publication, merge promotion,
+and workflow-specific prompts.
+
 ## Important Differences
 
 Daedalus currently differs from the Symphony draft in four material ways:
@@ -36,8 +50,16 @@ Daedalus currently differs from the Symphony draft in four material ways:
 
 ## Recommended Next Gaps
 
-1. Add stronger cancellation semantics for command-style runtimes, including subprocess group termination where safe.
-2. Add broader GitHub integration coverage for comments, labels, and failure recovery against a real repository.
-3. Expand harness checks for public docs, generic examples, and workflow-template drift.
+1. Make `issue-runner` accept a stricter Symphony-style contract with Daedalus
+   extensions isolated under `daedalus:`.
+2. Add stronger cancellation semantics for command-style runtimes, including
+   subprocess group termination where safe.
+3. Add broader GitHub integration coverage for comments, labels, and failure
+   recovery against a real repository.
+4. Expand harness checks for public docs, generic examples, workflow-template
+   drift, and operator CLI/docs drift.
+
+See [release-readiness.md](release-readiness.md) for the launch scorecard and
+hardening gates.
 
 Until those land, Daedalus should be described as **Symphony-inspired and partially compatible**, not as a strict implementation of the current spec.

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -86,5 +86,25 @@ def test_docs_index_links_harness_and_omits_removed_planning_archive():
     public_contract = (REPO_ROOT / "docs" / "public-contract.md").read_text(encoding="utf-8")
 
     assert "harness-engineering.md" in docs_index
+    assert "release-readiness.md" in docs_index
     assert REMOVED_PUBLIC_ARCHIVE not in docs_index.casefold()
     assert REMOVED_PUBLIC_ARCHIVE not in public_contract.casefold()
+
+
+def test_release_readiness_tracks_public_beta_gates():
+    readiness = (REPO_ROOT / "docs" / "release-readiness.md").read_text(encoding="utf-8")
+    conformance = (REPO_ROOT / "docs" / "symphony-conformance.md").read_text(encoding="utf-8")
+    harness = (REPO_ROOT / "docs" / "harness-engineering.md").read_text(encoding="utf-8")
+
+    assert "public beta candidate" in readiness
+    assert "Reference workflow: `issue-runner`" in readiness
+    assert "Flagship workflow: `change-delivery`" in readiness
+    assert "First-class tracker: GitHub" in readiness
+    assert "Experimental tracker: Linear" in readiness
+    assert "Keep `daedalus/projects/` placeholder-only" in readiness
+    assert "GitHub and real Codex app-server smoke tests are opt-in" in readiness
+    assert "strict Symphony contract" in readiness
+    assert "issue-runner` is the workflow that should converge" in conformance
+    assert "release-readiness.md" in conformance
+    assert "Harness Principles" in harness
+    assert "release readiness" in harness


### PR DESCRIPTION
## Summary

- Add `docs/release-readiness.md` as a public-beta scorecard for Symphony alignment, harness-engineering discipline, launch gates, and next hardening slices.
- Refresh Symphony conformance docs to make `issue-runner` the strict compatibility target and keep `change-delivery` as the opinionated GitHub SDLC workflow.
- Expand harness-engineering docs with explicit readiness guardrails and harness principles.
- Add public harness assertions that keep the readiness posture, launch gates, and docs links present.

## Validation

- `pytest tests/test_public_harness_checks.py -q` (`5 passed`)
- `pytest tests/test_public_harness_checks.py tests/test_docs_public_workflow_template.py tests/test_public_onboarding_smoke.py tests/test_pip_plugin_packaging.py -q` (`19 passed`)
- `pytest -q` (`824 passed, 8 skipped`)