### PR TITLE
[codex] Harden tracker-neutral bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daedalus
 
-**GitHub-first SDLC automation engine for Hermes Agent.**
+**Durable SDLC automation engine for Hermes Agent.**
 
 Daedalus is a stateful workflow runtime for agent-driven software delivery. It
 turns tracker issues into supervised agent work, records durable state, retries
@@ -41,12 +41,12 @@ workflow package owns its own policy, schema, prompts, gates, and commands.
 
 | Workflow | Purpose | Best fit |
 |---|---|---|
-| `change-delivery` | GitHub issue -> code -> internal review -> PR -> external review -> merge | Opinionated SDLC automation with review and merge gates |
 | `issue-runner` | tracker issue -> isolated workspace -> hooks -> prompt -> one agent run | Generic Symphony-shaped issue execution |
+| `change-delivery` | GitHub-backed issue -> code -> internal review -> PR -> external review -> merge | Opinionated SDLC automation with review and merge gates |
 
-`change-delivery` is the default public bootstrap path. `issue-runner` is the
-cleaner reference workflow for generic tracker-driven automation and future
-Symphony compatibility.
+`issue-runner` is the default public bootstrap path and the cleaner reference
+workflow for generic tracker-driven automation and future Symphony
+compatibility. `change-delivery` is the richer GitHub-backed SDLC workflow.
 
 ## Control Loop
 
@@ -107,13 +107,13 @@ hermes daedalus service-up
 hermes
 ```
 
-Use the generic workflow instead:
+Use the opinionated change-delivery workflow instead:
 
 ```bash
-hermes daedalus bootstrap --workflow issue-runner
+hermes daedalus bootstrap --workflow change-delivery
 ```
 
-`bootstrap` detects the repo, derives the GitHub slug, creates the workflow
+`bootstrap` detects the repo, derives the repo slug, creates the workflow
 root, writes the repo-owned workflow contract, commits it on a bootstrap branch,
 and writes `./.hermes/daedalus/workflow-root` so later commands can resolve the
 instance from the repo checkout.

--- a/daedalus/__init__.py
+++ b/daedalus/__init__.py
@@ -5,19 +5,20 @@ from pathlib import Path
 PLUGIN_DIR = Path(__file__).resolve().parent
 
 # Put the plugin dir on sys.path so absolute imports of sibling top-level
-# packages (workflows/, etc.) resolve when Hermes loads us as a package.
-# Hermes' plugin loader puts ~/.hermes/plugins/ on sys.path so this package
-# (`daedalus`) is importable, but doesn't add this directory itself — so
-# tools.py's `from workflows.change_delivery.paths import ...` fails without
-# this bootstrap. Same self-bootstrap pattern as workflows/__main__.py.
+# packages (workflows/, runtimes/, trackers/) resolve when Hermes loads us as a
+# package. Append instead of prepending: Hermes has its own top-level packages,
+# and plugin modules must never shadow them during agent startup.
 _PLUGIN_DIR_STR = str(PLUGIN_DIR)
 if _PLUGIN_DIR_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_DIR_STR)
+    sys.path.append(_PLUGIN_DIR_STR)
 
 
 try:
     from .schemas import setup_cli
-    from .tools import execute_raw_args, execute_workflow_command
+    from . import daedalus_cli as _cli
+    execute_raw_args = _cli.execute_raw_args
+    execute_workflow_command = _cli.execute_workflow_command
+    sys.modules.setdefault(f"{__name__}.tools", _cli)
 except ImportError:
     def _load_local_module(module_name: str):
         module_path = PLUGIN_DIR / f"{module_name}.py"
@@ -29,9 +30,9 @@ except ImportError:
         return module
 
     setup_cli = _load_local_module("schemas").setup_cli
-    _tools_module = _load_local_module("tools")
-    execute_raw_args = _tools_module.execute_raw_args
-    execute_workflow_command = _tools_module.execute_workflow_command
+    _cli_module = _load_local_module("daedalus_cli")
+    execute_raw_args = _cli_module.execute_raw_args
+    execute_workflow_command = _cli_module.execute_workflow_command
 
 
 def register(ctx):

--- a/daedalus/alerts.py
+++ b/daedalus/alerts.py
@@ -23,19 +23,19 @@ DEFAULT_WORKFLOW_ROOT = resolve_default_workflow_root()
 DEFAULT_STATE_PATH = workflow_runtime_paths(DEFAULT_WORKFLOW_ROOT)["alert_state_path"]
 
 
-def _load_tools_module():
-    module_path = PLUGIN_DIR / "tools.py"
-    spec = importlib.util.spec_from_file_location("daedalus_tools_for_alerts", module_path)
+def _load_cli_module():
+    module_path = PLUGIN_DIR / "daedalus_cli.py"
+    spec = importlib.util.spec_from_file_location("daedalus_cli_for_alerts", module_path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load Daedalus plugin tools from {module_path}")
+        raise RuntimeError(f"unable to load Daedalus plugin CLI from {module_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
 def _execute_plugin_command(command: str) -> str:
-    tools_module = _load_tools_module()
-    result = tools_module.execute_raw_args(command)
+    cli_module = _load_cli_module()
+    result = cli_module.execute_raw_args(command)
     if result.startswith("daedalus error:"):
         raise RuntimeError(result)
     return result

--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -263,7 +263,7 @@ def _render_template_unit(*, mode: str) -> str:
             # pyyaml/jsonschema deps the installer's _check_runtime_deps verified
             # against. /usr/bin/env python3 with a non-empty PATH may resolve
             # to homebrew python or a node-managed python that lacks pyyaml.
-            f"ExecStart=/usr/bin/python3 %h/.hermes/plugins/daedalus/tools.py "
+            f"ExecStart=/usr/bin/python3 %h/.hermes/plugins/daedalus/daedalus_cli.py "
             f"service-loop --workflow-root %h/.hermes/workflows/%i "
             f"--project-key %i --instance-id daedalus-{mode}-%i "
             f"--interval-seconds 30 --service-mode {mode} --json"
@@ -2020,7 +2020,7 @@ def build_doctor_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
 
 
 def _lazy_cmd_watch(args, parser):
-    """Lazy import so importing tools.py doesn't pull rich into every CLI invocation."""
+    """Lazy import so importing the CLI doesn't pull rich into every invocation."""
     try:
         from watch import cmd_watch
     except ImportError:
@@ -2045,9 +2045,11 @@ def _workflow_template_path(workflow_name: str) -> Path:
     return path
 
 
-_GITHUB_REMOTE_RE = re.compile(
-    r"^(?:git@github\.com:|ssh://git@github\.com/|https?://(?:www\.)?github\.com/)"
-    r"(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+_REMOTE_OWNER_REPO_RE = re.compile(
+    r"(?P<owner>[^/:]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+_REMOTE_SCP_RE = re.compile(
+    r"^[^@]+@[^:]+:(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
 )
 
 
@@ -2079,17 +2081,18 @@ def _discover_git_repo_root(start_path: Path | None) -> Path:
     return Path(repo_root).expanduser().resolve()
 
 
-def _github_slug_from_remote_url(remote_url: str) -> str:
-    match = _GITHUB_REMOTE_RE.match(remote_url.strip())
+def _repo_slug_from_remote_url(remote_url: str) -> str:
+    raw = remote_url.strip()
+    match = _REMOTE_SCP_RE.match(raw) or _REMOTE_OWNER_REPO_RE.search(raw)
     if not match:
         raise DaedalusCommandError(
-            "unable to derive --github-slug from git origin; use a GitHub remote or pass --github-slug explicitly"
+            "unable to derive --repo-slug from git origin; pass --repo-slug owner/repo explicitly"
         )
     owner = match.group("owner").strip()
     repo = match.group("repo").strip()
     if not owner or not repo:
         raise DaedalusCommandError(
-            "unable to derive --github-slug from git origin; use a GitHub remote or pass --github-slug explicitly"
+            "unable to derive --repo-slug from git origin; pass --repo-slug owner/repo explicitly"
         )
     return f"{owner}/{repo}"
 
@@ -2281,25 +2284,25 @@ def bootstrap_workflow_root(
     repo_path: Path | None,
     workflow_name: str,
     workflow_root: Path | None,
-    github_slug: str | None,
+    repo_slug: str | None,
     active_lane_label: str,
     engine_owner: str,
     force: bool,
 ) -> dict[str, Any]:
     repo_root = _discover_git_repo_root(repo_path)
     remote_url = None
-    resolved_github_slug = (github_slug or "").strip()
-    if not resolved_github_slug:
+    resolved_repo_slug = (repo_slug or "").strip()
+    if not resolved_repo_slug:
         remote_url = _git_stdout("remote", "get-url", "origin", cwd=repo_root)
-        resolved_github_slug = _github_slug_from_remote_url(remote_url)
+        resolved_repo_slug = _repo_slug_from_remote_url(remote_url)
 
     try:
         instance_name = derive_workflow_instance_name(
-            github_slug=resolved_github_slug,
+            repo_slug=resolved_repo_slug,
             workflow_name=workflow_name,
         )
     except ValueError as exc:
-        raise DaedalusCommandError(f"--github-slug {resolved_github_slug!r} is invalid: {exc}") from exc
+        raise DaedalusCommandError(f"--repo-slug {resolved_repo_slug!r} is invalid: {exc}") from exc
 
     resolved_workflow_root = (
         workflow_root.expanduser().resolve()
@@ -2311,7 +2314,7 @@ def bootstrap_workflow_root(
         workflow_root=resolved_workflow_root,
         workflow_name=workflow_name,
         repo_path=repo_root,
-        github_slug=resolved_github_slug,
+        repo_slug=resolved_repo_slug,
         active_lane_label=active_lane_label,
         engine_owner=engine_owner,
         force=force,
@@ -2352,7 +2355,7 @@ def scaffold_workflow_root(
     workflow_root: Path,
     workflow_name: str,
     repo_path: Path | None,
-    github_slug: str,
+    repo_slug: str,
     active_lane_label: str,
     engine_owner: str,
     force: bool,
@@ -2380,21 +2383,21 @@ def scaffold_workflow_root(
     config = dict(template_contract.config)
     workflow_policy = template_contract.prompt_template
 
-    resolved_github_slug = github_slug.strip()
-    if not resolved_github_slug:
-        raise DaedalusCommandError("--github-slug cannot be blank")
+    resolved_repo_slug = repo_slug.strip()
+    if not resolved_repo_slug:
+        raise DaedalusCommandError("--repo-slug cannot be blank")
     try:
         resolved_instance_name = derive_workflow_instance_name(
-            github_slug=resolved_github_slug,
+            repo_slug=resolved_repo_slug,
             workflow_name=workflow_name,
         )
     except ValueError as exc:
-        raise DaedalusCommandError(f"--github-slug {resolved_github_slug!r} is invalid: {exc}") from exc
+        raise DaedalusCommandError(f"--repo-slug {resolved_repo_slug!r} is invalid: {exc}") from exc
     if root.name != resolved_instance_name:
         expected_root = root.parent / resolved_instance_name
         raise DaedalusCommandError(
             "workflow root directory name must follow <owner>-<repo>-<workflow-type>: "
-            f"expected {expected_root} for github-slug={resolved_github_slug!r} "
+            f"expected {expected_root} for repo-slug={resolved_repo_slug!r} "
             f"and workflow={workflow_name!r}"
         )
 
@@ -2403,15 +2406,19 @@ def scaffold_workflow_root(
     config["workflow"] = workflow_name
     instance_cfg = config.setdefault("instance", {})
     repository_cfg = config.setdefault("repository", {})
-    triggers_cfg = config.setdefault("triggers", {})
-    lane_selector_cfg = triggers_cfg.setdefault("lane-selector", {})
 
     instance_cfg["name"] = resolved_instance_name
     instance_cfg["engine-owner"] = engine_owner
     repository_cfg["local-path"] = str(resolved_repo_path)
-    repository_cfg["github-slug"] = resolved_github_slug
-    repository_cfg["active-lane-label"] = active_lane_label
-    lane_selector_cfg["label"] = active_lane_label
+    repository_cfg["slug"] = resolved_repo_slug
+    if workflow_name == "change-delivery":
+        repository_cfg["github-slug"] = resolved_repo_slug
+        repository_cfg["active-lane-label"] = active_lane_label
+    triggers_cfg = config.get("triggers")
+    if isinstance(triggers_cfg, dict):
+        lane_selector_cfg = triggers_cfg.get("lane-selector")
+        if isinstance(lane_selector_cfg, dict):
+            lane_selector_cfg["label"] = active_lane_label
 
     created_dirs = [
         root / "config",
@@ -2453,7 +2460,7 @@ def scaffold_workflow_root(
         "instance_name": resolved_instance_name,
         "engine_owner": engine_owner,
         "repo_path": str(resolved_repo_path),
-        "github_slug": resolved_github_slug,
+        "repo_slug": resolved_repo_slug,
         "active_lane_label": active_lane_label,
         "force": force,
         "workflow_contract_pointer_path": str(workflow_contract_pointer_path(root)),
@@ -2467,7 +2474,7 @@ def cmd_scaffold_workflow(args, parser) -> str:
         workflow_root=Path(args.workflow_root),
         workflow_name=args.workflow,
         repo_path=Path(args.repo_path) if args.repo_path else None,
-        github_slug=args.github_slug,
+        repo_slug=args.repo_slug,
         active_lane_label=args.active_lane_label,
         engine_owner=args.engine_owner,
         force=args.force,
@@ -2480,7 +2487,7 @@ def cmd_scaffold_workflow(args, parser) -> str:
         f"workflow: {result['workflow']}",
         f"instance: {result['instance_name']}",
         f"repo-path: {result['repo_path']}",
-        f"github-slug: {result['github_slug']}",
+        f"repo-slug: {result['repo_slug']}",
     ]
     return "\n".join(lines)
 
@@ -2490,7 +2497,7 @@ def cmd_bootstrap_workflow(args, parser) -> str:
         repo_path=Path(args.repo_path) if args.repo_path else None,
         workflow_name=args.workflow,
         workflow_root=Path(args.workflow_root) if args.workflow_root else None,
-        github_slug=args.github_slug,
+        repo_slug=args.repo_slug,
         active_lane_label=args.active_lane_label,
         engine_owner=args.engine_owner,
         force=args.force,
@@ -2501,7 +2508,7 @@ def cmd_bootstrap_workflow(args, parser) -> str:
         f"bootstrapped workflow root: {result['workflow_root']}",
         f"contract: {result['contract_path']}",
         f"repo-path: {result['repo_path']}",
-        f"github-slug: {result['github_slug']}",
+        f"repo-slug: {result['repo_slug']}",
         f"git branch: {result['git_branch']}",
         f"repo pointer: {result['repo_pointer_path']}",
         f"edit next: {result['next_edit_path']}",
@@ -2965,9 +2972,9 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         required=True,
         help="Workflow root to create. Directory name must be <owner>-<repo>-<workflow-type>.",
     )
-    scaffold_cmd.add_argument("--workflow", default="change-delivery", choices=["change-delivery", "issue-runner"])
+    scaffold_cmd.add_argument("--workflow", default="issue-runner", choices=["change-delivery", "issue-runner"])
     scaffold_cmd.add_argument("--repo-path", type=Path)
-    scaffold_cmd.add_argument("--github-slug", required=True)
+    scaffold_cmd.add_argument("--repo-slug", required=True, help="Repository identity in owner/repo form for workflow instance naming.")
     scaffold_cmd.add_argument("--active-lane-label", default="active-lane")
     scaffold_cmd.add_argument("--engine-owner", default="hermes", choices=["hermes", "openclaw"])
     scaffold_cmd.add_argument("--force", action="store_true")
@@ -2980,8 +2987,8 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     )
     bootstrap_cmd.add_argument("--repo-path", type=Path, help="Git checkout to inspect (defaults to current working directory).")
     bootstrap_cmd.add_argument("--workflow-root", type=Path, help="Optional explicit workflow root override.")
-    bootstrap_cmd.add_argument("--workflow", default="change-delivery", choices=["change-delivery", "issue-runner"])
-    bootstrap_cmd.add_argument("--github-slug", help="Override the inferred GitHub slug from git origin.")
+    bootstrap_cmd.add_argument("--workflow", default="issue-runner", choices=["change-delivery", "issue-runner"])
+    bootstrap_cmd.add_argument("--repo-slug", help="Override the inferred repository slug from git origin.")
     bootstrap_cmd.add_argument("--active-lane-label", default="active-lane")
     bootstrap_cmd.add_argument("--engine-owner", default="hermes", choices=["hermes", "openclaw"])
     bootstrap_cmd.add_argument("--force", action="store_true")

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -40,7 +40,7 @@ import sys
 def _load_migration_module():
     """Load the sibling migration.py module via file path.
 
-    Mirrors tools.py::_load_daedalus_module / alerts.py::_load_tools_module
+    Mirrors daedalus_cli.py::_load_daedalus_module / alerts.py::_load_cli_module
     so runtime.py works whether loaded as part of the hermes_relay package
     or directly via spec_from_file_location.
     """

--- a/daedalus/schemas.py
+++ b/daedalus/schemas.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 
 try:
-    from .tools import configure_subcommands
+    from .daedalus_cli import configure_subcommands
 except ImportError:
-    module_path = Path(__file__).resolve().parent / "tools.py"
-    spec = spec_from_file_location("daedalus_tools_for_schemas", module_path)
+    module_path = Path(__file__).resolve().parent / "daedalus_cli.py"
+    spec = spec_from_file_location("daedalus_cli_for_schemas", module_path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load tools from {module_path}")
+        raise RuntimeError(f"unable to load cli from {module_path}")
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
     configure_subcommands = module.configure_subcommands

--- a/daedalus/skills/daedalus-hardening-slices/SKILL.md
+++ b/daedalus/skills/daedalus-hardening-slices/SKILL.md
@@ -16,7 +16,7 @@ Use this when continuing Daedalus reliability work around stalled dispatches, re
 
 2. **Locate the real implementation points**
    - `runtime.py` for schema, lane actions, recovery, reaping, and runtime status.
-   - `tools.py` for doctor/report exposure.
+   - `daedalus_cli.py` for doctor/report exposure.
    - `alerts.py` for alert decisioning and state persistence.
    - Tests in `tests/test_runtime_tools_alerts.py` or adjacent files.
 

--- a/daedalus/skills/daedalus-retire-watchdog-and-migrate-control-schema/SKILL.md
+++ b/daedalus/skills/daedalus-retire-watchdog-and-migrate-control-schema/SKILL.md
@@ -44,7 +44,7 @@ Steps
      - if neither exists, create `execution_controls`
    - Do not leave compatibility shims around once the migration exists.
 
-4. Update operator surface in `tools.py`.
+4. Update operator surface in `daedalus_cli.py`.
    - Replace cutover commands with:
      - `/daedalus active-gate-status`
      - `/daedalus set-active-execution --enabled true|false`

--- a/daedalus/skills/hermes-plugin-cli-wiring/SKILL.md
+++ b/daedalus/skills/hermes-plugin-cli-wiring/SKILL.md
@@ -125,7 +125,7 @@ For project-local operator plugins, keep the real implementation inside the plug
 Preferred shape:
 - `.hermes/plugins/<plugin>/__init__.py`
 - `.hermes/plugins/<plugin>/schemas.py`
-- `.hermes/plugins/<plugin>/tools.py`
+- `.hermes/plugins/<plugin>/cli.py`
 - `.hermes/plugins/<plugin>/runtime.py` (or `core/runtime.py`)
 - optional `.hermes/plugins/<plugin>/alerts.py`
 - `scripts/<entrypoint>.py` wrappers that import the plugin module and call `main()`

--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -43,6 +43,23 @@ def register(kind: str):
     return _register
 
 
+def _ensure_builtin_tracker_kinds() -> None:
+    """Register built-ins even if submodules were imported before this package reloaded.
+
+    Hermes plugin tests load repo and installed-plugin copies in the same Python
+    process. In that situation ``trackers`` can be re-execed while
+    ``trackers.local_json`` remains cached, so decorators do not run again.
+    Explicitly binding the built-in classes keeps the registry deterministic.
+    """
+    from .github import GithubTrackerClient
+    from .linear import LinearTrackerClient
+    from .local_json import LocalJsonTrackerClient
+
+    _TRACKER_KINDS.setdefault("github", GithubTrackerClient)
+    _TRACKER_KINDS.setdefault("linear", LinearTrackerClient)
+    _TRACKER_KINDS.setdefault("local-json", LocalJsonTrackerClient)
+
+
 def resolve_tracker_path(*, workflow_root: Path, tracker_cfg: dict[str, Any]) -> Path:
     path_value = str(tracker_cfg.get("path") or "").strip()
     if not path_value:
@@ -82,9 +99,7 @@ def build_tracker_client(
     run_json: Callable[..., Any] | None = None,
 ) -> TrackerClient:
     kind = tracker_kind(tracker_cfg)
-    from . import github  # noqa: F401
-    from . import linear  # noqa: F401
-    from . import local_json  # noqa: F401
+    _ensure_builtin_tracker_kinds()
 
     if kind not in _TRACKER_KINDS:
         raise TrackerConfigError(

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -21,7 +21,7 @@ def _github_slug_match(raw: str) -> re.Match[str] | None:
 
 def _github_slug_config_error() -> TrackerConfigError:
     return TrackerConfigError(
-        "repository.github-slug must be in owner/repo or host/owner/repo form for tracker.kind='github'"
+        "tracker.github_slug or repository.github-slug must be in owner/repo or host/owner/repo form for tracker.kind='github'"
     )
 
 
@@ -218,7 +218,7 @@ def _resolve_repo_path(
         if not required:
             return None
         raise TrackerConfigError(
-            "tracker.kind='github' requires repository.github-slug or repository.local-path"
+            "tracker.kind='github' requires tracker.github_slug, repository.github-slug, or repository.local-path"
         )
     path = Path(raw).expanduser()
     if not path.is_absolute():

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -32,8 +32,29 @@ properties:
     required: [local-path, github-slug, active-lane-label]
     properties:
       local-path: {type: string}
+      slug: {type: string}
       github-slug: {type: string}
       active-lane-label: {type: string}
+
+  tracker:
+    type: object
+    required: [kind]
+    properties:
+      kind:
+        type: string
+        enum: [github]
+      active_states:
+        type: array
+        items: {type: string}
+      terminal_states:
+        type: array
+        items: {type: string}
+      active-states:
+        type: array
+        items: {type: string}
+      terminal-states:
+        type: array
+        items: {type: string}
 
   runtimes:
     type: object

--- a/daedalus/workflows/change_delivery/workflow.template.md
+++ b/daedalus/workflows/change_delivery/workflow.template.md
@@ -8,8 +8,16 @@ instance:
 
 repository:
   local-path: /home/you/src/acme-repo
+  slug: your-org/your-repo
   github-slug: your-org/your-repo
   active-lane-label: active-lane
+
+tracker:
+  kind: github
+  active_states:
+    - open
+  terminal_states:
+    - closed
 
 runtimes:
   coder-runtime:

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -28,9 +28,10 @@ properties:
 
   repository:
     type: object
-    required: [local-path, github-slug]
+    required: [local-path]
     properties:
       local-path: {type: string}
+      slug: {type: string}
       github-slug: {type: string}
 
   tracker:
@@ -41,6 +42,8 @@ properties:
         type: string
         enum: [local-json, linear, github]
       path: {type: string}
+      github_slug: {type: string}
+      github-slug: {type: string}
       endpoint: {type: string}
       api_key: {type: string}
       project_slug: {type: string}

--- a/daedalus/workflows/issue_runner/tracker.py
+++ b/daedalus/workflows/issue_runner/tracker.py
@@ -15,9 +15,6 @@ from trackers import (
     load_issues,
     resolve_tracker_path,
 )
-from trackers.github import GithubTrackerClient
-from trackers.linear import LinearTrackerClient
-from trackers.local_json import LocalJsonTrackerClient
 
 
 _WORKSPACE_KEY_ALLOWED = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
@@ -96,9 +93,6 @@ def _blocker_is_active(blocker: dict[str, Any], *, terminal_states: set[str]) ->
 __all__ = [
     "DEFAULT_ACTIVE_STATES",
     "DEFAULT_TERMINAL_STATES",
-    "GithubTrackerClient",
-    "LinearTrackerClient",
-    "LocalJsonTrackerClient",
     "TrackerClient",
     "TrackerConfigError",
     "build_tracker_client",

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -8,7 +8,7 @@ instance:
 
 repository:
   local-path: /home/you/src/acme-repo
-  github-slug: your-org/your-repo
+  slug: your-org/your-repo
 
 tracker:
   kind: local-json

--- a/daedalus/workflows/shared/paths.py
+++ b/daedalus/workflows/shared/paths.py
@@ -36,10 +36,10 @@ def normalize_workflow_instance_segment(value: str | None) -> str:
     return text.strip("-")
 
 
-def derive_workflow_instance_name(*, github_slug: str, workflow_name: str) -> str:
-    slug = str(github_slug or "").strip()
+def derive_workflow_instance_name(*, repo_slug: str, workflow_name: str) -> str:
+    slug = str(repo_slug or "").strip()
     if slug.count("/") != 1:
-        raise ValueError("github slug must use owner/repo format")
+        raise ValueError("repo slug must use owner/repo format")
     owner_raw, repo_raw = slug.split("/", 1)
     owner = normalize_workflow_instance_segment(owner_raw)
     repo = normalize_workflow_instance_segment(repo_raw)
@@ -211,4 +211,3 @@ def resolve_default_workflow_root(
     if workflow_config_path(repo_parent).exists():
         return repo_parent
     return cwd_path
-

--- a/daedalus_cli.py
+++ b/daedalus_cli.py
@@ -1,11 +1,11 @@
 """Repo-root wrapper for the official Hermes plugin layout."""
 
 try:
-    from .daedalus.tools import *  # noqa: F401,F403
-    from .daedalus.tools import execute_raw_args as _execute_raw_args
+    from .daedalus.daedalus_cli import *  # noqa: F401,F403
+    from .daedalus.daedalus_cli import execute_raw_args as _execute_raw_args
 except ImportError:
-    from daedalus.tools import *  # noqa: F401,F403
-    from daedalus.tools import execute_raw_args as _execute_raw_args
+    from daedalus.daedalus_cli import *  # noqa: F401,F403
+    from daedalus.daedalus_cli import execute_raw_args as _execute_raw_args
 
 
 if __name__ == "__main__":

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,14 +9,14 @@ Entry point for everything that won't fit on the [project landing page](../READM
 - **[workflows/README.md](workflows/README.md)** — the two bundled workflows, when to use each, and where their templates live.
 - **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
 - **[symphony-conformance.md](symphony-conformance.md)** — where Daedalus matches the current Symphony draft, and where it still differs.
-- **[harness-engineering.md](harness-engineering.md)** — repo-level checks that keep the public surface generic, GitHub-first, and template-safe.
+- **[harness-engineering.md](harness-engineering.md)** — repo-level checks that keep the public surface generic, tracker-neutral, and template-safe.
 - **[release-readiness.md](release-readiness.md)** — public-beta scorecard, launch gates, and next hardening slice.
 - **[security.md](security.md)** — the trust model, shell/network posture, and secret-handling expectations.
 
 ## How to read these docs
 
 - Generic docs describe the plugin engine: contracts, state stores, runtimes, trackers, service supervision, and observability.
-- Workflow docs describe lifecycle policy. `change-delivery` is the opinionated GitHub issue-to-merge path; `issue-runner` is the smaller generic tracker-driven path.
+- Workflow docs describe lifecycle policy. `issue-runner` is the generic tracker-driven path; `change-delivery` is the opinionated GitHub-backed issue-to-merge path.
 - Operator docs describe installed deployments. SQL examples usually apply to `change-delivery`; `issue-runner` uses persisted status, scheduler, and audit files instead.
 
 ## Concepts
@@ -49,8 +49,8 @@ Day-2 commands and observability.
 - [Bundled workflows](workflows/README.md) — overview of `change-delivery` and `issue-runner`
 - [change-delivery](workflows/change-delivery.md) — opinionated GitHub SDLC workflow
 - [issue-runner](workflows/issue-runner.md) — generic tracker-driven reference workflow
-- [examples/change-delivery.workflow.md](examples/change-delivery.workflow.md) — copyable default contract
-- [examples/issue-runner.workflow.md](examples/issue-runner.workflow.md) — copyable generic tracker-driven contract
+- [examples/issue-runner.workflow.md](examples/issue-runner.workflow.md) — copyable default generic tracker-driven contract
+- [examples/change-delivery.workflow.md](examples/change-delivery.workflow.md) — copyable GitHub-backed SDLC contract
 
 ## History & decisions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -292,7 +292,7 @@ daedalus/
 ├── __init__.py              # Plugin registration
 ├── plugin.yaml              # Plugin manifest
 ├── schemas.py               # CLI/slash parser schema
-├── tools.py                 # Operator surface + systemd helpers
+├── daedalus_cli.py          # Operator surface + systemd helpers
 ├── runtime.py               # Durable engine (the heart)
 │   ├── database schema
 │   ├── leases + heartbeats

--- a/docs/concepts/failures.md
+++ b/docs/concepts/failures.md
@@ -160,5 +160,5 @@ group by lane_id;
 - Failure tracking: `daedalus/runtime.py` (look for `record_failure`, `resolve_failure`, `retry_eligible`)
 - Action queue: `daedalus/runtime.py` (look for `request_active_action`, `action_idempotency_key`)
 - Retry logic: `daedalus/workflows/change_delivery/dispatch.py`
-- Operator surface: `daedalus/tools.py` (`analyze-failure` command)
+- Operator surface: `daedalus/daedalus_cli.py` (`analyze-failure` command)
 - Tests: `tests/test_workflows_change_delivery_actions.py`, `tests/test_stall_detection.py`

--- a/docs/concepts/migration.md
+++ b/docs/concepts/migration.md
@@ -167,7 +167,7 @@ The shadow rows remain, so you can diff "what shadow would do" vs "what active d
 ## Where this lives in code
 
 - Filesystem migration: `daedalus/migration.py`
-- Systemd templates: `daedalus/tools.py` (service-install helpers)
+- Systemd templates: `daedalus/daedalus_cli.py` (service-install helpers)
 - Migration scripts: `scripts/migrate_config.py`, `scripts/install.py`
 - Active gate: `daedalus/runtime.py::active_gate_status`
 - Shadow/active modes: `daedalus/runtime.py` (look for `Mode.SHADOW`, `Mode.ACTIVE`)

--- a/docs/concepts/shadow-active.md
+++ b/docs/concepts/shadow-active.md
@@ -61,5 +61,5 @@ sequenceDiagram
 
 - Mode selection: `daedalus/runtime.py` (look for `Mode`, `iterate_shadow`, `iterate_active`)
 - Active gate: `daedalus/runtime.py::active_gate_status`
-- Service supervision: `daedalus/tools.py` (systemd helpers)
+- Service supervision: `daedalus/daedalus_cli.py` (systemd helpers)
 - Shadow reporting: `daedalus/formatters.py::format_shadow_report`

--- a/docs/examples/change-delivery.workflow.md
+++ b/docs/examples/change-delivery.workflow.md
@@ -8,8 +8,16 @@ instance:
 
 repository:
   local-path: /home/you/src/acme-repo
+  slug: your-org/your-repo
   github-slug: your-org/your-repo
   active-lane-label: active-lane
+
+tracker:
+  kind: github
+  active_states:
+    - open
+  terminal_states:
+    - closed
 
 runtimes:
   coder-runtime:

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -8,7 +8,7 @@ instance:
 
 repository:
   local-path: /home/you/src/acme-repo
-  github-slug: your-org/your-repo
+  slug: your-org/your-repo
 
 tracker:
   kind: local-json

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -5,10 +5,13 @@ the implementation continues to move quickly.
 
 ## Public Posture
 
-The public release is GitHub-first:
+The public release is tracker-neutral in shape and GitHub-first in production
+coverage:
 
-- `change-delivery` is the supported managed SDLC workflow.
-- `issue-runner` supports GitHub as the first-class tracker path.
+- `issue-runner` is the default managed workflow and uses the shared tracker
+  boundary.
+- `change-delivery` is the opinionated GitHub-backed SDLC workflow.
+- GitHub is the first-class production tracker adapter.
 - `local-json` exists for local development and deterministic tests.
 - Linear remains an experimental adapter until the GitHub path has real
   integration coverage and stronger operator docs.
@@ -17,7 +20,8 @@ The public release is GitHub-first:
 
 The harness tests should catch these regressions before review:
 
-- public docs must describe the GitHub-first path clearly
+- public docs must keep the workflow story tracker-neutral while documenting
+  GitHub as the first-class adapter
 - release readiness must keep the public-beta posture and launch gates explicit
 - public examples must use generic placeholders like `your-org/your-repo`
 - bundled workflow templates must match their public docs copies

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -1,8 +1,8 @@
 # Daedalus installation
 
 This is the supported community install path for the first public release.
-The default managed path is for the bundled `change-delivery` workflow, but
-`issue-runner` now uses the same repo-owned contract and `service-up` surface.
+The default managed path is for the bundled `issue-runner` workflow. Use
+`change-delivery` when you want the opinionated GitHub-backed SDLC workflow.
 
 ## Requirements
 
@@ -24,18 +24,18 @@ The bundled `issue-runner` template defaults to `tracker.kind: local-json` so
 it is runnable without an external tracker. For first-class tracker operation,
 switch it to `tracker.kind: github` and keep `gh` authenticated in the repo
 checkout before running `service-up`. Linear exists as an experimental adapter,
-but it is deferred for the public GitHub-first path.
+but it is deferred until the GitHub adapter is hardened further.
 
 ## Bundled workflows
 
 Daedalus currently ships two workflow packages:
 
 - `change-delivery`
-  This is the supported managed workflow behind `bootstrap` and `service-up`.
+  This is the opinionated GitHub-backed SDLC workflow. Use
+  `bootstrap --workflow change-delivery`, then bring it up with `service-up`.
 - `issue-runner`
-  This is the bundled generic tracker-driven workflow. Use
-  `bootstrap --workflow issue-runner` or `scaffold-workflow --workflow issue-runner`,
-  then bring it up with `service-up` in `active` mode.
+  This is the bundled generic tracker-driven workflow behind the default
+  `bootstrap` and `service-up` path.
 
 ## Install the plugin
 
@@ -66,13 +66,14 @@ cd /path/to/your/repo
 hermes daedalus bootstrap
 ```
 
-This is the preferred path for `change-delivery`. To bootstrap the generic
-workflow instead, run `hermes daedalus bootstrap --workflow issue-runner`.
+This bootstraps the generic `issue-runner` workflow by default. To bootstrap
+the opinionated SDLC workflow instead, run
+`hermes daedalus bootstrap --workflow change-delivery`.
 
 `bootstrap`:
 
 - detects the git repo root from the current checkout
-- derives `github-slug` from `origin`
+- derives `repo-slug` from `origin`
 - creates the supported instance layout below
 - writes or promotes the repo-owned workflow contract
 - creates a dedicated bootstrap branch
@@ -90,8 +91,8 @@ If you want explicit control over the target root or slug:
 
 ```bash
 hermes daedalus scaffold-workflow \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-change-delivery \
-  --github-slug your-org/your-repo
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-issue-runner \
+  --repo-slug your-org/your-repo
 ```
 
 That creates the same supported instance layout:
@@ -100,13 +101,13 @@ That creates the same supported instance layout:
 ~/.hermes/workflows/<owner>-<repo>-<workflow-type>/
 ```
 
-If you want the bundled generic workflow instead of the managed default:
+If you want the opinionated change-delivery workflow instead:
 
 ```bash
 hermes daedalus scaffold-workflow \
-  --workflow issue-runner \
-  --workflow-root ~/.hermes/workflows/your-org-your-repo-issue-runner \
-  --github-slug your-org/your-repo
+  --workflow change-delivery \
+  --workflow-root ~/.hermes/workflows/your-org-your-repo-change-delivery \
+  --repo-slug your-org/your-repo
 ```
 
 The first workflow in a repo is written to:

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -10,7 +10,7 @@ and keep `change-delivery` as the opinionated GitHub SDLC workflow.
 ## Positioning
 
 - Daedalus is a long-running workflow orchestrator with durable state, hot reload, isolated lane worktrees, recovery, and operator observability.
-- Daedalus is intentionally **GitHub-first** for the public release. The current Symphony draft is **Linear-first**, so Daedalus tracks that shape without making Linear the launch path.
+- Daedalus is intentionally **tracker-neutral in contract shape** and **GitHub-first in production coverage** for the public release. The current Symphony draft is **Linear-first**, so Daedalus tracks that shape without making Linear the launch path.
 - Daedalus now uses a Symphony-style `WORKFLOW.md` as the native public contract for bundled workflows. `issue-runner` is the closer generic reference surface; `change-delivery` remains the richer GitHub SDLC workflow.
 
 ## Status Matrix
@@ -43,7 +43,7 @@ and workflow-specific prompts.
 
 Daedalus currently differs from the Symphony draft in four material ways:
 
-1. The supported managed workflow is GitHub-backed `change-delivery`; `issue-runner` is the generic reference workflow, but public hardening is GitHub-first rather than Linear-first.
+1. The default managed workflow is `issue-runner`, while `change-delivery` remains the opinionated GitHub-backed SDLC workflow.
 2. Runtime adapters are still mixed: both bundled workflows can use Codex app-server, but non-Codex command runtimes remain CLI/session-oriented.
 3. `WORKFLOW.md` still maps into the current Daedalus schema rather than a tracker-agnostic Symphony config model.
 4. Long-running service paths have async supervision for `issue-runner` workers and `change-delivery` active iterations, but manual `tick` remains synchronous and command-style runtimes still have limited cancellation semantics.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -8,8 +8,8 @@ its own lifecycle, prompts, gates, and operator commands.
 
 | Workflow | Use it when... | Default template | Managed path |
 |---|---|---|---|
-| [`change-delivery`](change-delivery.md) | you want the opinionated GitHub SDLC workflow: issue -> code -> review -> PR -> merge | [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | yes — `bootstrap` + `service-up` |
-| [`issue-runner`](issue-runner.md) | you want a generic tracker-driven workflow that selects issues, creates workspaces, runs hooks, and invokes one agent | [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md) | yes — `bootstrap --workflow issue-runner` or explicit `scaffold-workflow` + `service-up` |
+| [`issue-runner`](issue-runner.md) | you want a generic tracker-driven workflow that selects issues, creates workspaces, runs hooks, and invokes one agent | [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md) | yes — default `bootstrap` + `service-up` |
+| [`change-delivery`](change-delivery.md) | you want the opinionated GitHub-backed SDLC workflow: issue -> code -> review -> PR -> merge | [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | yes — `bootstrap --workflow change-delivery` + `service-up` |
 
 ## The boundary
 

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -1,7 +1,7 @@
 # `change-delivery`
 
-`change-delivery` is the opinionated bundled SDLC workflow. It is the current
-managed/default Daedalus path.
+`change-delivery` is the opinionated bundled SDLC workflow for GitHub-backed
+issue-to-PR delivery.
 
 ## What it does
 
@@ -14,8 +14,8 @@ It takes a GitHub issue through:
 5. external review
 6. merge and promotion
 
-This is the workflow behind the default `bootstrap` and `service-up` operator
-flow.
+Use `bootstrap --workflow change-delivery` when you want this lifecycle instead
+of the default generic `issue-runner` workflow.
 
 ## Use it when
 
@@ -30,7 +30,8 @@ flow.
 
 ## Key config blocks
 
-- `repository`: repo checkout, GitHub slug, active-lane label
+- `repository`: repo checkout, repo slug, GitHub slug, active-lane label
+- `tracker`: GitHub-backed issue source and issue state mapping
 - `runtimes`: shared runtime backend profiles used by the workflow roles
 - `agents`: the workflow roles and their runtime/model bindings
 - `gates`: publish/merge policy
@@ -78,11 +79,11 @@ watch` and the HTTP state payload under `codex_turns`.
 
 ## Operator path
 
-Default onboarding:
+Onboarding:
 
 ```bash
 cd /path/to/repo
-hermes daedalus bootstrap
+hermes daedalus bootstrap --workflow change-delivery
 $EDITOR /path/to/repo/WORKFLOW.md
 hermes daedalus service-up
 ```

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -61,7 +61,7 @@ Supported tracker kinds today:
 
 - `github` — first-class public tracker path, backed by authenticated `gh`
 - `local-json` — local development and test fixture path
-- `linear` — experimental adapter, deferred until after the GitHub-first path is hardened
+- `linear` — experimental adapter, deferred until after the GitHub adapter is hardened
 
 `issue-runner` composes the shared `trackers/` clients with workflow-specific
 eligibility, ordering, retry, and workspace policy.
@@ -89,7 +89,7 @@ Use either:
 
 ```bash
 cd /path/to/repo
-hermes daedalus bootstrap --workflow issue-runner
+hermes daedalus bootstrap
 ```
 
 or the explicit scaffold path:
@@ -98,13 +98,13 @@ or the explicit scaffold path:
 hermes daedalus scaffold-workflow \
   --workflow issue-runner \
   --workflow-root ~/.hermes/workflows/<owner>-<repo>-issue-runner \
-  --github-slug <owner>/<repo>
+  --repo-slug <owner>/<repo>
 ```
 
 Then edit:
 
 - `WORKFLOW.md` or `WORKFLOW-issue-runner.md` in the repo checkout
-- `tracker.active_states: [open]`, `tracker.terminal_states: [closed]`, and `gh` auth if you are using `tracker.kind: github`
+- `tracker.github_slug`, `tracker.active_states: [open]`, `tracker.terminal_states: [closed]`, and `gh` auth if you are using `tracker.kind: github`
 - `config/issues.json` if you are using `tracker.kind: local-json`
 - `tracker.endpoint`, `tracker.api_key`, and `tracker.project_slug` only if you are deliberately testing the experimental Linear adapter
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -23,7 +23,7 @@ PAYLOAD_ITEMS = [
     "runtimes",
     "schemas.py",
     "trackers",
-    "tools.py",
+    "daedalus_cli.py",
     "watch.py",
     "watch_sources.py",
     "workflows",

--- a/tests/test_daedalus_migration.py
+++ b/tests/test_daedalus_migration.py
@@ -147,7 +147,7 @@ def test_cli_migrate_filesystem_invokes_migrator(tmp_path, monkeypatch):
     """Smoke test: `daedalus migrate-filesystem --workflow-root <path>`
     invokes migrate_filesystem_state and prints the result."""
     import importlib.util
-    tools_path = Path(__file__).resolve().parents[1] / "daedalus" / "tools.py"
+    tools_path = Path(__file__).resolve().parents[1] / "daedalus" / "daedalus_cli.py"
     spec = importlib.util.spec_from_file_location("daedalus_tools_for_migrate_test", tools_path)
     tools = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(tools)

--- a/tests/test_daedalus_observability_cli.py
+++ b/tests/test_daedalus_observability_cli.py
@@ -26,7 +26,7 @@ def _make_workflow_root(tmp_path):
 
 
 def test_set_observability_writes_override(tmp_path):
-    tools = load_module("daedalus_tools_set_obs_test", "tools.py")
+    tools = load_module("daedalus_tools_set_obs_test", "daedalus_cli.py")
     root = _make_workflow_root(tmp_path)
 
     args = mock.Mock()
@@ -45,7 +45,7 @@ def test_set_observability_writes_override(tmp_path):
 
 
 def test_set_observability_unset_removes_block(tmp_path):
-    tools = load_module("daedalus_tools_set_obs_test", "tools.py")
+    tools = load_module("daedalus_tools_set_obs_test", "daedalus_cli.py")
     root = _make_workflow_root(tmp_path)
 
     # First set
@@ -69,7 +69,7 @@ def test_set_observability_unset_removes_block(tmp_path):
 
 
 def test_get_observability_shows_default_source_when_no_yaml_no_override(tmp_path):
-    tools = load_module("daedalus_tools_get_obs_test", "tools.py")
+    tools = load_module("daedalus_tools_get_obs_test", "daedalus_cli.py")
     root = _make_workflow_root(tmp_path)
 
     # Create a workflow.yaml without an observability block
@@ -101,7 +101,7 @@ storage: {ledger: l, health: h, audit-log: a}
 
 
 def test_get_observability_shows_override_source_when_overridden(tmp_path):
-    tools = load_module("daedalus_tools_get_obs_test", "tools.py")
+    tools = load_module("daedalus_tools_get_obs_test", "daedalus_cli.py")
     root = _make_workflow_root(tmp_path)
 
     (root / "config" / "workflow.yaml").write_text("""\

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -26,6 +27,7 @@ def test_install_into_default_hermes_home_copies_plugin_tree(tmp_path):
     assert (plugin_dir / "runtime.py").exists()
     assert (plugin_dir / "alerts.py").exists()
     assert (plugin_dir / "trackers" / "__init__.py").exists()
+    assert not (plugin_dir / "tools.py").exists()
     assert (plugin_dir / "workflows" / "change_delivery" / "status.py").exists()
     assert (plugin_dir / "workflows" / "change_delivery" / "workflow.template.md").exists()
     assert (plugin_dir / "workflows" / "issue_runner" / "workflow.template.md").exists()
@@ -44,10 +46,27 @@ def test_install_into_explicit_destination_uses_given_path(tmp_path):
     assert (target / "runtimes" / "codex_app_server.py").exists()
     assert (target / "plugin.yaml").exists()
     assert (target / "trackers" / "linear.py").exists()
-    assert (target / "tools.py").exists()
+    assert (target / "daedalus_cli.py").exists()
+    assert not (target / "tools.py").exists()
     assert (target / "workflows" / "change_delivery" / "workflow.py").exists()
     assert (target / "workflows" / "issue_runner" / "workspace.py").exists()
     assert not (target / "projects").exists()
+
+
+def test_installed_plugin_does_not_shadow_hermes_tools_package(tmp_path):
+    install = load_install_module()
+    repo_root = Path(__file__).resolve().parents[1]
+    hermes_home = tmp_path / ".hermes"
+    plugin_dir = install.install_plugin(repo_root=repo_root, hermes_home=hermes_home)
+
+    before = list(sys.path)
+    try:
+        sys.path.insert(0, str(plugin_dir))
+        spec = importlib.util.find_spec("tools")
+    finally:
+        sys.path[:] = before
+
+    assert spec is None or not str(spec.origin or "").startswith(str(plugin_dir))
 
 
 def test_install_replaces_legacy_symlink_destination_with_real_directory(tmp_path):

--- a/tests/test_official_plugin_layout.py
+++ b/tests/test_official_plugin_layout.py
@@ -23,7 +23,7 @@ def test_repo_root_exposes_official_hermes_plugin_layout():
         REPO_ROOT / "__init__.py",
         REPO_ROOT / "runtimes" / "__init__.py",
         REPO_ROOT / "schemas.py",
-        REPO_ROOT / "tools.py",
+        REPO_ROOT / "daedalus_cli.py",
         REPO_ROOT / "trackers" / "__init__.py",
         REPO_ROOT / "runtime.py",
         REPO_ROOT / "workflows" / "__init__.py",
@@ -35,6 +35,7 @@ def test_repo_root_exposes_official_hermes_plugin_layout():
     ]
     missing = [str(path.relative_to(REPO_ROOT)) for path in expected if not path.exists()]
     assert not missing, f"missing repo-root plugin files: {missing}"
+    assert not (REPO_ROOT / "tools.py").exists()
 
 
 def test_repo_root_manifest_matches_installed_payload_manifest():
@@ -71,8 +72,8 @@ def test_repo_root_plugin_entrypoint_registers_same_commands_and_skill():
 
 
 def test_repo_root_tools_wrapper_dispatches_scaffold(tmp_path):
-    tools = _load_module("daedalus_repo_root_tools_test", REPO_ROOT / "tools.py")
-    workflow_root = tmp_path / "attmous-daedalus-change-delivery"
+    tools = _load_module("daedalus_repo_root_tools_test", REPO_ROOT / "daedalus_cli.py")
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
@@ -85,7 +86,7 @@ def test_repo_root_tools_wrapper_dispatches_scaffold(tmp_path):
     )
 
     out = tools.execute_raw_args(
-        f"scaffold-workflow --workflow-root {workflow_root} --repo-path {repo} --github-slug attmous/daedalus"
+        f"scaffold-workflow --workflow-root {workflow_root} --repo-path {repo} --repo-slug attmous/daedalus"
     )
 
     assert "daedalus error:" not in out, out

--- a/tests/test_pip_plugin_packaging.py
+++ b/tests/test_pip_plugin_packaging.py
@@ -106,7 +106,7 @@ def test_wheel_extracts_to_working_plugin_package(tmp_path):
 
     plugin_dir = site_packages / "daedalus"
     plugin = _load_module("daedalus_packaged_plugin_test", plugin_dir / "__init__.py")
-    tools = _load_module("daedalus_packaged_tools_test", plugin_dir / "tools.py")
+    tools = _load_module("daedalus_packaged_tools_test", plugin_dir / "daedalus_cli.py")
     assert (plugin_dir / "runtimes" / "__init__.py").exists()
     assert (plugin_dir / "trackers" / "__init__.py").exists()
 
@@ -133,7 +133,7 @@ def test_wheel_extracts_to_working_plugin_package(tmp_path):
     assert any(item["name"] == "daedalus" for item in calls["cli_commands"])
     assert any(name == "operator" and path.exists() for name, path, _desc in calls["skills"])
 
-    workflow_root = tmp_path / "attmous-daedalus-change-delivery"
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
@@ -145,7 +145,7 @@ def test_wheel_extracts_to_working_plugin_package(tmp_path):
         text=True,
     )
     out = tools.execute_raw_args(
-        f"scaffold-workflow --workflow-root {workflow_root} --repo-path {repo} --github-slug attmous/daedalus"
+        f"scaffold-workflow --workflow-root {workflow_root} --repo-path {repo} --repo-slug attmous/daedalus"
     )
     assert "daedalus error:" not in out, out
     assert (repo / "WORKFLOW.md").exists()

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -63,13 +63,14 @@ def test_projects_tree_is_placeholder_only():
     ]
 
 
-def test_public_docs_present_github_first_path():
+def test_public_docs_present_tracker_neutral_path():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     install = (REPO_ROOT / "docs" / "operator" / "installation.md").read_text(encoding="utf-8")
     issue_runner = (REPO_ROOT / "docs" / "workflows" / "issue-runner.md").read_text(encoding="utf-8")
     conformance = (REPO_ROOT / "docs" / "symphony-conformance.md").read_text(encoding="utf-8")
 
-    assert "GitHub-first SDLC automation engine" in readme
+    assert "Durable SDLC automation engine" in readme
+    assert "issue-runner` is the default public bootstrap path" in readme
     assert "First-class tracker" in readme
     assert "docs/harness-engineering.md" in readme
     assert "tracker.kind: github" in install
@@ -77,6 +78,7 @@ def test_public_docs_present_github_first_path():
     assert "`github` — first-class public tracker path" in issue_runner
     assert "`local-json` — local development and test fixture path" in issue_runner
     assert "`linear` — experimental adapter" in issue_runner
+    assert "tracker-neutral in contract shape" in conformance
     assert "skipped-by-default live smoke" in conformance
     assert ("Linear integration" + " smoke tests") not in conformance
 

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -15,78 +15,14 @@ def _load_module(module_name: str, path: Path):
     return module
 
 
-def test_public_onboarding_path_install_bootstrap_and_service_up(tmp_path, monkeypatch):
+def test_public_onboarding_path_install_bootstrap_defaults_to_issue_runner_and_service_up(tmp_path, monkeypatch):
     install = _load_module("daedalus_install_smoke", REPO_ROOT / "scripts" / "install.py")
     hermes_home = tmp_path / ".hermes"
     plugin_dir = install.install_plugin(repo_root=REPO_ROOT, hermes_home=hermes_home)
     monkeypatch.setenv("HOME", str(tmp_path))
 
     monkeypatch.syspath_prepend(str(plugin_dir))
-    tools = _load_module("daedalus_tools_smoke", plugin_dir / "tools.py")
-
-    systemd_user_dir = tmp_path / "systemd-user"
-    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_user_dir))
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
-    subprocess.run(
-        ["git", "remote", "add", "origin", "git@github.com:attmous/daedalus.git"],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    monkeypatch.chdir(repo)
-
-    captured_commands = []
-    real_run = subprocess.run
-
-    def fake_run(cmd, **kwargs):
-        captured_commands.append(cmd)
-        if cmd[:2] == ["systemctl", "--user"]:
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        return real_run(cmd, **kwargs)
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(tools.subprocess, "run", fake_run)
-
-    workflow_root = hermes_home / "workflows" / "attmous-daedalus-change-delivery"
-
-    bootstrap_out = tools.execute_raw_args("bootstrap")
-    assert "bootstrapped workflow root" in bootstrap_out
-    assert (repo / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root)
-    assert (repo / "WORKFLOW.md").exists()
-    assert ["git", "checkout", "-b", "daedalus/bootstrap-change-delivery"] in captured_commands
-
-    service_up_out = tools.execute_raw_args("service-up --json")
-    service_up_payload = json.loads(service_up_out)
-    assert service_up_payload["ok"] is True
-    assert service_up_payload["preflight"]["ok"] is True
-    assert service_up_payload["preflight"]["workflow"] == "change-delivery"
-    assert Path(service_up_payload["service_install"]["unit_path"]).exists()
-    assert service_up_payload["service_enable"]["ok"] is True
-    assert service_up_payload["service_start"]["ok"] is True
-    assert service_up_payload["service_status"]["service_name"] == "daedalus-active@attmous-daedalus-change-delivery.service"
-
-    status_out = tools.execute_raw_args("status --format json")
-    status_payload = json.loads(status_out)
-    assert status_payload["runtime_status"] == "initialized"
-    assert status_payload["project_key"] == "attmous-daedalus-change-delivery"
-
-    assert ["systemctl", "--user", "daemon-reload"] in captured_commands
-    assert ["systemctl", "--user", "enable", "daedalus-active@attmous-daedalus-change-delivery.service"] in captured_commands
-    assert ["systemctl", "--user", "start", "daedalus-active@attmous-daedalus-change-delivery.service"] in captured_commands
-
-
-def test_issue_runner_onboarding_path_bootstrap_service_up_and_status(tmp_path, monkeypatch):
-    install = _load_module("daedalus_install_issue_runner_smoke", REPO_ROOT / "scripts" / "install.py")
-    hermes_home = tmp_path / ".hermes"
-    plugin_dir = install.install_plugin(repo_root=REPO_ROOT, hermes_home=hermes_home)
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    monkeypatch.syspath_prepend(str(plugin_dir))
-    tools = _load_module("daedalus_tools_issue_runner_smoke", plugin_dir / "tools.py")
+    tools = _load_module("daedalus_tools_smoke", plugin_dir / "daedalus_cli.py")
 
     systemd_user_dir = tmp_path / "systemd-user"
     monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_user_dir))
@@ -117,7 +53,7 @@ def test_issue_runner_onboarding_path_bootstrap_service_up_and_status(tmp_path, 
 
     workflow_root = hermes_home / "workflows" / "attmous-daedalus-issue-runner"
 
-    bootstrap_out = tools.execute_raw_args("bootstrap --workflow issue-runner")
+    bootstrap_out = tools.execute_raw_args("bootstrap")
     assert "bootstrapped workflow root" in bootstrap_out
     assert (repo / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root)
     assert (repo / "WORKFLOW.md").exists()
@@ -140,6 +76,70 @@ def test_issue_runner_onboarding_path_bootstrap_service_up_and_status(tmp_path, 
     assert status_payload["contractPath"] == str(repo / "WORKFLOW.md")
     assert status_payload["tracker"]["kind"] == "local-json"
     assert status_payload["tracker"]["issueCount"] >= 1
+
+    assert ["systemctl", "--user", "daemon-reload"] in captured_commands
+    assert ["systemctl", "--user", "enable", "daedalus-active@attmous-daedalus-issue-runner.service"] in captured_commands
+    assert ["systemctl", "--user", "start", "daedalus-active@attmous-daedalus-issue-runner.service"] in captured_commands
+
+
+def test_change_delivery_onboarding_path_bootstrap_service_up_and_status(tmp_path, monkeypatch):
+    install = _load_module("daedalus_install_issue_runner_smoke", REPO_ROOT / "scripts" / "install.py")
+    hermes_home = tmp_path / ".hermes"
+    plugin_dir = install.install_plugin(repo_root=REPO_ROOT, hermes_home=hermes_home)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.syspath_prepend(str(plugin_dir))
+    tools = _load_module("daedalus_tools_issue_runner_smoke", plugin_dir / "daedalus_cli.py")
+
+    systemd_user_dir = tmp_path / "systemd-user"
+    monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_user_dir))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:attmous/daedalus.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    monkeypatch.chdir(repo)
+
+    captured_commands = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        captured_commands.append(cmd)
+        if cmd[:2] == ["systemctl", "--user"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(tools.subprocess, "run", fake_run)
+
+    workflow_root = hermes_home / "workflows" / "attmous-daedalus-change-delivery"
+
+    bootstrap_out = tools.execute_raw_args("bootstrap --workflow change-delivery")
+    assert "bootstrapped workflow root" in bootstrap_out
+    assert (repo / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root)
+    assert (repo / "WORKFLOW.md").exists()
+    assert ["git", "checkout", "-b", "daedalus/bootstrap-change-delivery"] in captured_commands
+
+    service_up_out = tools.execute_raw_args("service-up --json")
+    service_up_payload = json.loads(service_up_out)
+    assert service_up_payload["ok"] is True
+    assert service_up_payload["preflight"]["ok"] is True
+    assert service_up_payload["preflight"]["workflow"] == "change-delivery"
+    assert Path(service_up_payload["service_install"]["unit_path"]).exists()
+    assert service_up_payload["service_enable"]["ok"] is True
+    assert service_up_payload["service_start"]["ok"] is True
+    assert service_up_payload["service_status"]["service_name"] == "daedalus-active@attmous-daedalus-change-delivery.service"
+
+    status_out = tools.execute_raw_args("status --format json")
+    status_payload = json.loads(status_out)
+    assert status_payload["runtime_status"] == "initialized"
+    assert status_payload["project_key"] == "attmous-daedalus-change-delivery"
 
 
 def test_readme_quickstart_mentions_supported_public_path():

--- a/tests/test_rename_pass_phase_d_1.py
+++ b/tests/test_rename_pass_phase_d_1.py
@@ -180,7 +180,7 @@ def test_parity_gate_accepts_run_internal_review():
     from pathlib import Path
     repo_root = Path(__file__).resolve().parent.parent / "daedalus"
     runtime_src = (repo_root / "runtime.py").read_text()
-    tools_src = (repo_root / "tools.py").read_text()
+    tools_src = (repo_root / "daedalus_cli.py").read_text()
     for src in (runtime_src, tools_src):
         assert "run_internal_review" in src
         assert (

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -29,7 +29,7 @@ def runtime_module():
 
 @pytest.fixture()
 def tools_module():
-    return load_module("daedalus_tools_test", "tools.py")
+    return load_module("daedalus_tools_test", "daedalus_cli.py")
 
 
 @pytest.fixture()

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 
-TOOLS_PATH = Path(__file__).resolve().parents[1] / "daedalus" / "tools.py"
+TOOLS_PATH = Path(__file__).resolve().parents[1] / "daedalus" / "daedalus_cli.py"
 
 
 def load_tools():
@@ -25,7 +25,7 @@ def test_render_template_unit_active_mode():
     assert "%i" in rendered
     assert "service-loop" in rendered
     assert "--service-mode active" in rendered
-    assert "/.hermes/plugins/daedalus/tools.py" in rendered
+    assert "/.hermes/plugins/daedalus/daedalus_cli.py" in rendered
 
 
 def test_render_template_unit_shadow_mode():

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -20,7 +20,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def _tools():
-    return load_module("daedalus_tools_bootstrap_workflow_test", "tools.py")
+    return load_module("daedalus_tools_bootstrap_workflow_test", "daedalus_cli.py")
 
 
 def _init_git_repo(path: Path, *, remote_url: str) -> None:
@@ -44,7 +44,7 @@ def test_bootstrap_workflow_infers_repo_root_slug_and_default_root(tmp_path, mon
         repo_path=nested,
         workflow_name="change-delivery",
         workflow_root=None,
-        github_slug=None,
+        repo_slug=None,
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=False,
@@ -59,7 +59,7 @@ def test_bootstrap_workflow_infers_repo_root_slug_and_default_root(tmp_path, mon
     assert Path(result["workflow_root"]) == expected_root
     assert result["detected_repo_root"] == str(repo_root.resolve())
     assert result["repo_path"] == str(repo_root.resolve())
-    assert result["github_slug"] == "attmous/daedalus"
+    assert result["repo_slug"] == "attmous/daedalus"
     assert result["remote_url"] == "git@github.com:attmous/daedalus.git"
     assert result["repo_pointer_path"] == str(pointer_path)
     assert result["next_edit_path"] == str(contract_path)
@@ -81,17 +81,45 @@ def test_bootstrap_workflow_accepts_explicit_slug_for_non_github_remote(tmp_path
         repo_path=repo_root,
         workflow_name="change-delivery",
         workflow_root=workflow_root,
-        github_slug="acme/widget",
+        repo_slug="acme/widget",
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=False,
     )
 
     cfg = load_workflow_contract_file(repo_root / "WORKFLOW.md").config
-    assert result["github_slug"] == "acme/widget"
+    assert result["repo_slug"] == "acme/widget"
+    assert cfg["repository"]["slug"] == "acme/widget"
     assert cfg["repository"]["github-slug"] == "acme/widget"
     assert cfg["repository"]["local-path"] == str(repo_root.resolve())
     assert (repo_root / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root.resolve())
+
+
+def test_bootstrap_issue_runner_infers_repo_slug_from_non_github_remote(tmp_path, monkeypatch):
+    tools = _tools()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    repo_root = tmp_path / "repo"
+    _init_git_repo(repo_root, remote_url="git@example.com:team/project.git")
+
+    result = tools.bootstrap_workflow_root(
+        repo_path=repo_root,
+        workflow_name="issue-runner",
+        workflow_root=None,
+        repo_slug=None,
+        active_lane_label="active-lane",
+        engine_owner="hermes",
+        force=False,
+    )
+
+    cfg = load_workflow_contract_file(repo_root / "WORKFLOW.md").config
+    assert result["repo_slug"] == "team/project"
+    assert Path(result["workflow_root"]) == home / ".hermes" / "workflows" / "team-project-issue-runner"
+    assert cfg["workflow"] == "issue-runner"
+    assert cfg["repository"]["slug"] == "team/project"
+    assert "github-slug" not in cfg["repository"]
 
 
 def test_bootstrap_issue_runner_recommends_service_up(tmp_path, monkeypatch):
@@ -107,7 +135,7 @@ def test_bootstrap_issue_runner_recommends_service_up(tmp_path, monkeypatch):
         repo_path=repo_root,
         workflow_name="issue-runner",
         workflow_root=None,
-        github_slug=None,
+        repo_slug=None,
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=False,
@@ -130,7 +158,7 @@ def test_bootstrap_second_workflow_promotes_default_contract_without_clobbering(
         repo_path=repo_root,
         workflow_name="change-delivery",
         workflow_root=None,
-        github_slug=None,
+        repo_slug=None,
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=False,
@@ -141,7 +169,7 @@ def test_bootstrap_second_workflow_promotes_default_contract_without_clobbering(
         repo_path=repo_root,
         workflow_name="issue-runner",
         workflow_root=None,
-        github_slug=None,
+        repo_slug=None,
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=False,
@@ -196,7 +224,7 @@ def test_bootstrap_rejects_non_daedalus_workflow_md_without_changes(tmp_path, mo
             repo_path=repo_root,
             workflow_name="issue-runner",
             workflow_root=None,
-            github_slug=None,
+            repo_slug=None,
             active_lane_label="active-lane",
             engine_owner="hermes",
             force=False,
@@ -229,7 +257,7 @@ def test_bootstrap_promotion_refuses_existing_named_target_even_with_force(tmp_p
             repo_path=repo_root,
             workflow_name="issue-runner",
             workflow_root=None,
-            github_slug=None,
+            repo_slug=None,
             active_lane_label="active-lane",
             engine_owner="hermes",
             force=True,
@@ -251,7 +279,7 @@ def test_bootstrap_workflow_requires_git_repo(tmp_path):
             repo_path=non_repo,
             workflow_name="change-delivery",
             workflow_root=None,
-            github_slug=None,
+            repo_slug=None,
             active_lane_label="active-lane",
             engine_owner="hermes",
             force=False,

--- a/tests/test_tools_format_flag.py
+++ b/tests/test_tools_format_flag.py
@@ -17,7 +17,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def _tools():
-    return load_module("daedalus_tools_format_flag_test", "tools.py")
+    return load_module("daedalus_tools_format_flag_test", "daedalus_cli.py")
 
 
 def test_resolve_format_default_is_text():

--- a/tests/test_tools_new_command_dispatch.py
+++ b/tests/test_tools_new_command_dispatch.py
@@ -28,7 +28,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def _tools():
-    return load_module("daedalus_tools_new_command_dispatch_test", "tools.py")
+    return load_module("daedalus_tools_new_command_dispatch_test", "daedalus_cli.py")
 
 
 def test_set_observability_dispatched_not_falling_through_to_unknown(tmp_path):
@@ -81,7 +81,7 @@ def test_watch_dispatched_not_falling_through_to_unknown(tmp_path):
 
 def test_scaffold_workflow_dispatched_not_falling_through_to_unknown(tmp_path):
     tools = _tools()
-    root = tmp_path / "attmous-daedalus-change-delivery"
+    root = tmp_path / "attmous-daedalus-issue-runner"
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
@@ -93,7 +93,7 @@ def test_scaffold_workflow_dispatched_not_falling_through_to_unknown(tmp_path):
         text=True,
     )
     out = tools.execute_raw_args(
-        f"scaffold-workflow --workflow-root {root} --repo-path {repo} --github-slug attmous/daedalus"
+        f"scaffold-workflow --workflow-root {root} --repo-path {repo} --repo-slug attmous/daedalus"
     )
     assert "unknown daedalus command" not in out, out
     assert "scaffolded workflow root" in out

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -4,7 +4,7 @@ the argparse ``func=run_cli_command`` path.
 Codex Cloud follow-up to a3ea328: the previous fix only routed
 ``watch`` / ``set-observability`` / ``get-observability`` through
 ``execute_raw_args`` (the slash-command path). The argparse CLI path
-(``python3 tools.py <cmd> ...`` and any ``setup_cli``-registered command)
+(``python3 daedalus_cli.py <cmd> ...`` and any ``setup_cli``-registered command)
 still calls ``run_cli_command`` which previously hard-coded
 ``execute_namespace`` -- raising ``unknown daedalus command`` for the new
 string-returning subcommands.
@@ -31,7 +31,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def _tools():
-    return load_module("daedalus_tools_run_cli_command_dispatch_test", "tools.py")
+    return load_module("daedalus_tools_run_cli_command_dispatch_test", "daedalus_cli.py")
 
 
 def _parse(tools, argv):
@@ -99,7 +99,7 @@ def test_run_cli_command_dispatches_watch(tmp_path, capsys):
 
 def test_run_cli_command_dispatches_scaffold_workflow(tmp_path, capsys):
     tools = _tools()
-    root = tmp_path / "attmous-daedalus-change-delivery"
+    root = tmp_path / "attmous-daedalus-issue-runner"
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
@@ -118,7 +118,7 @@ def test_run_cli_command_dispatches_scaffold_workflow(tmp_path, capsys):
             str(root),
             "--repo-path",
             str(repo),
-            "--github-slug",
+            "--repo-slug",
             "attmous/daedalus",
         ],
     )

--- a/tests/test_tools_scaffold_workflow.py
+++ b/tests/test_tools_scaffold_workflow.py
@@ -21,7 +21,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def _tools():
-    return load_module("daedalus_tools_scaffold_workflow_test", "tools.py")
+    return load_module("daedalus_tools_scaffold_workflow_test", "daedalus_cli.py")
 
 
 def _init_git_repo(path: Path, *, remote_url: str = "git@github.com:attmous/daedalus.git") -> None:
@@ -40,7 +40,7 @@ def test_scaffold_workflow_writes_config_and_layout(tmp_path):
         workflow_root=root,
         workflow_name="change-delivery",
         repo_path=repo,
-        github_slug="attmous/daedalus",
+        repo_slug="attmous/daedalus",
         active_lane_label="ready-for-daedalus",
         engine_owner="hermes",
         force=False,
@@ -52,7 +52,9 @@ def test_scaffold_workflow_writes_config_and_layout(tmp_path):
     assert result["contract_path"] == str(contract_path)
     assert cfg["instance"]["name"] == "attmous-daedalus-change-delivery"
     assert cfg["instance"]["engine-owner"] == "hermes"
+    assert cfg["repository"]["slug"] == "attmous/daedalus"
     assert cfg["repository"]["github-slug"] == "attmous/daedalus"
+    assert cfg["tracker"]["kind"] == "github"
     assert cfg["repository"]["active-lane-label"] == "ready-for-daedalus"
     assert cfg["triggers"]["lane-selector"]["label"] == "ready-for-daedalus"
     assert cfg["repository"]["local-path"] == str(repo.resolve())
@@ -78,7 +80,7 @@ def test_scaffold_workflow_refuses_to_overwrite_without_force(tmp_path):
             workflow_root=root,
             workflow_name="change-delivery",
             repo_path=repo,
-            github_slug="attmous/daedalus",
+            repo_slug="attmous/daedalus",
             active_lane_label="active-lane",
             engine_owner="hermes",
             force=False,
@@ -101,7 +103,7 @@ def test_scaffold_workflow_force_replaces_existing_config(tmp_path):
         workflow_root=root,
         workflow_name="change-delivery",
         repo_path=repo,
-        github_slug="attmous/daedalus",
+        repo_slug="attmous/daedalus",
         active_lane_label="active-lane",
         engine_owner="openclaw",
         force=True,
@@ -128,7 +130,7 @@ def test_scaffold_workflow_force_retires_legacy_yaml_when_present(tmp_path):
         workflow_root=root,
         workflow_name="change-delivery",
         repo_path=repo,
-        github_slug="attmous/daedalus",
+        repo_slug="attmous/daedalus",
         active_lane_label="active-lane",
         engine_owner="hermes",
         force=True,
@@ -149,7 +151,7 @@ def test_scaffold_workflow_requires_owner_repo_workflow_root_name(tmp_path):
             workflow_root=root,
             workflow_name="change-delivery",
             repo_path=repo,
-            github_slug="attmous/daedalus",
+            repo_slug="attmous/daedalus",
             active_lane_label="active-lane",
             engine_owner="hermes",
             force=False,
@@ -168,7 +170,7 @@ def test_scaffold_issue_runner_seeds_sample_tracker_file(tmp_path):
         workflow_root=root,
         workflow_name="issue-runner",
         repo_path=repo,
-        github_slug="attmous/daedalus",
+        repo_slug="attmous/daedalus",
         active_lane_label="ignored-for-issue-runner",
         engine_owner="hermes",
         force=False,
@@ -179,6 +181,9 @@ def test_scaffold_issue_runner_seeds_sample_tracker_file(tmp_path):
 
     assert result["workflow"] == "issue-runner"
     assert cfg["workflow"] == "issue-runner"
+    assert cfg["repository"]["slug"] == "attmous/daedalus"
+    assert "github-slug" not in cfg["repository"]
+    assert "triggers" not in cfg
     assert issues_path.exists()
     payload = json.loads(issues_path.read_text(encoding="utf-8"))
     assert payload["issues"][0]["id"] == "ISSUE-1"

--- a/tests/test_workflow_slash_command.py
+++ b/tests/test_workflow_slash_command.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 
-TOOLS_PATH = Path(__file__).resolve().parents[1] / "daedalus" / "tools.py"
+TOOLS_PATH = Path(__file__).resolve().parents[1] / "daedalus" / "daedalus_cli.py"
 
 
 def load_tools():

--- a/tests/test_workflows_code_review_paths.py
+++ b/tests/test_workflows_code_review_paths.py
@@ -98,7 +98,7 @@ def test_derive_workflow_instance_name_uses_owner_repo_workflow_convention(tmp_p
     paths_module = load_module("daedalus_workflows_change_delivery_paths_test", "workflows/change_delivery/paths.py")
 
     name = paths_module.derive_workflow_instance_name(
-        github_slug="Attmous/Daedalus_Core",
+        repo_slug="Attmous/Daedalus_Core",
         workflow_name="change-delivery",
     )
 

--- a/tests/test_workflows_code_review_tools_bridge.py
+++ b/tests/test_workflows_code_review_tools_bridge.py
@@ -16,7 +16,7 @@ def load_module(module_name: str, relative_path: str):
 
 
 def test_build_shadow_report_uses_adapter_status_bridge(monkeypatch, tmp_path):
-    tools_module = load_module("daedalus_tools_bridge_test", "tools.py")
+    tools_module = load_module("daedalus_tools_bridge_test", "daedalus_cli.py")
     runtime_module = load_module("daedalus_runtime_for_tools_bridge_test", "runtime.py")
     workflow_root = tmp_path / "workflow"
     runtime_paths = runtime_module._runtime_paths(workflow_root)

--- a/tests/test_workflows_issue_runner_cli.py
+++ b/tests/test_workflows_issue_runner_cli.py
@@ -12,7 +12,7 @@ def _config(tmp_path: Path) -> dict:
         "workflow": "issue-runner",
         "schema-version": 1,
         "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
-        "repository": {"local-path": str(tmp_path / "repo"), "github-slug": "attmous/daedalus"},
+        "repository": {"local-path": str(tmp_path / "repo"), "slug": "attmous/daedalus"},
         "tracker": {
             "kind": "local-json",
             "path": "config/issues.json",

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -12,7 +12,7 @@ def _config() -> dict:
         "workflow": "issue-runner",
         "schema-version": 1,
         "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
-        "repository": {"local-path": "/tmp/repo", "github-slug": "attmous/daedalus"},
+        "repository": {"local-path": "/tmp/repo", "slug": "attmous/daedalus"},
         "tracker": {
             "kind": "local-json",
             "path": "config/issues.json",
@@ -60,6 +60,16 @@ def test_issue_runner_schema_accepts_minimal_valid_config():
         (REPO_ROOT / "daedalus" / "workflows" / "issue_runner" / "schema.yaml").read_text(encoding="utf-8")
     )
     jsonschema.validate(_config(), schema)
+
+
+def test_issue_runner_schema_does_not_require_github_slug_for_local_json():
+    schema = yaml.safe_load(
+        (REPO_ROOT / "daedalus" / "workflows" / "issue_runner" / "schema.yaml").read_text(encoding="utf-8")
+    )
+    cfg = _config()
+    cfg["repository"].pop("slug")
+
+    jsonschema.validate(cfg, schema)
 
 
 def test_issue_runner_schema_rejects_wrong_workflow_name():
@@ -138,6 +148,7 @@ def test_issue_runner_schema_accepts_github_tracker():
     cfg = _config()
     cfg["tracker"] = {
         "kind": "github",
+        "github_slug": "attmous/daedalus",
         "active_states": ["open"],
         "terminal_states": ["closed"],
         "required_labels": ["ready"],

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -13,7 +13,7 @@ def _config(tmp_path: Path) -> dict:
         "workflow": "issue-runner",
         "schema-version": 1,
         "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
-        "repository": {"local-path": str(tmp_path / "repo"), "github-slug": "attmous/daedalus"},
+        "repository": {"local-path": str(tmp_path / "repo"), "slug": "attmous/daedalus"},
         "tracker": {
             "kind": "local-json",
             "path": "config/issues.json",


### PR DESCRIPTION
## What changed

- Make `issue-runner` the default `bootstrap` / `scaffold-workflow` path.
- Rename operator-facing slug config from `--github-slug` to `--repo-slug` for workflow instance naming.
- Stop emitting `repository.github-slug` for `issue-runner` local-json configs; GitHub-specific issue-runner config now belongs under `tracker.github_slug`.
- Keep `change-delivery` explicitly GitHub-backed by declaring `tracker.kind: github` in its template/schema.
- Rename Daedalus' top-level operator module from `tools.py` to `daedalus_cli.py` so it no longer shadows Hermes' own `tools.registry` package.
- Update install payload, systemd unit templates, docs, and tests for the new CLI module name and defaults.

## Why

The public surface now describes workflows in terms of generic issues and shared tracker adapters. The default onboarding path should match that by bootstrapping `issue-runner` first, while GitHub remains the first-class production adapter and `change-delivery` remains the opinionated GitHub-backed SDLC workflow.

The `tools.py` rename fixes a real Hermes startup failure: with the Daedalus plugin path on `sys.path`, Hermes could resolve `import tools.registry` to Daedalus' `tools.py` file instead of Hermes' `tools` package.

## Validation

- `git diff --check`
- `pytest -q` -> `827 passed, 8 skipped`
- `hermes plugins list` with Daedalus enabled
- Verified installed plugin has `daedalus_cli.py` and no `tools.py`
