### PR TITLE
[codex] tighten landing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,99 +2,62 @@
 
 **GitHub-first SDLC automation engine for Hermes Agent.**
 
-Daedalus is a stateful workflow runtime for agent-driven software delivery. It
-turns tracker issues into supervised agent work, records durable state, retries
-and reconciles failures, and exposes operator surfaces for running the loop
-without treating prompts or Markdown files as the scheduler.
+Daedalus is a durable control plane for agentic software work. It turns tracker
+issues into supervised workflow runs, dispatches agents through runtime
+adapters, persists state, reconciles failures, and gives operators a live
+surface for the loop.
 
-`WORKFLOW.md` is the repo-owned contract. The engine is the plugin, database,
-state files, leases, service loop, workflow packages, runtime adapters, tracker
-clients, and observability around that contract.
+`WORKFLOW.md` is the repo-owned workflow contract. It is not the scheduler.
+The scheduler is the Daedalus plugin, service loop, workflow package, state
+store, leases, tracker clients, runtime adapters, and observability around that
+contract.
 
-## What Runs
+## Mental Model
 
 ```mermaid
 flowchart LR
-  Repo["target repo<br/>WORKFLOW*.md"] --> Root["workflow instance root<br/>~/.hermes/workflows/&lt;owner&gt;-&lt;repo&gt;-&lt;workflow&gt;"]
-  Plugin["plugin code<br/>~/.hermes/plugins/daedalus"] --> Service["systemd --user<br/>daedalus-active@&lt;instance&gt;"]
+  Repo["target repo<br/>WORKFLOW*.md"] --> Root["workflow root<br/>~/.hermes/workflows/&lt;owner&gt;-&lt;repo&gt;-&lt;workflow&gt;"]
+  Plugin["plugin<br/>~/.hermes/plugins/daedalus"] --> Service["systemd user service"]
   Root --> Service
-  Service --> Engine["Daedalus runtime<br/>preflight · tick · reconcile"]
-  Engine --> Workflow["workflow package<br/>change-delivery or issue-runner"]
-  Workflow --> Tracker["tracker client<br/>GitHub · local-json · Linear experimental"]
-  Workflow --> Runtime["agent runtime<br/>codex-app-server · acpx-codex · claude-cli · hermes-agent"]
-  Runtime --> Workspace["per-issue workspace"]
-  Engine --> State["durable state<br/>SQLite · JSON · JSONL"]
+  Service --> Workflow["workflow package"]
+  Workflow --> Tracker["tracker<br/>GitHub first"]
+  Workflow --> Runtime["runtime adapter<br/>Codex · Claude · Hermes"]
+  Runtime --> Workspace["isolated workspace"]
+  Service --> State["durable state<br/>SQLite · JSON · JSONL"]
   Workspace --> State
 ```
 
-The important separation:
+The separation is intentional:
 
-- **Plugin code** lives under `~/.hermes/plugins/daedalus`.
-- **Workflow instance data** lives under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`.
-- **Repo policy** lives in `WORKFLOW.md` or `WORKFLOW-<workflow>.md`.
-- **Agent work** happens in the configured repo/workspace paths, not inside the public `daedalus/projects/` tree.
+- Plugin code lives in `~/.hermes/plugins/daedalus`.
+- Workflow instance data lives in `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`.
+- Repo policy and operator config live in `WORKFLOW.md` or `WORKFLOW-<workflow>.md`.
+- Agent work happens in configured workspaces, not in `daedalus/projects/`.
 
 ## Bundled Workflows
 
-Daedalus does not assume one universal lifecycle. The engine is shared; each
-workflow package owns its own policy, schema, prompts, gates, and commands.
-
-| Workflow | Purpose | Best fit |
+| Workflow | What it automates | Use it when |
 |---|---|---|
-| `change-delivery` | GitHub issue -> code -> internal review -> PR -> external review -> merge | Opinionated SDLC automation with review and merge gates |
-| `issue-runner` | tracker issue -> isolated workspace -> hooks -> prompt -> one agent run | Generic Symphony-shaped issue execution |
+| `change-delivery` | GitHub issue -> implementation -> internal review -> PR -> external review -> merge | You want the opinionated SDLC workflow with review and merge gates. |
+| `issue-runner` | tracker issue -> workspace -> hooks -> prompt -> one agent run | You want a smaller generic tracker-driven workflow. |
 
-`change-delivery` is the default public bootstrap path. `issue-runner` is the
-cleaner reference workflow for generic tracker-driven automation and future
-Symphony compatibility.
+`change-delivery` is the default bootstrap path. `issue-runner` is the cleaner
+generic reference workflow and the closest surface to Symphony-style issue
+execution.
 
-## Control Loop
+## What Is Stateful
 
-```mermaid
-sequenceDiagram
-  participant T as Tracker
-  participant D as Daedalus service
-  participant W as Workflow package
-  participant R as Runtime adapter
-  participant S as Durable state
+Daedalus is not controlled by Markdown files alone. The workflow contract is
+configuration; runtime truth is persisted separately.
 
-  D->>W: load WORKFLOW*.md + last good config
-  W->>T: list/refresh candidate and terminal issues
-  W->>S: read lanes, scheduler, retries, threads
-  W->>D: select, reconcile, or clean up
-  D->>R: dispatch prompt/command when eligible
-  R-->>D: result, thread id, tokens, rate limits
-  D->>S: record status, events, retry, cleanup, metrics
-```
-
-Daedalus is intentionally stateful. These paths are relative to the workflow
-root unless noted otherwise:
-
-| State surface | Used for |
+| Surface | Purpose |
 |---|---|
-| `runtime/state/daedalus/daedalus.db` | `change-delivery` runtime rows, leases, lanes, actions, reviews, failures |
-| `memory/workflow-scheduler.json` | running workers, retry queue, Codex thread mappings, token/rate-limit totals |
-| `memory/workflow-audit.jsonl` | append-only workflow audit events |
+| `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
+| `memory/workflow-scheduler.json` | running workers, retries, Codex thread mappings, token/rate-limit totals |
+| `memory/workflow-audit.jsonl` | workflow audit history |
 | `memory/workflow-status.json` / `workflow-health.json` | operator and HTTP status projections |
-| `.lane-state.json` / `.lane-memo.md` | lane-local handoff artifacts for `change-delivery` |
 
-## Supported Public Path
-
-- **Platform:** Linux
-- **Plugin install:** `hermes plugins install attmous/daedalus --enable`
-- **Plugin source of truth:** `~/.hermes/plugins/daedalus`
-- **Workflow root:** `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
-- **Workflow contract:** repo-owned `WORKFLOW.md` or `WORKFLOW-<workflow>.md`
-- **First-class tracker:** GitHub issues through authenticated `gh`
-- **Experimental tracker:** Linear
-- **Supervision:** `systemd --user`
-- **Runtime adapters:** `codex-app-server`, `acpx-codex`, `claude-cli`, `hermes-agent`
-
-The current release posture is **public beta candidate**. See
-[docs/release-readiness.md](docs/release-readiness.md) and
-[docs/public-contract.md](docs/public-contract.md) for the supported boundary.
-
-## Install And Start
+## Quick Start
 
 ```bash
 sudo apt install python3-yaml python3-jsonschema
@@ -107,32 +70,39 @@ hermes daedalus service-up
 hermes
 ```
 
+Bootstrap creates the workflow root, writes the repo-owned contract, commits it
+on a bootstrap branch, and stores a repo-local pointer so later commands can
+resolve the workflow instance.
+
 Use the generic workflow instead:
 
 ```bash
 hermes daedalus bootstrap --workflow issue-runner
 ```
 
-`bootstrap` detects the repo, derives the GitHub slug, creates the workflow
-root, writes the repo-owned workflow contract, commits it on a bootstrap branch,
-and writes `./.hermes/daedalus/workflow-root` so later commands can resolve the
-instance from the repo checkout.
-
-`service-up` validates the contract, runs workflow preflight, installs the
-systemd user unit, enables it, and starts the supervised loop.
-
-If your workflow uses an external Codex app-server, start the shared listener:
-
-```bash
-hermes daedalus codex-app-server up
-hermes daedalus codex-app-server doctor
-```
-
-For manual scaffold paths, service modes, pip installs, lower-level command
-details, and troubleshooting, read
+For manual scaffold paths, service modes, pip installs, and every lower-level command,
+use the full install guide:
 [docs/operator/installation.md](docs/operator/installation.md).
 
-## Operator Surface
+## Configure The Workflow
+
+Edit the generated repo contract:
+
+- `WORKFLOW.md` when the repo carries one workflow
+- `WORKFLOW-change-delivery.md` / `WORKFLOW-issue-runner.md` when it carries more than one
+
+Common knobs live in the YAML front matter:
+
+- `repository` / `tracker`: repo checkout, GitHub slug, labels, issue states
+- `runtimes`: `codex-app-server`, `acpx-codex`, `claude-cli`, `hermes-agent`
+- `agents`: model/runtime bindings for workflow roles
+- `gates` / `hooks`: workflow-specific policy
+- `observability` / `server`: comments, webhooks, HTTP status
+
+The Markdown body is the workflow policy prompt. The workflow package decides
+how to use it.
+
+## Operate It
 
 ```text
 /daedalus status
@@ -145,48 +115,36 @@ details, and troubleshooting, read
 /workflow issue-runner run --max-iterations 1 --json
 ```
 
-The operator surfaces read state; they do not require you to inspect SQLite,
-JSONL, scheduler files, or systemd logs by hand. The optional HTTP status server
-exposes workflow-scoped JSON and HTML snapshots for dashboards.
+The operator surfaces read the persisted state for you. You should not need to
+inspect SQLite, scheduler JSON, JSONL logs, or systemd journals by hand during
+normal operation.
 
-## Recovery Model
+## Public Posture
 
-```mermaid
-flowchart TD
-  A["worker dispatched"] --> B{"completed?"}
-  B -- yes --> C["record result<br/>update metrics"]
-  B -- no --> D{"stalled, failed, or process restarted?"}
-  D -- retryable --> E["persist retry<br/>backoff or continuation delay"]
-  D -- terminal issue --> F["cancel or suppress retry<br/>run cleanup hooks"]
-  E --> G["next tick reselects eligible work"]
-  F --> H["workspace cleanup<br/>thread mapping cleared"]
-  C --> G
-```
+- **First-class tracker:** GitHub issues through authenticated `gh`
+- **Experimental tracker:** Linear
+- **Supervision:** `systemd --user`
+- **Runtime adapters:** `codex-app-server`, `acpx-codex`, `claude-cli`, `hermes-agent`
+- **Release posture:** public beta candidate
 
-The engine keeps running on bad config reloads, tracker errors, worker failures,
-and restarts. The exact behavior depends on the workflow:
-
-- `issue-runner` has bounded async workers, retry queue persistence, terminal
-  workspace cleanup, lifecycle hooks, and Codex `issue_id -> thread_id` resume.
-- `change-delivery` adds active-lane state, leases, action idempotency, review
-  gates, PR publishing, merge promotion, and SQLite-backed runtime state.
+Stable public boundaries are tracked in [docs/public-contract.md](docs/public-contract.md).
+Readiness and generic-surface guardrails are tracked in
+[docs/harness-engineering.md](docs/harness-engineering.md).
 
 ## Documentation
 
-- [docs/architecture.md](docs/architecture.md) — durable runtime model and engine/workflow boundary.
-- [docs/workflows/README.md](docs/workflows/README.md) — how `change-delivery` and `issue-runner` differ.
-- [docs/operator/installation.md](docs/operator/installation.md) — install, bootstrap, service, and troubleshooting.
-- [docs/operator/cheat-sheet.md](docs/operator/cheat-sheet.md) — day-2 commands.
+- [docs/operator/installation.md](docs/operator/installation.md) — full install, bootstrap, service, and troubleshooting path.
+- [docs/workflows/README.md](docs/workflows/README.md) — workflow comparison and templates.
+- [docs/architecture.md](docs/architecture.md) — engine/workflow boundary and durable runtime model.
+- [docs/operator/cheat-sheet.md](docs/operator/cheat-sheet.md) — day-2 commands and debugging.
 - [docs/symphony-conformance.md](docs/symphony-conformance.md) — Symphony alignment and remaining gaps.
-- [docs/harness-engineering.md](docs/harness-engineering.md) — public-readiness checks and guardrails.
 - [docs/security.md](docs/security.md) — trust model, shell/runtime posture, and secrets.
 
 ## Name
 
-In the myth, Daedalus built the labyrinth, gave Theseus the thread, and warned
-Icarus about unsafe flight. The name is a reminder of the same engineering
-shape here: build the maze, keep the recovery thread, and put limits around
-autonomy.
+Daedalus built the labyrinth, kept the thread, and understood the risk of
+unchecked flight. The project uses the name as a reminder: build the workflow
+maze, keep recovery paths visible, and put limits around autonomy.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ store, leases, tracker clients, runtime adapters, and observability around it.
 
 | Capability | What it means |
 |---|---|
-| **Repo-owned workflow contracts** | Generates `WORKFLOW.md` into your target repo so config and policy live beside the code being automated. |
-| **Durable runtime state** | Persists leases, running work, retries, thread mappings, audit history, status, and health in SQLite, JSON, and JSONL. |
-| **Supervised service loop** | Runs under `systemd --user`, survives restarts, reconciles stalled work, and resumes eligible runs. |
-| **Runtime flexibility** | Dispatches through runtime profiles for hosted agents, CLI agents, Codex app-server, or custom commands. |
-| **Operator surface** | Exposes `/daedalus`, `/workflow`, watch output, service controls, and optional HTTP status. |
+| Issue-based automation | Turns selected issues into supervised workflow runs with explicit lifecycle policy. |
+| Repo-owned workflow contracts | Generates `WORKFLOW.md` into your target repo so config and policy live beside the code being automated. |
+| Durable runtime state | Persists leases, running work, retries, thread mappings, audit history, status, and health in SQLite, JSON, and JSONL. |
+| Supervised service loop | Runs under `systemd --user`, survives restarts, reconciles stalled work, and resumes eligible runs. |
+| Runtime flexibility | Dispatches through runtime profiles for hosted agents, CLI agents, Codex app-server, or custom commands. |
+| Operator surface | Exposes `/daedalus`, `/workflow`, watch output, service controls, and optional HTTP status. |
+| Bundled workflow engine | Ships `issue-runner` and `change-delivery`, with shared tracker, runtime, config, and observability primitives. |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -70,16 +70,15 @@ Inside Hermes Agent:
 
 ```bash
 # Daedalus engine and service commands
-/daedalus status          # show runtime state, workflow root, and important paths
-/daedalus doctor          # run health checks across config, service, state, and integrations
-/daedalus watch           # render a live operator view
-/daedalus service-status  # show the systemd user service state
+/daedalus status                            # show runtime state, workflow root, and important paths
+/daedalus doctor                            # run health checks across config, service, state, and integrations
+/daedalus watch                             # render a live operator view
+/daedalus service-status                    # show the systemd user service state
 
 # Workflow package commands
-/workflow issue-runner status                         # show selected issues, runs, retries, and scheduler state
-/workflow issue-runner run --max-iterations 1 --json  # run one bounded service-loop iteration
-/workflow change-delivery status                      # show active issue/lane and next action
-/workflow change-delivery tick                        # run one change-delivery workflow tick
+/workflow issue-runner status               # show selected issues, runs, retries, and scheduler state
+/workflow change-delivery status            # show active issue/lane and next action
+/workflow change-delivery tick              # run one change-delivery workflow tick
 ```
 
 The operator surfaces read the persisted state for you. You should not need to

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ workflow contract: it defines policy and configuration, but it is not the
 scheduler. The scheduler is the plugin, service loop, workflow package, state
 store, leases, tracker clients, runtime adapters, and observability around it.
 
+## What You Get
+
+| Capability | What it means |
+|---|---|
+| Issue-based automation | Turns selected issues into supervised workflow runs with explicit lifecycle policy. |
+| Repo-owned workflow contracts | Generates `WORKFLOW.md` into your target repo so config and policy live beside the code being automated. |
+| Durable runtime state | Persists leases, running work, retries, thread mappings, audit history, status, and health in SQLite, JSON, and JSONL. |
+| Supervised service loop | Runs under `systemd --user`, survives restarts, reconciles stalled work, and resumes eligible runs. |
+| Runtime flexibility | Dispatches through runtime profiles for hosted agents, CLI agents, Codex app-server, or custom commands. |
+| Operator surface | Exposes `/daedalus`, `/workflow`, watch output, service controls, and optional HTTP status. |
+| Bundled workflow engine | Ships `issue-runner` and `change-delivery`, with shared tracker, runtime, config, and observability primitives. |
+
 ## Mental Model
 
 | Term | Meaning |
@@ -131,18 +143,6 @@ how to use it. See the full [WORKFLOW.md guide](docs/workflows/workflow-contract
 Stable public boundaries are tracked in [docs/public-contract.md](docs/public-contract.md).
 Readiness and generic-surface guardrails are tracked in
 [docs/harness-engineering.md](docs/harness-engineering.md).
-
-## What Is Stateful
-
-Daedalus is not controlled by Markdown files alone. The workflow contract is
-configuration; runtime truth is persisted separately.
-
-| Surface | Purpose |
-|---|---|
-| `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
-| `memory/workflow-scheduler.json` | running workers, retries, thread mappings, token/rate-limit totals |
-| `memory/workflow-audit.jsonl` | workflow audit history |
-| `memory/workflow-status.json` / `workflow-health.json` | operator and HTTP status projections |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -71,18 +71,6 @@ For manual scaffold paths, service modes, pip installs, and every lower-level co
 use the full install guide:
 [docs/operator/installation.md](docs/operator/installation.md).
 
-## What Is Stateful
-
-Daedalus is not controlled by Markdown files alone. The workflow contract is
-configuration; runtime truth is persisted separately.
-
-| Surface | Purpose |
-|---|---|
-| `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
-| `memory/workflow-scheduler.json` | running workers, retries, thread mappings, token/rate-limit totals |
-| `memory/workflow-audit.jsonl` | workflow audit history |
-| `memory/workflow-status.json` / `workflow-health.json` | operator and HTTP status projections |
-
 ## Operate It
 
 After installing the plugin, run Hermes from your target repo:
@@ -144,15 +132,29 @@ Stable public boundaries are tracked in [docs/public-contract.md](docs/public-co
 Readiness and generic-surface guardrails are tracked in
 [docs/harness-engineering.md](docs/harness-engineering.md).
 
+## What Is Stateful
+
+Daedalus is not controlled by Markdown files alone. The workflow contract is
+configuration; runtime truth is persisted separately.
+
+| Surface | Purpose |
+|---|---|
+| `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
+| `memory/workflow-scheduler.json` | running workers, retries, thread mappings, token/rate-limit totals |
+| `memory/workflow-audit.jsonl` | workflow audit history |
+| `memory/workflow-status.json` / `workflow-health.json` | operator and HTTP status projections |
+
 ## Documentation
 
-- [docs/operator/installation.md](docs/operator/installation.md) — full install, bootstrap, service, and troubleshooting path.
-- [docs/workflows/workflow-contract.md](docs/workflows/workflow-contract.md) — `WORKFLOW.md` structure and examples.
-- [docs/workflows/README.md](docs/workflows/README.md) — workflow comparison and templates.
-- [docs/architecture.md](docs/architecture.md) — engine/workflow boundary and durable runtime model.
-- [docs/operator/cheat-sheet.md](docs/operator/cheat-sheet.md) — day-2 commands and debugging.
-- [docs/symphony-conformance.md](docs/symphony-conformance.md) — Symphony alignment and remaining gaps.
-- [docs/security.md](docs/security.md) — trust model, shell/runtime posture, and secrets.
+| Doc | Purpose |
+|---|---|
+| [Installation](docs/operator/installation.md) | Full install, bootstrap, service, and troubleshooting path. |
+| [WORKFLOW.md guide](docs/workflows/workflow-contract.md) | Workflow contract structure and examples. |
+| [Bundled workflows](docs/workflows/README.md) | Workflow comparison and templates. |
+| [Architecture](docs/architecture.md) | Engine/workflow boundary and durable runtime model. |
+| [Operator cheat sheet](docs/operator/cheat-sheet.md) | Day-2 commands and debugging. |
+| [Symphony conformance](docs/symphony-conformance.md) | Symphony alignment and remaining gaps. |
+| [Security](docs/security.md) | Trust model, shell/runtime posture, and secrets. |
 
 ## Name
 

--- a/README.md
+++ b/README.md
@@ -22,39 +22,11 @@ store, leases, tracker clients, runtime adapters, and observability around it.
 
 | Capability | What it means |
 |---|---|
-| Issue-based automation | Turns selected issues into supervised workflow runs with explicit lifecycle policy. |
-| Repo-owned workflow contracts | Generates `WORKFLOW.md` into your target repo so config and policy live beside the code being automated. |
-| Durable runtime state | Persists leases, running work, retries, thread mappings, audit history, status, and health in SQLite, JSON, and JSONL. |
-| Supervised service loop | Runs under `systemd --user`, survives restarts, reconciles stalled work, and resumes eligible runs. |
-| Runtime flexibility | Dispatches through runtime profiles for hosted agents, CLI agents, Codex app-server, or custom commands. |
-| Operator surface | Exposes `/daedalus`, `/workflow`, watch output, service controls, and optional HTTP status. |
-| Bundled workflow engine | Ships `issue-runner` and `change-delivery`, with shared tracker, runtime, config, and observability primitives. |
-
-## Mental Model
-
-| Term | Meaning |
-|---|---|
-| Target repo | The user repository where work should happen. Bootstrap writes `WORKFLOW.md` here. |
-| Workflow contract | `WORKFLOW.md` or `WORKFLOW-<name>.md`; YAML front matter plus Markdown policy text. |
-| Workflow root | Durable instance data under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`. |
-| Workflow package | The installed Python implementation that decides the lifecycle for a selected issue. |
-| Tracker | The system Daedalus reads issues from and writes status back to. |
-| Issue | The unit of work selected from a tracker. Workflows should model issues, not one tracker vendor. |
-| Runtime | The adapter that runs an agent or command against a workspace. |
-| Workspace | The isolated checkout/path where the agent does work for an issue. |
-| State store | SQLite, JSON, and JSONL files that preserve current state, history, retries, leases, and metrics. |
-| Operator surface | Hermes commands, service controls, watch output, and optional HTTP status. |
-
-## Bundled Workflows
-
-| Workflow | What it automates | Use it when |
-|---|---|---|
-| `issue-runner` | issue -> workspace -> hooks -> prompt -> one agent run | You want a small generic issue workflow. |
-| `change-delivery` | issue -> implementation -> internal review -> PR -> external review -> merge | You want the opinionated SDLC workflow with review and merge gates. |
-
-`issue-runner` is the generic reference workflow and the closest surface to
-Symphony-style issue execution. `change-delivery` is richer and more
-opinionated.
+| **Repo-owned workflow contracts** | Generates `WORKFLOW.md` into your target repo so config and policy live beside the code being automated. |
+| **Durable runtime state** | Persists leases, running work, retries, thread mappings, audit history, status, and health in SQLite, JSON, and JSONL. |
+| **Supervised service loop** | Runs under `systemd --user`, survives restarts, reconciles stalled work, and resumes eligible runs. |
+| **Runtime flexibility** | Dispatches through runtime profiles for hosted agents, CLI agents, Codex app-server, or custom commands. |
+| **Operator surface** | Exposes `/daedalus`, `/workflow`, watch output, service controls, and optional HTTP status. |
 
 ## Quick Start
 
@@ -129,6 +101,32 @@ Common knobs live in the YAML front matter:
 
 The Markdown body is the workflow policy prompt. The workflow package decides
 how to use it. See the full [WORKFLOW.md guide](docs/workflows/workflow-contract.md).
+
+## Mental Model
+
+| Term | Meaning |
+|---|---|
+| Target repo | The user repository where work should happen. Bootstrap writes `WORKFLOW.md` here. |
+| Workflow contract | `WORKFLOW.md` or `WORKFLOW-<name>.md`; YAML front matter plus Markdown policy text. |
+| Workflow root | Durable instance data under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`. |
+| Workflow package | The installed Python implementation that decides the lifecycle for a selected issue. |
+| Tracker | The system Daedalus reads issues from and writes status back to. |
+| Issue | The unit of work selected from a tracker. Workflows should model issues, not one tracker vendor. |
+| Runtime | The adapter that runs an agent or command against a workspace. |
+| Workspace | The isolated checkout/path where the agent does work for an issue. |
+| State store | SQLite, JSON, and JSONL files that preserve current state, history, retries, leases, and metrics. |
+| Operator surface | Hermes commands, service controls, watch output, and optional HTTP status. |
+
+## Bundled Workflows
+
+| Workflow | What it automates | Use it when |
+|---|---|---|
+| `issue-runner` | issue -> workspace -> hooks -> prompt -> one agent run | You want a small generic issue workflow. |
+| `change-delivery` | issue -> implementation -> internal review -> PR -> external review -> merge | You want the opinionated SDLC workflow with review and merge gates. |
+
+`issue-runner` is the generic reference workflow and the closest surface to
+Symphony-style issue execution. `change-delivery` is richer and more
+opinionated.
 
 ## Supported Surfaces
 

--- a/README.md
+++ b/README.md
@@ -71,24 +71,6 @@ For manual scaffold paths, service modes, pip installs, and every lower-level co
 use the full install guide:
 [docs/operator/installation.md](docs/operator/installation.md).
 
-## Configure The Workflow
-
-Edit the generated contract in your target repo:
-
-- `WORKFLOW.md` when the repo carries one workflow
-- `WORKFLOW-issue-runner.md` / `WORKFLOW-change-delivery.md` when it carries more than one
-
-Common knobs live in the YAML front matter:
-
-- `tracker` / `repository`: issue source, repo checkout, labels, states
-- `runtimes`: runtime profiles such as Codex app-server, CLI agents, or custom commands
-- `agents`: model/runtime bindings for workflow roles
-- `hooks` / `gates`: workflow-specific lifecycle policy
-- `observability` / `server`: comments, webhooks, HTTP status
-
-The Markdown body is the workflow policy prompt. The workflow package decides
-how to use it. See the full [WORKFLOW.md guide](docs/workflows/workflow-contract.md).
-
 ## What Is Stateful
 
 Daedalus is not controlled by Markdown files alone. The workflow contract is
@@ -129,6 +111,24 @@ Inside Hermes Agent:
 The operator surfaces read the persisted state for you. You should not need to
 inspect SQLite, scheduler JSON, JSONL logs, or systemd journals by hand during
 normal operation.
+
+## Configure The Workflow
+
+Edit the generated contract in your target repo:
+
+- `WORKFLOW.md` when the repo carries one workflow
+- `WORKFLOW-issue-runner.md` / `WORKFLOW-change-delivery.md` when it carries more than one
+
+Common knobs live in the YAML front matter:
+
+- `tracker` / `repository`: issue source, repo checkout, labels, states
+- `runtimes`: runtime profiles such as Codex app-server, CLI agents, or custom commands
+- `agents`: model/runtime bindings for workflow roles
+- `hooks` / `gates`: workflow-specific lifecycle policy
+- `observability` / `server`: comments, webhooks, HTTP status
+
+The Markdown body is the workflow policy prompt. The workflow package decides
+how to use it. See the full [WORKFLOW.md guide](docs/workflows/workflow-contract.md).
 
 ## Supported Surfaces
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ hermes
 
 Inside Hermes Agent:
 
-```text
+```bash
 # Daedalus engine and service commands
 /daedalus status          # show runtime state, workflow root, and important paths
 /daedalus doctor          # run health checks across config, service, state, and integrations

--- a/README.md
+++ b/README.md
@@ -1,49 +1,93 @@
 # Daedalus
 
-**GitHub-first SDLC automation engine for Hermes Agent.**
+<div align="center">
 
-Daedalus is a durable control plane for agentic software work. It turns tracker
-issues into supervised workflow runs, dispatches agents through runtime
-adapters, persists state, reconciles failures, and gives operators a live
-surface for the loop.
+![Daedalus banner](assets/daedalus-banner.gif)
 
-`WORKFLOW.md` is the repo-owned workflow contract. It is not the scheduler.
-The scheduler is the Daedalus plugin, service loop, workflow package, state
-store, leases, tracker clients, runtime adapters, and observability around that
-contract.
+**Durable SDLC automation engine for Hermes Agent.**
+
+</div>
+
+Daedalus is a control plane for agentic software work. It turns issues into
+supervised workflow runs, dispatches agents through runtime adapters, persists
+state, reconciles failures, and gives operators a live surface for the loop.
+
+During bootstrap, the Daedalus plugin generates a `WORKFLOW.md` file in the
+repository you want Daedalus to operate on. That file is your repo-local
+workflow contract: it defines policy and configuration, but it is not the
+scheduler. The scheduler is the plugin, service loop, workflow package, state
+store, leases, tracker clients, runtime adapters, and observability around it.
 
 ## Mental Model
 
-```mermaid
-flowchart LR
-  Repo["target repo<br/>WORKFLOW*.md"] --> Root["workflow root<br/>~/.hermes/workflows/&lt;owner&gt;-&lt;repo&gt;-&lt;workflow&gt;"]
-  Plugin["plugin<br/>~/.hermes/plugins/daedalus"] --> Service["systemd user service"]
-  Root --> Service
-  Service --> Workflow["workflow package"]
-  Workflow --> Tracker["tracker<br/>GitHub first"]
-  Workflow --> Runtime["runtime adapter<br/>Codex · Claude · Hermes"]
-  Runtime --> Workspace["isolated workspace"]
-  Service --> State["durable state<br/>SQLite · JSON · JSONL"]
-  Workspace --> State
-```
-
-The separation is intentional:
-
-- Plugin code lives in `~/.hermes/plugins/daedalus`.
-- Workflow instance data lives in `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`.
-- Repo policy and operator config live in `WORKFLOW.md` or `WORKFLOW-<workflow>.md`.
-- Agent work happens in configured workspaces, not in `daedalus/projects/`.
+| Term | Meaning |
+|---|---|
+| Target repo | The user repository where work should happen. Bootstrap writes `WORKFLOW.md` here. |
+| Workflow contract | `WORKFLOW.md` or `WORKFLOW-<name>.md`; YAML front matter plus Markdown policy text. |
+| Workflow root | Durable instance data under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`. |
+| Workflow package | The installed Python implementation that decides the lifecycle for a selected issue. |
+| Tracker | The system Daedalus reads issues from and writes status back to. |
+| Issue | The unit of work selected from a tracker. Workflows should model issues, not one tracker vendor. |
+| Runtime | The adapter that runs an agent or command against a workspace. |
+| Workspace | The isolated checkout/path where the agent does work for an issue. |
+| State store | SQLite, JSON, and JSONL files that preserve current state, history, retries, leases, and metrics. |
+| Operator surface | Hermes commands, service controls, watch output, and optional HTTP status. |
 
 ## Bundled Workflows
 
 | Workflow | What it automates | Use it when |
 |---|---|---|
-| `change-delivery` | GitHub issue -> implementation -> internal review -> PR -> external review -> merge | You want the opinionated SDLC workflow with review and merge gates. |
-| `issue-runner` | tracker issue -> workspace -> hooks -> prompt -> one agent run | You want a smaller generic tracker-driven workflow. |
+| `issue-runner` | issue -> workspace -> hooks -> prompt -> one agent run | You want a small generic issue workflow. |
+| `change-delivery` | issue -> implementation -> internal review -> PR -> external review -> merge | You want the opinionated SDLC workflow with review and merge gates. |
 
-`change-delivery` is the default bootstrap path. `issue-runner` is the cleaner
-generic reference workflow and the closest surface to Symphony-style issue
-execution.
+`issue-runner` is the generic reference workflow and the closest surface to
+Symphony-style issue execution. `change-delivery` is richer and more
+opinionated.
+
+## Quick Start
+
+```bash
+sudo apt install python3-yaml python3-jsonschema
+hermes plugins install attmous/daedalus --enable
+
+cd /path/to/your/repo
+hermes daedalus bootstrap --workflow issue-runner
+$EDITOR WORKFLOW.md
+hermes daedalus service-up
+hermes
+```
+
+Bootstrap creates the workflow root, writes the workflow contract into your
+repo, commits it on a bootstrap branch, and stores a repo-local pointer so later
+commands can resolve the workflow instance.
+
+For the opinionated change-delivery workflow:
+
+```bash
+hermes daedalus bootstrap --workflow change-delivery
+```
+
+For manual scaffold paths, service modes, pip installs, and every lower-level command,
+use the full install guide:
+[docs/operator/installation.md](docs/operator/installation.md).
+
+## Configure The Workflow
+
+Edit the generated contract in your target repo:
+
+- `WORKFLOW.md` when the repo carries one workflow
+- `WORKFLOW-issue-runner.md` / `WORKFLOW-change-delivery.md` when it carries more than one
+
+Common knobs live in the YAML front matter:
+
+- `tracker` / `repository`: issue source, repo checkout, labels, states
+- `runtimes`: runtime profiles such as Codex app-server, CLI agents, or custom commands
+- `agents`: model/runtime bindings for workflow roles
+- `hooks` / `gates`: workflow-specific lifecycle policy
+- `observability` / `server`: comments, webhooks, HTTP status
+
+The Markdown body is the workflow policy prompt. The workflow package decides
+how to use it. See the full [WORKFLOW.md guide](docs/workflows/workflow-contract.md).
 
 ## What Is Stateful
 
@@ -53,79 +97,48 @@ configuration; runtime truth is persisted separately.
 | Surface | Purpose |
 |---|---|
 | `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
-| `memory/workflow-scheduler.json` | running workers, retries, Codex thread mappings, token/rate-limit totals |
+| `memory/workflow-scheduler.json` | running workers, retries, thread mappings, token/rate-limit totals |
 | `memory/workflow-audit.jsonl` | workflow audit history |
 | `memory/workflow-status.json` / `workflow-health.json` | operator and HTTP status projections |
 
-## Quick Start
+## Operate It
+
+After installing the plugin, run Hermes from your target repo:
 
 ```bash
-sudo apt install python3-yaml python3-jsonschema
-hermes plugins install attmous/daedalus --enable
-
 cd /path/to/your/repo
-hermes daedalus bootstrap
-$EDITOR WORKFLOW.md
-hermes daedalus service-up
 hermes
 ```
 
-Bootstrap creates the workflow root, writes the repo-owned contract, commits it
-on a bootstrap branch, and stores a repo-local pointer so later commands can
-resolve the workflow instance.
-
-Use the generic workflow instead:
-
-```bash
-hermes daedalus bootstrap --workflow issue-runner
-```
-
-For manual scaffold paths, service modes, pip installs, and every lower-level command,
-use the full install guide:
-[docs/operator/installation.md](docs/operator/installation.md).
-
-## Configure The Workflow
-
-Edit the generated repo contract:
-
-- `WORKFLOW.md` when the repo carries one workflow
-- `WORKFLOW-change-delivery.md` / `WORKFLOW-issue-runner.md` when it carries more than one
-
-Common knobs live in the YAML front matter:
-
-- `repository` / `tracker`: repo checkout, GitHub slug, labels, issue states
-- `runtimes`: `codex-app-server`, `acpx-codex`, `claude-cli`, `hermes-agent`
-- `agents`: model/runtime bindings for workflow roles
-- `gates` / `hooks`: workflow-specific policy
-- `observability` / `server`: comments, webhooks, HTTP status
-
-The Markdown body is the workflow policy prompt. The workflow package decides
-how to use it.
-
-## Operate It
+Inside Hermes Agent:
 
 ```text
-/daedalus status
-/daedalus doctor
-/daedalus watch
-/daedalus service-status
-/workflow change-delivery status
-/workflow change-delivery tick
-/workflow issue-runner status
-/workflow issue-runner run --max-iterations 1 --json
+# Daedalus engine and service commands
+/daedalus status          # show runtime state, workflow root, and important paths
+/daedalus doctor          # run health checks across config, service, state, and integrations
+/daedalus watch           # render a live operator view
+/daedalus service-status  # show the systemd user service state
+
+# Workflow package commands
+/workflow issue-runner status                         # show selected issues, runs, retries, and scheduler state
+/workflow issue-runner run --max-iterations 1 --json  # run one bounded service-loop iteration
+/workflow change-delivery status                      # show active issue/lane and next action
+/workflow change-delivery tick                        # run one change-delivery workflow tick
 ```
 
 The operator surfaces read the persisted state for you. You should not need to
 inspect SQLite, scheduler JSON, JSONL logs, or systemd journals by hand during
 normal operation.
 
-## Public Posture
+## Supported Surfaces
 
-- **First-class tracker:** GitHub issues through authenticated `gh`
-- **Experimental tracker:** Linear
-- **Supervision:** `systemd --user`
-- **Runtime adapters:** `codex-app-server`, `acpx-codex`, `claude-cli`, `hermes-agent`
-- **Release posture:** public beta candidate
+| Area | Status | Notes |
+|---|---|---|
+| GitHub tracker | First-class tracker | Public supported path through authenticated `gh`. |
+| `local-json` tracker | Development and fixtures | Useful for local tests and examples. |
+| Linear tracker | Experimental | Deferred until after the GitHub path is hardened. |
+| Supervision | Supported | `systemd --user`. |
+| Runtime adapters | Supported | Codex app-server, ACPX Codex, Claude CLI, Hermes agent, custom commands. |
 
 Stable public boundaries are tracked in [docs/public-contract.md](docs/public-contract.md).
 Readiness and generic-surface guardrails are tracked in
@@ -134,6 +147,7 @@ Readiness and generic-surface guardrails are tracked in
 ## Documentation
 
 - [docs/operator/installation.md](docs/operator/installation.md) — full install, bootstrap, service, and troubleshooting path.
+- [docs/workflows/workflow-contract.md](docs/workflows/workflow-contract.md) — `WORKFLOW.md` structure and examples.
 - [docs/workflows/README.md](docs/workflows/README.md) — workflow comparison and templates.
 - [docs/architecture.md](docs/architecture.md) — engine/workflow boundary and durable runtime model.
 - [docs/operator/cheat-sheet.md](docs/operator/cheat-sheet.md) — day-2 commands and debugging.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Day-2 commands and observability.
 ## Workflow docs
 
 - [Bundled workflows](workflows/README.md) — overview of `change-delivery` and `issue-runner`
+- [WORKFLOW.md guide](workflows/workflow-contract.md) — repo-owned contract location, front matter, and Markdown body
 - [change-delivery](workflows/change-delivery.md) — opinionated GitHub SDLC workflow
 - [issue-runner](workflows/issue-runner.md) — generic tracker-driven reference workflow
 - [examples/change-delivery.workflow.md](examples/change-delivery.workflow.md) — copyable default contract

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -8,8 +8,10 @@ its own lifecycle, prompts, gates, and operator commands.
 
 | Workflow | Use it when... | Default template | Managed path |
 |---|---|---|---|
-| [`change-delivery`](change-delivery.md) | you want the opinionated GitHub SDLC workflow: issue -> code -> review -> PR -> merge | [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | yes — `bootstrap` + `service-up` |
-| [`issue-runner`](issue-runner.md) | you want a generic tracker-driven workflow that selects issues, creates workspaces, runs hooks, and invokes one agent | [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md) | yes — `bootstrap --workflow issue-runner` or explicit `scaffold-workflow` + `service-up` |
+| [`issue-runner`](issue-runner.md) | you want a generic issue workflow that creates workspaces, runs hooks, and invokes one agent | [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md) | yes — `bootstrap --workflow issue-runner` or explicit `scaffold-workflow` + `service-up` |
+| [`change-delivery`](change-delivery.md) | you want the opinionated SDLC workflow: issue -> code -> review -> PR -> merge | [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | yes — `bootstrap --workflow change-delivery` + `service-up` |
+
+For the contract file itself, see the [`WORKFLOW.md` guide](workflow-contract.md).
 
 ## The boundary
 

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -1,0 +1,82 @@
+# WORKFLOW.md Guide
+
+Daedalus uses a repo-owned workflow contract to keep workflow policy close to
+the code being automated. Bootstrap writes this file into the target repository,
+not into the Daedalus plugin repository.
+
+## Where It Lives
+
+When a repository has one workflow:
+
+```text
+/path/to/target-repo/WORKFLOW.md
+```
+
+When a repository has more than one workflow:
+
+```text
+/path/to/target-repo/WORKFLOW-issue-runner.md
+/path/to/target-repo/WORKFLOW-change-delivery.md
+```
+
+The workflow root stores runtime data separately under:
+
+```text
+~/.hermes/workflows/<owner>-<repo>-<workflow-type>/
+```
+
+Bootstrap writes a pointer at `./.hermes/daedalus/workflow-root` in the target
+repo so Hermes commands can find the workflow root from that checkout.
+
+## File Shape
+
+`WORKFLOW.md` has YAML front matter followed by Markdown policy text:
+
+```markdown
+---
+workflow: issue-runner
+schema-version: 1
+
+instance:
+  name: your-org-your-repo-issue-runner
+
+tracker:
+  kind: github
+
+agent:
+  name: Issue_Runner_Agent
+  model: gpt-5.5
+  runtime: codex
+---
+
+# Workflow Policy
+
+Only work on the selected issue. Keep changes narrow and report validation.
+```
+
+## Front Matter
+
+The YAML front matter is structured operator configuration:
+
+- `workflow` selects the workflow package.
+- `instance` names the workflow instance.
+- `tracker` and `repository` configure where issues and code live.
+- `runtimes` and `agents` bind workflow roles to execution backends.
+- `hooks`, `gates`, `observability`, and `server` configure workflow-specific behavior.
+
+Each workflow validates this section against its own schema before dispatch.
+
+## Markdown Body
+
+The Markdown body is policy text. Workflows decide how to use it:
+
+- `issue-runner` renders it as the issue prompt template.
+- `change-delivery` composes it into workflow-specific role prompts.
+
+Treat edits to the body like prompt changes: review them carefully and rely on
+hot reload to keep the last known good config if a bad edit lands.
+
+## Examples
+
+- [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md)
+- [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md)

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -69,7 +69,8 @@ def test_public_docs_present_github_first_path():
     issue_runner = (REPO_ROOT / "docs" / "workflows" / "issue-runner.md").read_text(encoding="utf-8")
     conformance = (REPO_ROOT / "docs" / "symphony-conformance.md").read_text(encoding="utf-8")
 
-    assert "GitHub-first SDLC automation engine" in readme
+    assert "Durable SDLC automation engine" in readme
+    assert "GitHub-first SDLC automation engine" not in readme
     assert "First-class tracker" in readme
     assert "docs/harness-engineering.md" in readme
     assert "tracker.kind: github" in install
@@ -87,6 +88,7 @@ def test_docs_index_links_harness_and_omits_removed_planning_archive():
 
     assert "harness-engineering.md" in docs_index
     assert "release-readiness.md" in docs_index
+    assert "workflows/workflow-contract.md" in docs_index
     assert REMOVED_PUBLIC_ARCHIVE not in docs_index.casefold()
     assert REMOVED_PUBLIC_ARCHIVE not in public_contract.casefold()
 


### PR DESCRIPTION
## Summary

- Restores the banner GIF at the top of the landing README.
- Removes GitHub from the tagline and moves tracker support into a dedicated supported-surfaces table where GitHub is marked first-class.
- Replaces the dense Mermaid mental model with a terminology table for target repo, workflow contract, workflow root, tracker, runtime, workspace, state, and operator surface.
- Reorders bundled workflows with `issue-runner` first and keeps the workflow descriptions issue-centered instead of tracker-vendor-centered.
- Moves Quick Start above state internals, clarifies that `WORKFLOW.md` is generated into the user target repo, and adds comments to Hermes `/daedalus` and `/workflow` commands.
- Adds `docs/workflows/workflow-contract.md` and links it from the README and docs index.

## Validation

- `git diff --check`
- `pytest tests/test_public_harness_checks.py tests/test_public_onboarding_smoke.py tests/test_docs_public_workflow_template.py -q` (`16 passed`)
- `pytest -q` (`824 passed, 8 skipped`)