### PR TITLE
Tighten issue-runner GitHub config

### DIFF
--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -75,7 +75,7 @@ def describe_tracker_source(*, workflow_root: Path, tracker_cfg: dict[str, Any])
     if kind == "local-json":
         return str(resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg))
     if kind == "github":
-        slug = tracker_cfg.get("github_slug") or tracker_cfg.get("github-slug")
+        slug = tracker_cfg.get("github_slug")
         if slug:
             return f"github:{slug}"
         repo_path = tracker_cfg.get("repo_path") or tracker_cfg.get("repo-path")

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -21,7 +21,7 @@ def _github_slug_match(raw: str) -> re.Match[str] | None:
 
 def _github_slug_config_error() -> TrackerConfigError:
     return TrackerConfigError(
-        "tracker.github_slug or repository.github-slug must be in owner/repo or host/owner/repo form for tracker.kind='github'"
+        "tracker.github_slug must be in owner/repo or host/owner/repo form for tracker.kind='github'"
     )
 
 
@@ -135,12 +135,8 @@ def github_slug_from_config(
     tracker_cfg: dict[str, Any],
     repository_cfg: dict[str, Any] | None = None,
 ) -> str | None:
-    repository_cfg = repository_cfg or {}
     raw = str(
         tracker_cfg.get("github_slug")
-        or tracker_cfg.get("github-slug")
-        or repository_cfg.get("github_slug")
-        or repository_cfg.get("github-slug")
         or ""
     ).strip()
     if not raw:
@@ -167,11 +163,13 @@ def validate_github_tracker_config(
 ) -> None:
     repository_cfg = repository_cfg or {}
     slug = github_slug_from_config(tracker_cfg, repository_cfg)
+    if not slug:
+        raise TrackerConfigError("tracker.kind='github' requires tracker.github_slug")
     resolved_repo_path = _resolve_repo_path(
         workflow_root=workflow_root,
         tracker_cfg=tracker_cfg,
         repo_path=repo_path,
-        required=slug is None,
+        required=False,
     )
     if resolved_repo_path is not None and not resolved_repo_path.exists():
         raise TrackerConfigError(
@@ -218,7 +216,7 @@ def _resolve_repo_path(
         if not required:
             return None
         raise TrackerConfigError(
-            "tracker.kind='github' requires tracker.github_slug, repository.github-slug, or repository.local-path"
+            "tracker.kind='github' requires tracker.github_slug or repository.local-path"
         )
     path = Path(raw).expanduser()
     if not path.is_absolute():

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -70,9 +70,15 @@ def _validate_config(config: dict[str, Any]) -> None:
         tracker_kind = str(tracker_cfg.get("kind") or "").strip()
         tracker_client_cfg = dict(tracker_cfg)
         if tracker_kind == "github":
-            slug = github_slug_from_config(tracker_client_cfg, repository_cfg)
-            if slug:
-                tracker_client_cfg.setdefault("github_slug", slug)
+            if tracker_client_cfg.get("github-slug"):
+                raise TrackerConfigError(
+                    "issue-runner GitHub config uses tracker.github_slug; remove tracker.github-slug"
+                )
+            if repository_cfg.get("github_slug") or repository_cfg.get("github-slug"):
+                raise TrackerConfigError(
+                    "issue-runner GitHub config uses tracker.github_slug; remove repository.github-slug"
+                )
+            github_slug_from_config(tracker_client_cfg)
             validate_github_tracker_config(
                 workflow_root=workflow_root,
                 tracker_cfg=tracker_client_cfg,
@@ -87,7 +93,7 @@ def _validate_config(config: dict[str, Any]) -> None:
             repo_path=repo_path,
         )
         if tracker_kind == "github":
-            expected_slug = github_slug_from_config(tracker_client_cfg, repository_cfg)
+            expected_slug = github_slug_from_config(tracker_client_cfg)
             auth_host = github_auth_host_from_slug(expected_slug)
             auth_status = getattr(client, "auth_status_payload")(hostname=auth_host)
             _assert_github_auth_ok(auth_status, hostname=auth_host)

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -32,7 +32,6 @@ properties:
     properties:
       local-path: {type: string}
       slug: {type: string}
-      github-slug: {type: string}
 
   tracker:
     type: object
@@ -43,7 +42,6 @@ properties:
         enum: [local-json, linear, github]
       path: {type: string}
       github_slug: {type: string}
-      github-slug: {type: string}
       endpoint: {type: string}
       api_key: {type: string}
       project_slug: {type: string}

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -70,10 +70,17 @@ def _tracker_config_for_client(config: dict[str, Any]) -> dict[str, Any]:
     tracker_cfg = dict(config.get("tracker") or {})
     if str(tracker_cfg.get("kind") or "").strip() != "github":
         return tracker_cfg
+    if tracker_cfg.get("github-slug"):
+        raise TrackerConfigError(
+            "issue-runner GitHub config uses tracker.github_slug; remove tracker.github-slug"
+        )
     repository_cfg = config.get("repository") or {}
-    slug = github_slug_from_config(tracker_cfg, repository_cfg)
-    if slug:
-        tracker_cfg.setdefault("github_slug", slug)
+    if repository_cfg.get("github_slug") or repository_cfg.get("github-slug"):
+        raise TrackerConfigError(
+            "issue-runner GitHub config uses tracker.github_slug; remove repository.github-slug"
+        )
+    if not github_slug_from_config(tracker_cfg):
+        raise TrackerConfigError("tracker.kind='github' requires tracker.github_slug")
     return tracker_cfg
 
 
@@ -438,7 +445,6 @@ class IssueRunnerWorkspace:
         try:
             expected = github_slug_from_config(
                 self.config.get("tracker") or {},
-                self.config.get("repository") or {},
             )
             auth_host = github_auth_host_from_slug(expected)
             auth_payload = getattr(self.tracker_client, "auth_status_payload")(hostname=auth_host)
@@ -464,7 +470,6 @@ class IssueRunnerWorkspace:
             resolved = str(repo_payload.get("nameWithOwner") or "").strip()
             expected = github_slug_from_config(
                 self.config.get("tracker") or {},
-                self.config.get("repository") or {},
             )
             expected_name_with_owner = github_name_with_owner_from_slug(expected)
             if (

--- a/docs/operator/github-smoke.md
+++ b/docs/operator/github-smoke.md
@@ -25,11 +25,13 @@ export DAEDALUS_GITHUB_SMOKE_LABEL=daedalus-smoke
 ```
 
 `DAEDALUS_GITHUB_SMOKE_REPO_PATH` only needs to exist locally. The tracker uses
-`gh --repo <owner>/<repo>`, so the path does not have to be a git checkout.
+`tracker.github_slug` and `gh --repo <owner>/<repo>`, so the path does not have
+to be a git checkout.
 
 ## What It Proves
 
 - `tracker.kind: github` can select issues via `gh`
+- `tracker.github_slug` is the GitHub repository source of truth
 - required-label filtering works against live GitHub data
 - a no-op runtime can dispatch from the selected issue
 - scheduler state records the continuation retry

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -22,8 +22,8 @@ If your host does not have those runtimes, edit `WORKFLOW.md` before starting th
 
 The bundled `issue-runner` template defaults to `tracker.kind: local-json` so
 it is runnable without an external tracker. For first-class tracker operation,
-switch it to `tracker.kind: github` and keep `gh` authenticated in the repo
-checkout before running `service-up`. Linear exists as an experimental adapter,
+switch it to `tracker.kind: github`, set `tracker.github_slug`, and keep `gh`
+authenticated before running `service-up`. Linear exists as an experimental adapter,
 but it is deferred until the GitHub adapter is hardened further.
 
 ## Bundled workflows

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -63,6 +63,20 @@ Supported tracker kinds today:
 - `local-json` — local development and test fixture path
 - `linear` — experimental adapter, deferred until after the GitHub adapter is hardened
 
+GitHub configuration is explicit. Put the repository slug under the tracker,
+not under `repository`:
+
+```yaml
+repository:
+  local-path: /path/to/repo
+  slug: your-org/your-repo
+tracker:
+  kind: github
+  github_slug: your-org/your-repo
+  active_states: [open]
+  terminal_states: [closed]
+```
+
 `issue-runner` composes the shared `trackers/` clients with workflow-specific
 eligibility, ordering, retry, and workspace policy.
 

--- a/tests/test_github_issue_runner_smoke.py
+++ b/tests/test_github_issue_runner_smoke.py
@@ -74,9 +74,10 @@ def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_iss
             "workflow": "issue-runner",
             "schema-version": 1,
             "instance": {"name": "smoke-issue-runner", "engine-owner": "hermes"},
-            "repository": {"local-path": str(repo_path), "github-slug": smoke_repo},
+            "repository": {"local-path": str(repo_path), "slug": smoke_repo},
             "tracker": {
                 "kind": "github",
+                "github_slug": smoke_repo,
                 "active_states": ["open"],
                 "terminal_states": ["closed"],
                 "required_labels": [label],

--- a/tests/test_workflows_issue_runner_github_preflight.py
+++ b/tests/test_workflows_issue_runner_github_preflight.py
@@ -6,9 +6,10 @@ def _github_config(repo_path: Path) -> dict:
         "workflow": "issue-runner",
         "schema-version": 1,
         "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
-        "repository": {"local-path": str(repo_path), "github-slug": "attmous/daedalus"},
+        "repository": {"local-path": str(repo_path), "slug": "attmous/daedalus"},
         "tracker": {
             "kind": "github",
+            "github_slug": "attmous/daedalus",
             "active_states": ["open"],
             "terminal_states": ["closed"],
         },
@@ -69,7 +70,8 @@ def test_issue_runner_preflight_checks_auth_for_configured_github_host(monkeypat
     repo_path.mkdir()
     commands = []
     cfg = _github_config(repo_path)
-    cfg["repository"]["github-slug"] = "github.example.com/attmous/daedalus"
+    cfg["repository"]["slug"] = "attmous/daedalus"
+    cfg["tracker"]["github_slug"] = "github.example.com/attmous/daedalus"
 
     def fake_run_json(command, cwd=None):
         commands.append(command)
@@ -95,6 +97,55 @@ def test_issue_runner_preflight_checks_auth_for_configured_github_host(monkeypat
     assert result.ok is True
     assert any(command[:3] == ["gh", "auth", "status"] for command in commands)
     assert any(command[:3] == ["gh", "repo", "view"] for command in commands)
+
+
+def test_issue_runner_preflight_rejects_repository_github_slug(tmp_path):
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    cfg = _github_config(repo_path)
+    cfg["tracker"].pop("github_slug")
+    cfg["repository"]["github-slug"] = "attmous/daedalus"
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "invalid-config"
+    assert "tracker.github_slug" in str(result.error_detail)
+    assert "repository.github-slug" in str(result.error_detail)
+
+
+def test_issue_runner_preflight_rejects_hyphenated_tracker_github_slug(tmp_path):
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    cfg = _github_config(repo_path)
+    cfg["tracker"].pop("github_slug")
+    cfg["tracker"]["github-slug"] = "attmous/daedalus"
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "invalid-config"
+    assert "tracker.github_slug" in str(result.error_detail)
+    assert "tracker.github-slug" in str(result.error_detail)
+
+
+def test_issue_runner_preflight_requires_tracker_github_slug(tmp_path):
+    from workflows.issue_runner.preflight import run_preflight
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    cfg = _github_config(repo_path)
+    cfg["tracker"].pop("github_slug")
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "invalid-config"
+    assert "requires tracker.github_slug" in str(result.error_detail)
 
 
 def test_issue_runner_preflight_rejects_github_state_shape(tmp_path):
@@ -159,7 +210,8 @@ def test_issue_runner_doctor_checks_auth_for_configured_github_host(monkeypatch,
     workflow_root = tmp_path / "wf"
     workflow_root.mkdir()
     cfg = _github_config(repo_path)
-    cfg["repository"]["github-slug"] = "github.example.com/attmous/daedalus"
+    cfg["repository"]["slug"] = "attmous/daedalus"
+    cfg["tracker"]["github_slug"] = "github.example.com/attmous/daedalus"
     (workflow_root / "WORKFLOW.md").write_text(
         render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- require issue-runner GitHub configs to use tracker.github_slug as the repository source of truth
- reject repository.github-slug and tracker.github-slug for issue-runner instead of silently adapting them
- update live smoke/docs to show the tracker-owned GitHub configuration

## Tests
- pytest tests/test_workflows_issue_runner_github_preflight.py tests/test_workflows_issue_runner_tracker.py tests/test_workflows_issue_runner_schema.py tests/test_github_issue_runner_smoke.py -q
- pytest tests/test_public_harness_checks.py tests/test_public_onboarding_smoke.py -q
- pytest -q