### PR TITLE
[codex] Extract shared engine primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Inside Hermes Agent:
 /workflow change-delivery tick              # run one change-delivery workflow tick
 ```
 
-The operator surfaces read the persisted state for you. You should not need to
-inspect SQLite, scheduler JSON, JSONL logs, or systemd journals by hand during
-normal operation.
+The operator surfaces read persisted state for you. You should not need to
+inspect SQLite, generated scheduler snapshots, JSONL logs, or systemd journals
+by hand during normal operation.
 
 ## Configure The Workflow
 

--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import sqlite3
 import subprocess
+import time
 from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from urllib.parse import urlparse
 
 import yaml
 
+from engine.state import read_engine_scheduler_state
 from workflows.contract import (
     WorkflowContractError,
     find_repo_workflow_contract_path,
@@ -34,6 +36,7 @@ from workflows.shared.paths import (
     project_key_for_workflow_root,
     repo_local_workflow_pointer_path,
     resolve_default_workflow_root as resolve_workflow_root_default,
+    runtime_paths,
     workflow_cli_argv,
 )
 from workflows.change_delivery.status import build_status as build_workflow_status
@@ -1016,43 +1019,43 @@ def _codex_app_server_endpoint_is_loopback(endpoint: str) -> bool:
         return False
 
 
-def _codex_app_server_scheduler_path(workflow_root: Path) -> Path:
-    configured_path: str | None = None
+def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
+    db_path = runtime_paths(workflow_root)["db_path"]
+    workflow_names: list[str] = []
     try:
         contract = load_workflow_contract(workflow_root)
-        storage = contract.config.get("storage") if isinstance(contract.config, dict) else None
-        if isinstance(storage, dict):
-            configured_path = storage.get("scheduler") or storage.get("scheduler-path")
+        workflow_name = str(contract.config.get("workflow") or "").strip()
+        if workflow_name:
+            workflow_names.append(workflow_name)
     except Exception:
-        configured_path = None
-    raw_path = str(configured_path or "memory/workflow-scheduler.json")
-    path = Path(raw_path)
-    return path if path.is_absolute() else workflow_root / path
+        pass
+    if not workflow_names:
+        workflow_names = ["issue-runner", "change-delivery"]
 
+    scheduler: dict[str, Any] | None = None
+    for workflow_name in workflow_names:
+        scheduler = read_engine_scheduler_state(
+            db_path,
+            workflow=workflow_name,
+            now_iso=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            now_epoch=time.time(),
+        )
+        if scheduler is None:
+            continue
+        raw_threads = scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}
+        totals = scheduler.get("codex_totals") or scheduler.get("codexTotals") or {}
+        if raw_threads or totals or workflow_name == workflow_names[-1]:
+            break
 
-def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
-    scheduler_path = _codex_app_server_scheduler_path(workflow_root)
-    if not scheduler_path.exists():
+    if scheduler is None:
         return {
             "ok": True,
-            "path": str(scheduler_path),
+            "path": str(db_path),
             "exists": False,
             "threads": [],
             "totals": {},
             "invalid_thread_count": 0,
             "error": None,
-        }
-    try:
-        scheduler = json.loads(scheduler_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        return {
-            "ok": False,
-            "path": str(scheduler_path),
-            "exists": True,
-            "threads": [],
-            "totals": {},
-            "invalid_thread_count": 0,
-            "error": str(exc),
         }
     raw_threads = scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}
     threads: list[dict[str, Any]] = []
@@ -1085,7 +1088,7 @@ def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
     totals = scheduler.get("codex_totals") or scheduler.get("codexTotals") or {}
     return {
         "ok": invalid_thread_count == 0,
-        "path": str(scheduler_path),
+        "path": str(db_path),
         "exists": True,
         "threads": threads,
         "totals": totals if isinstance(totals, dict) else {},
@@ -1288,7 +1291,7 @@ def codex_app_server_doctor(
                 "scheduler-thread-map",
                 "fail",
                 f"{scheduler.get('path')}: {scheduler.get('error')}",
-                remedy="repair or remove the scheduler JSON state file",
+                remedy="repair the shared engine SQLite state",
             )
         )
     elif not scheduler.get("exists"):

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -1,0 +1,36 @@
+"""Shared Daedalus engine primitives.
+
+Workflow packages own lifecycle policy. This package owns reusable runtime
+mechanics: durable file IO, audit writes, scheduler snapshots, and SQLite setup.
+"""
+
+from .audit import make_audit_fn
+from .driver import WorkflowDriver
+from .scheduler import (
+    RestoredSchedulerState,
+    build_scheduler_payload,
+    codex_threads_snapshot,
+    restore_scheduler_state,
+    retry_due_at,
+    retry_queue_snapshot,
+    running_snapshot,
+)
+from .sqlite import connect_daedalus_db
+from .storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
+
+__all__ = [
+    "RestoredSchedulerState",
+    "WorkflowDriver",
+    "append_jsonl",
+    "build_scheduler_payload",
+    "codex_threads_snapshot",
+    "connect_daedalus_db",
+    "load_optional_json",
+    "make_audit_fn",
+    "restore_scheduler_state",
+    "retry_due_at",
+    "retry_queue_snapshot",
+    "running_snapshot",
+    "write_json_atomic",
+    "write_text_atomic",
+]

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -6,6 +6,13 @@ mechanics: durable file IO, audit writes, scheduler snapshots, and SQLite setup.
 
 from .audit import make_audit_fn
 from .driver import WorkflowDriver
+from .lifecycle import (
+    clear_work_entries,
+    mark_running_work,
+    recover_running_as_retry,
+    retry_delay,
+    schedule_retry_entry,
+)
 from .scheduler import (
     RestoredSchedulerState,
     build_scheduler_payload,
@@ -17,20 +24,39 @@ from .scheduler import (
 )
 from .sqlite import connect_daedalus_db
 from .storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
+from .work_items import (
+    RetryEntry,
+    RunningWork,
+    WorkItemRef,
+    WorkResult,
+    work_item_from_change_delivery_lane,
+    work_item_from_issue,
+)
 
 __all__ = [
     "RestoredSchedulerState",
     "WorkflowDriver",
+    "RetryEntry",
+    "RunningWork",
+    "WorkItemRef",
+    "WorkResult",
     "append_jsonl",
     "build_scheduler_payload",
+    "clear_work_entries",
     "codex_threads_snapshot",
     "connect_daedalus_db",
     "load_optional_json",
+    "mark_running_work",
     "make_audit_fn",
+    "recover_running_as_retry",
     "restore_scheduler_state",
+    "retry_delay",
     "retry_due_at",
     "retry_queue_snapshot",
     "running_snapshot",
+    "schedule_retry_entry",
+    "work_item_from_change_delivery_lane",
+    "work_item_from_issue",
     "write_json_atomic",
     "write_text_atomic",
 ]

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -23,6 +23,13 @@ from .scheduler import (
     running_snapshot,
 )
 from .sqlite import connect_daedalus_db
+from .state import (
+    engine_state_tables_exist,
+    init_engine_state,
+    load_engine_scheduler_state,
+    read_engine_scheduler_state,
+    save_engine_scheduler_state,
+)
 from .storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
 from .work_items import (
     RetryEntry,
@@ -45,9 +52,13 @@ __all__ = [
     "clear_work_entries",
     "codex_threads_snapshot",
     "connect_daedalus_db",
+    "engine_state_tables_exist",
+    "init_engine_state",
+    "load_engine_scheduler_state",
     "load_optional_json",
     "mark_running_work",
     "make_audit_fn",
+    "read_engine_scheduler_state",
     "recover_running_as_retry",
     "restore_scheduler_state",
     "retry_delay",
@@ -55,6 +66,7 @@ __all__ = [
     "retry_queue_snapshot",
     "running_snapshot",
     "schedule_retry_entry",
+    "save_engine_scheduler_state",
     "work_item_from_change_delivery_lane",
     "work_item_from_issue",
     "write_json_atomic",

--- a/daedalus/engine/audit.py
+++ b/daedalus/engine/audit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from .storage import append_jsonl
+
+
+AuditPublisher = Callable[..., Any]
+Clock = Callable[[], str]
+
+
+def make_audit_fn(
+    *,
+    audit_log_path: Path,
+    now_iso: Clock,
+    publisher: AuditPublisher | None = None,
+) -> Callable[..., None]:
+    """Build a JSONL audit writer with best-effort subscriber fanout."""
+
+    def audit(action: str, summary: str, **extra: Any) -> None:
+        append_jsonl(
+            audit_log_path,
+            {
+                "at": now_iso(),
+                "action": action,
+                "summary": summary,
+                **extra,
+            },
+        )
+        if publisher is None:
+            return
+        try:
+            publisher(action=action, summary=summary, extra=dict(extra))
+        except Exception:
+            # Observability subscribers must never break workflow execution.
+            pass
+
+    return audit

--- a/daedalus/engine/driver.py
+++ b/daedalus/engine/driver.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class WorkflowDriver(Protocol):
+    """Minimal contract a workflow exposes to the Daedalus engine surface."""
+
+    def build_status(self) -> dict[str, Any]: ...
+
+    def doctor(self) -> dict[str, Any]: ...
+
+    def tick(self) -> dict[str, Any]: ...

--- a/daedalus/engine/lifecycle.py
+++ b/daedalus/engine/lifecycle.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .work_items import RetryEntry, RunningWork, WorkItemRef
+
+
+def clear_work_entries(entries: dict[str, dict[str, Any]], work_ids: list[str | None]) -> dict[str, dict[str, Any]]:
+    next_entries = dict(entries)
+    for work_id in work_ids:
+        if work_id:
+            next_entries.pop(str(work_id), None)
+    return next_entries
+
+
+def mark_running_work(
+    running_entries: dict[str, dict[str, Any]],
+    *,
+    work_items: list[tuple[WorkItemRef, int]],
+    now_epoch: float,
+) -> dict[str, dict[str, Any]]:
+    entries = dict(running_entries)
+    for work_item, attempt in work_items:
+        running = RunningWork(
+            work_item=work_item,
+            worker_id=f"worker:{work_item.id}:{int(now_epoch * 1000)}",
+            attempt=max(int(attempt or 0), 0),
+            started_at_epoch=now_epoch,
+            heartbeat_at_epoch=now_epoch,
+        )
+        entries[work_item.id] = running.to_scheduler_entry()
+    return entries
+
+
+def retry_delay(*, delay_type: str, retry_attempt: int, max_backoff_ms: int) -> int:
+    if delay_type == "continuation":
+        return 1000
+    return min(max_backoff_ms, 10000 * (2 ** max(retry_attempt - 1, 0)))
+
+
+def schedule_retry_entry(
+    *,
+    work_item: WorkItemRef,
+    existing_entry: dict[str, Any] | None,
+    error: str,
+    current_attempt: int | None,
+    delay_type: str,
+    max_backoff_ms: int,
+    now_epoch: float,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if delay_type == "continuation":
+        retry_attempt = 1
+    else:
+        retry_attempt = int((existing_entry or {}).get("attempt") or 0) + 1
+    delay_ms = retry_delay(
+        delay_type=delay_type,
+        retry_attempt=retry_attempt,
+        max_backoff_ms=max_backoff_ms,
+    )
+    entry = RetryEntry(
+        work_item=work_item,
+        attempt=retry_attempt,
+        due_at_epoch=now_epoch + (delay_ms / 1000.0),
+        error=error,
+        current_attempt=current_attempt,
+        delay_type=delay_type,
+    ).to_scheduler_entry()
+    summary = {
+        "issue_id": work_item.id,
+        "identifier": work_item.identifier,
+        "retry_attempt": retry_attempt,
+        "delay_ms": delay_ms,
+        "delay_type": delay_type,
+    }
+    return entry, summary
+
+
+def recover_running_as_retry(
+    retry_entries: dict[str, dict[str, Any]],
+    recovered_running: list[dict[str, Any]],
+    *,
+    now_epoch: float,
+    error: str = "scheduler restarted while issue was running",
+) -> dict[str, dict[str, Any]]:
+    entries = dict(retry_entries)
+    for running in recovered_running:
+        issue_id = str(running.get("issue_id") or "").strip()
+        if not issue_id:
+            continue
+        existing = entries.get(issue_id) or {}
+        entries[issue_id] = {
+            "issue_id": issue_id,
+            "identifier": running.get("identifier"),
+            "attempt": max(int(existing.get("attempt") or 0), int(running.get("attempt") or 0), 1),
+            "error": error,
+            "due_at_epoch": now_epoch,
+            "current_attempt": running.get("attempt"),
+        }
+    return entries

--- a/daedalus/engine/scheduler.py
+++ b/daedalus/engine/scheduler.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RestoredSchedulerState:
+    retry_entries: dict[str, dict[str, Any]]
+    recovered_running: list[dict[str, Any]]
+    codex_totals: dict[str, Any]
+    codex_threads: dict[str, dict[str, Any]]
+
+
+def retry_due_at(
+    entry: dict[str, Any] | None,
+    *,
+    default: float | None = None,
+    now_epoch: float | None = None,
+) -> float:
+    payload = entry or {}
+    if payload.get("due_at_monotonic") is not None:
+        return float(payload.get("due_at_monotonic") or 0.0)
+    if payload.get("due_at_epoch") is not None:
+        return float(payload.get("due_at_epoch") or 0.0)
+    if payload.get("dueAtEpoch") is not None:
+        return float(payload.get("dueAtEpoch") or 0.0)
+    if default is not None:
+        return float(default)
+    return float(now_epoch if now_epoch is not None else time.time())
+
+
+def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> RestoredSchedulerState:
+    retry_entries: dict[str, dict[str, Any]] = {}
+    for item in payload.get("retry_queue") or payload.get("retryQueue") or []:
+        if not isinstance(item, dict):
+            continue
+        issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
+        if not issue_id:
+            continue
+        retry_entries[issue_id] = {
+            "issue_id": issue_id,
+            "identifier": item.get("identifier"),
+            "attempt": int(item.get("attempt") or 0),
+            "error": item.get("error"),
+            "due_at_epoch": float(item.get("due_at_epoch") or item.get("dueAtEpoch") or now_epoch),
+            "current_attempt": item.get("current_attempt") or item.get("currentAttempt"),
+        }
+
+    recovered_running: list[dict[str, Any]] = []
+    for item in payload.get("running") or []:
+        if not isinstance(item, dict):
+            continue
+        issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
+        if not issue_id:
+            continue
+        started_at_epoch = float(item.get("started_at_epoch") or item.get("startedAtEpoch") or now_epoch)
+        recovered_running.append(
+            {
+                "issue_id": issue_id,
+                "worker_id": item.get("worker_id") or item.get("workerId") or f"worker:{issue_id}:recovered",
+                "identifier": item.get("identifier"),
+                "attempt": int(item.get("attempt") or 0),
+                "state": item.get("state"),
+                "worker_status": item.get("worker_status") or item.get("workerStatus") or "recovered",
+                "started_at_epoch": started_at_epoch,
+                "heartbeat_at_epoch": float(
+                    item.get("heartbeat_at_epoch")
+                    or item.get("heartbeatAtEpoch")
+                    or started_at_epoch
+                ),
+                "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
+                "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
+            }
+        )
+
+    return RestoredSchedulerState(
+        retry_entries=retry_entries,
+        recovered_running=recovered_running,
+        codex_totals=dict(payload.get("codex_totals") or payload.get("codexTotals") or {}),
+        codex_threads=restore_codex_threads(payload.get("codex_threads") or {}),
+    )
+
+
+def running_snapshot(
+    running_entries: dict[str, dict[str, Any]],
+    *,
+    now_epoch: float,
+) -> list[dict[str, Any]]:
+    running = []
+    for issue_id, entry in running_entries.items():
+        started_at_epoch = float(entry.get("started_at_epoch") or now_epoch)
+        heartbeat_at_epoch = float(entry.get("heartbeat_at_epoch") or started_at_epoch)
+        running.append(
+            {
+                "issue_id": issue_id,
+                "worker_id": entry.get("worker_id"),
+                "identifier": entry.get("identifier"),
+                "attempt": int(entry.get("attempt") or 0),
+                "state": entry.get("state"),
+                "worker_status": entry.get("worker_status") or "running",
+                "started_at_epoch": started_at_epoch,
+                "heartbeat_at_epoch": heartbeat_at_epoch,
+                "running_for_ms": max(int((now_epoch - started_at_epoch) * 1000), 0),
+                "heartbeat_age_ms": max(int((now_epoch - heartbeat_at_epoch) * 1000), 0),
+                "cancel_requested": bool(entry.get("cancel_requested") or False),
+                "cancel_reason": entry.get("cancel_reason"),
+                "thread_id": entry.get("thread_id"),
+                "turn_id": entry.get("turn_id"),
+            }
+        )
+    running.sort(key=lambda item: (item["state"] or "", item["identifier"] or item["issue_id"]))
+    return running
+
+
+def retry_queue_snapshot(
+    retry_entries: dict[str, dict[str, Any]],
+    *,
+    now_epoch: float,
+) -> list[dict[str, Any]]:
+    entries = []
+    for issue_id, entry in retry_entries.items():
+        due_at = retry_due_at(entry, default=now_epoch)
+        entries.append(
+            {
+                "issue_id": issue_id,
+                "identifier": entry.get("identifier"),
+                "attempt": int(entry.get("attempt") or 0),
+                "error": entry.get("error"),
+                "due_at_epoch": due_at,
+                "due_in_ms": max(int((due_at - now_epoch) * 1000), 0),
+            }
+        )
+    entries.sort(key=lambda item: (item["due_in_ms"], item["attempt"], item["identifier"] or item["issue_id"]))
+    return entries
+
+
+def restore_codex_threads(raw: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return {}
+    restored: dict[str, dict[str, Any]] = {}
+    for issue_id, item in raw.items():
+        if not isinstance(item, dict):
+            continue
+        normalized_issue_id = str(item.get("issue_id") or issue_id or "").strip()
+        thread_id = str(item.get("thread_id") or "").strip()
+        if not normalized_issue_id or not thread_id:
+            continue
+        restored[normalized_issue_id] = {
+            "issue_id": normalized_issue_id,
+            "identifier": item.get("identifier"),
+            "session_name": item.get("session_name"),
+            "thread_id": thread_id,
+            "turn_id": item.get("turn_id"),
+            "updated_at": item.get("updated_at"),
+        }
+    return restored
+
+
+def codex_threads_snapshot(codex_threads: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {
+        issue_id: dict(entry)
+        for issue_id, entry in sorted(codex_threads.items(), key=lambda item: item[0])
+    }
+
+
+def build_scheduler_payload(
+    *,
+    workflow: str,
+    retry_entries: dict[str, dict[str, Any]],
+    running_entries: dict[str, dict[str, Any]],
+    codex_totals: dict[str, Any] | None,
+    codex_threads: dict[str, dict[str, Any]],
+    now_iso: str,
+    now_epoch: float,
+) -> dict[str, Any]:
+    return {
+        "workflow": workflow,
+        "updatedAt": now_iso,
+        "retry_queue": retry_queue_snapshot(retry_entries, now_epoch=now_epoch),
+        "running": running_snapshot(running_entries, now_epoch=now_epoch),
+        "codex_totals": dict(codex_totals or {}),
+        "codex_threads": codex_threads_snapshot(codex_threads),
+    }

--- a/daedalus/engine/sqlite.py
+++ b/daedalus/engine/sqlite.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def connect_daedalus_db(db_path: Path) -> sqlite3.Connection:
+    """Open the Daedalus SQLite state store with production pragmas."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA temp_store = MEMORY")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .scheduler import build_scheduler_payload
+from .sqlite import connect_daedalus_db
+
+
+ENGINE_STATE_TABLES = (
+    "engine_work_items",
+    "engine_running_work",
+    "engine_retry_queue",
+    "engine_runtime_sessions",
+    "engine_runtime_totals",
+)
+
+
+def _json_dumps(value: Any) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, sort_keys=True)
+
+
+def _json_loads(value: Any) -> Any:
+    if value in (None, "", "null"):
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    ).fetchone()
+    return bool(row)
+
+
+def engine_state_tables_exist(conn: sqlite3.Connection) -> bool:
+    return all(_table_exists(conn, name) for name in ENGINE_STATE_TABLES)
+
+
+def init_engine_state(conn: sqlite3.Connection) -> None:
+    """Create shared Daedalus engine state tables.
+
+    Workflow-specific tables still own workflow policy and domain state. These
+    tables own the neutral execution state used by scheduler, watch, doctor,
+    retry, and runtime-session surfaces.
+    """
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS engine_work_items (
+          workflow TEXT NOT NULL,
+          work_id TEXT NOT NULL,
+          identifier TEXT,
+          state TEXT,
+          title TEXT,
+          url TEXT,
+          source TEXT,
+          metadata_json TEXT,
+          updated_at TEXT NOT NULL,
+          updated_at_epoch REAL NOT NULL,
+          PRIMARY KEY (workflow, work_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS engine_running_work (
+          workflow TEXT NOT NULL,
+          work_id TEXT NOT NULL,
+          worker_id TEXT,
+          attempt INTEGER NOT NULL DEFAULT 0,
+          worker_status TEXT NOT NULL DEFAULT 'running',
+          started_at_epoch REAL NOT NULL,
+          heartbeat_at_epoch REAL NOT NULL,
+          cancel_requested INTEGER NOT NULL DEFAULT 0,
+          cancel_reason TEXT,
+          thread_id TEXT,
+          turn_id TEXT,
+          updated_at TEXT NOT NULL,
+          updated_at_epoch REAL NOT NULL,
+          PRIMARY KEY (workflow, work_id),
+          FOREIGN KEY (workflow, work_id) REFERENCES engine_work_items(workflow, work_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS engine_retry_queue (
+          workflow TEXT NOT NULL,
+          work_id TEXT NOT NULL,
+          attempt INTEGER NOT NULL DEFAULT 0,
+          due_at_epoch REAL NOT NULL,
+          error TEXT,
+          current_attempt INTEGER,
+          delay_type TEXT NOT NULL DEFAULT 'failure',
+          updated_at TEXT NOT NULL,
+          updated_at_epoch REAL NOT NULL,
+          PRIMARY KEY (workflow, work_id),
+          FOREIGN KEY (workflow, work_id) REFERENCES engine_work_items(workflow, work_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS engine_runtime_sessions (
+          workflow TEXT NOT NULL,
+          work_id TEXT NOT NULL,
+          session_name TEXT,
+          runtime_name TEXT,
+          runtime_kind TEXT,
+          session_id TEXT,
+          thread_id TEXT,
+          turn_id TEXT,
+          status TEXT,
+          cancel_requested INTEGER NOT NULL DEFAULT 0,
+          cancel_reason TEXT,
+          metadata_json TEXT,
+          updated_at TEXT NOT NULL,
+          updated_at_epoch REAL NOT NULL,
+          PRIMARY KEY (workflow, work_id),
+          FOREIGN KEY (workflow, work_id) REFERENCES engine_work_items(workflow, work_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS engine_runtime_totals (
+          workflow TEXT PRIMARY KEY,
+          input_tokens INTEGER NOT NULL DEFAULT 0,
+          output_tokens INTEGER NOT NULL DEFAULT 0,
+          total_tokens INTEGER NOT NULL DEFAULT 0,
+          turn_count INTEGER NOT NULL DEFAULT 0,
+          rate_limits_json TEXT,
+          updated_at TEXT NOT NULL,
+          updated_at_epoch REAL NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_status
+          ON engine_running_work(workflow, worker_status);
+        CREATE INDEX IF NOT EXISTS idx_engine_retry_workflow_due
+          ON engine_retry_queue(workflow, due_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_runtime_sessions_thread
+          ON engine_runtime_sessions(workflow, thread_id);
+        """
+    )
+
+
+def _open_engine_state_db(db_path: Path) -> sqlite3.Connection:
+    conn = connect_daedalus_db(db_path)
+    init_engine_state(conn)
+    return conn
+
+
+def _work_item_from_entry(*, workflow: str, work_id: str, entry: dict[str, Any]) -> dict[str, Any]:
+    metadata = dict(entry.get("metadata") or {})
+    for key in ("issue_number", "issueNumber", "worktree", "last_event", "last_message"):
+        if entry.get(key) is not None:
+            metadata[key] = entry.get(key)
+    return {
+        "workflow": workflow,
+        "work_id": work_id,
+        "identifier": entry.get("identifier") or work_id,
+        "state": entry.get("state") or entry.get("workflow_state") or entry.get("status"),
+        "title": entry.get("title") or entry.get("issue_title"),
+        "url": entry.get("url") or entry.get("issue_url"),
+        "source": entry.get("source") or workflow,
+        "metadata": metadata,
+    }
+
+
+def _upsert_work_item(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    work_id: str,
+    entry: dict[str, Any],
+    now_iso: str,
+    now_epoch: float,
+) -> None:
+    item = _work_item_from_entry(workflow=workflow, work_id=work_id, entry=entry)
+    conn.execute(
+        """
+        INSERT INTO engine_work_items (
+          workflow, work_id, identifier, state, title, url, source, metadata_json, updated_at, updated_at_epoch
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(workflow, work_id) DO UPDATE SET
+          identifier=excluded.identifier,
+          state=excluded.state,
+          title=excluded.title,
+          url=excluded.url,
+          source=excluded.source,
+          metadata_json=excluded.metadata_json,
+          updated_at=excluded.updated_at,
+          updated_at_epoch=excluded.updated_at_epoch
+        """,
+        (
+            item["workflow"],
+            item["work_id"],
+            item["identifier"],
+            item["state"],
+            item["title"],
+            item["url"],
+            item["source"],
+            _json_dumps(item["metadata"]),
+            now_iso,
+            now_epoch,
+        ),
+    )
+
+
+def save_engine_scheduler_state(
+    db_path: Path,
+    *,
+    workflow: str,
+    retry_entries: dict[str, dict[str, Any]],
+    running_entries: dict[str, dict[str, Any]],
+    codex_totals: dict[str, Any] | None,
+    codex_threads: dict[str, dict[str, Any]],
+    now_iso: str,
+    now_epoch: float,
+) -> None:
+    conn = _open_engine_state_db(db_path)
+    try:
+        conn.execute("DELETE FROM engine_running_work WHERE workflow=?", (workflow,))
+        conn.execute("DELETE FROM engine_retry_queue WHERE workflow=?", (workflow,))
+        conn.execute("DELETE FROM engine_runtime_sessions WHERE workflow=?", (workflow,))
+
+        for work_id, entry in sorted(running_entries.items(), key=lambda item: str(item[0])):
+            work_id = str(entry.get("issue_id") or work_id or "").strip()
+            if not work_id:
+                continue
+            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+            conn.execute(
+                """
+                INSERT INTO engine_running_work (
+                  workflow, work_id, worker_id, attempt, worker_status, started_at_epoch, heartbeat_at_epoch,
+                  cancel_requested, cancel_reason, thread_id, turn_id, updated_at, updated_at_epoch
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    workflow,
+                    work_id,
+                    entry.get("worker_id"),
+                    int(entry.get("attempt") or 0),
+                    entry.get("worker_status") or "running",
+                    float(entry.get("started_at_epoch") or now_epoch),
+                    float(entry.get("heartbeat_at_epoch") or entry.get("started_at_epoch") or now_epoch),
+                    1 if entry.get("cancel_requested") else 0,
+                    entry.get("cancel_reason"),
+                    entry.get("thread_id"),
+                    entry.get("turn_id"),
+                    now_iso,
+                    now_epoch,
+                ),
+            )
+
+        for work_id, entry in sorted(retry_entries.items(), key=lambda item: str(item[0])):
+            work_id = str(entry.get("issue_id") or work_id or "").strip()
+            if not work_id:
+                continue
+            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+            conn.execute(
+                """
+                INSERT INTO engine_retry_queue (
+                  workflow, work_id, attempt, due_at_epoch, error, current_attempt, delay_type, updated_at, updated_at_epoch
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    workflow,
+                    work_id,
+                    int(entry.get("attempt") or 0),
+                    float(entry.get("due_at_epoch") or now_epoch),
+                    entry.get("error"),
+                    entry.get("current_attempt"),
+                    entry.get("delay_type") or "failure",
+                    now_iso,
+                    now_epoch,
+                ),
+            )
+
+        for work_id, entry in sorted(codex_threads.items(), key=lambda item: str(item[0])):
+            if not isinstance(entry, dict):
+                continue
+            work_id = str(entry.get("issue_id") or work_id or "").strip()
+            thread_id = str(entry.get("thread_id") or "").strip()
+            if not work_id or not thread_id:
+                continue
+            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+            metadata = {
+                key: value
+                for key, value in entry.items()
+                if key
+                not in {
+                    "issue_id",
+                    "identifier",
+                    "session_name",
+                    "runtime_name",
+                    "runtime_kind",
+                    "session_id",
+                    "thread_id",
+                    "turn_id",
+                    "status",
+                    "cancel_requested",
+                    "cancel_reason",
+                    "updated_at",
+                    "updatedAt",
+                }
+            }
+            conn.execute(
+                """
+                INSERT INTO engine_runtime_sessions (
+                  workflow, work_id, session_name, runtime_name, runtime_kind, session_id, thread_id, turn_id,
+                  status, cancel_requested, cancel_reason, metadata_json, updated_at, updated_at_epoch
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    workflow,
+                    work_id,
+                    entry.get("session_name") or entry.get("sessionName"),
+                    entry.get("runtime_name") or entry.get("runtimeName"),
+                    entry.get("runtime_kind") or entry.get("runtimeKind"),
+                    entry.get("session_id") or entry.get("sessionId"),
+                    thread_id,
+                    entry.get("turn_id") or entry.get("turnId"),
+                    entry.get("status"),
+                    1 if (entry.get("cancel_requested") or entry.get("cancelRequested")) else 0,
+                    entry.get("cancel_reason") or entry.get("cancelReason"),
+                    _json_dumps(metadata),
+                    entry.get("updated_at") or entry.get("updatedAt") or now_iso,
+                    now_epoch,
+                ),
+            )
+
+        totals = dict(codex_totals or {})
+        conn.execute(
+            """
+            INSERT INTO engine_runtime_totals (
+              workflow, input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(workflow) DO UPDATE SET
+              input_tokens=excluded.input_tokens,
+              output_tokens=excluded.output_tokens,
+              total_tokens=excluded.total_tokens,
+              turn_count=excluded.turn_count,
+              rate_limits_json=excluded.rate_limits_json,
+              updated_at=excluded.updated_at,
+              updated_at_epoch=excluded.updated_at_epoch
+            """,
+            (
+                workflow,
+                int(totals.get("input_tokens") or 0),
+                int(totals.get("output_tokens") or 0),
+                int(totals.get("total_tokens") or 0),
+                int(totals.get("turn_count") or 0),
+                _json_dumps(totals.get("rate_limits")),
+                now_iso,
+                now_epoch,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _scheduler_state_from_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    now_iso: str,
+    now_epoch: float,
+) -> dict[str, Any]:
+    running_entries: dict[str, dict[str, Any]] = {}
+    for row in conn.execute(
+        """
+        SELECT r.work_id, w.identifier, w.state, r.worker_id, r.attempt, r.worker_status,
+               r.started_at_epoch, r.heartbeat_at_epoch, r.cancel_requested, r.cancel_reason,
+               r.thread_id, r.turn_id
+        FROM engine_running_work r
+        LEFT JOIN engine_work_items w ON w.workflow = r.workflow AND w.work_id = r.work_id
+        WHERE r.workflow=?
+        """,
+        (workflow,),
+    ).fetchall():
+        (
+            work_id,
+            identifier,
+            state,
+            worker_id,
+            attempt,
+            worker_status,
+            started_at_epoch,
+            heartbeat_at_epoch,
+            cancel_requested,
+            cancel_reason,
+            thread_id,
+            turn_id,
+        ) = row
+        running_entries[str(work_id)] = {
+            "issue_id": str(work_id),
+            "identifier": identifier,
+            "state": state,
+            "worker_id": worker_id,
+            "attempt": int(attempt or 0),
+            "worker_status": worker_status or "running",
+            "started_at_epoch": float(started_at_epoch or now_epoch),
+            "heartbeat_at_epoch": float(heartbeat_at_epoch or started_at_epoch or now_epoch),
+            "cancel_requested": bool(cancel_requested),
+            "cancel_reason": cancel_reason,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+        }
+
+    retry_entries: dict[str, dict[str, Any]] = {}
+    for row in conn.execute(
+        """
+        SELECT q.work_id, w.identifier, q.attempt, q.due_at_epoch, q.error, q.current_attempt, q.delay_type
+        FROM engine_retry_queue q
+        LEFT JOIN engine_work_items w ON w.workflow = q.workflow AND w.work_id = q.work_id
+        WHERE q.workflow=?
+        """,
+        (workflow,),
+    ).fetchall():
+        work_id, identifier, attempt, due_at_epoch, error, current_attempt, delay_type = row
+        retry_entries[str(work_id)] = {
+            "issue_id": str(work_id),
+            "identifier": identifier,
+            "attempt": int(attempt or 0),
+            "due_at_epoch": float(due_at_epoch or now_epoch),
+            "error": error,
+            "current_attempt": current_attempt,
+            "delay_type": delay_type or "failure",
+        }
+
+    codex_threads: dict[str, dict[str, Any]] = {}
+    for row in conn.execute(
+        """
+        SELECT s.work_id, w.identifier, s.session_name, s.runtime_name, s.runtime_kind, s.session_id,
+               s.thread_id, s.turn_id, s.status, s.cancel_requested, s.cancel_reason, s.metadata_json, s.updated_at
+        FROM engine_runtime_sessions s
+        LEFT JOIN engine_work_items w ON w.workflow = s.workflow AND w.work_id = s.work_id
+        WHERE s.workflow=? AND s.thread_id IS NOT NULL AND s.thread_id != ''
+        """,
+        (workflow,),
+    ).fetchall():
+        (
+            work_id,
+            identifier,
+            session_name,
+            runtime_name,
+            runtime_kind,
+            session_id,
+            thread_id,
+            turn_id,
+            status,
+            cancel_requested,
+            cancel_reason,
+            metadata_json,
+            updated_at,
+        ) = row
+        metadata = _json_loads(metadata_json) or {}
+        entry = {
+            **metadata,
+            "issue_id": str(work_id),
+            "identifier": identifier or metadata.get("identifier") or str(work_id),
+            "session_name": session_name,
+            "runtime_name": runtime_name,
+            "runtime_kind": runtime_kind,
+            "session_id": session_id,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+            "status": status,
+            "cancel_requested": bool(cancel_requested),
+            "cancel_reason": cancel_reason,
+            "updated_at": updated_at,
+        }
+        codex_threads[str(work_id)] = {key: value for key, value in entry.items() if value is not None}
+
+    totals_row = conn.execute(
+        """
+        SELECT input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json
+        FROM engine_runtime_totals
+        WHERE workflow=?
+        """,
+        (workflow,),
+    ).fetchone()
+    codex_totals: dict[str, Any] = {}
+    if totals_row is not None:
+        input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json = totals_row
+        codex_totals = {
+            "input_tokens": int(input_tokens or 0),
+            "output_tokens": int(output_tokens or 0),
+            "total_tokens": int(total_tokens or 0),
+            "turn_count": int(turn_count or 0),
+        }
+        rate_limits = _json_loads(rate_limits_json)
+        if rate_limits is not None:
+            codex_totals["rate_limits"] = rate_limits
+
+    return build_scheduler_payload(
+        workflow=workflow,
+        retry_entries=retry_entries,
+        running_entries=running_entries,
+        codex_totals=codex_totals,
+        codex_threads=codex_threads,
+        now_iso=now_iso,
+        now_epoch=now_epoch,
+    )
+
+
+def load_engine_scheduler_state(
+    db_path: Path,
+    *,
+    workflow: str,
+    now_iso: str,
+    now_epoch: float,
+) -> dict[str, Any]:
+    conn = _open_engine_state_db(db_path)
+    try:
+        return _scheduler_state_from_connection(conn, workflow=workflow, now_iso=now_iso, now_epoch=now_epoch)
+    finally:
+        conn.close()
+
+
+def read_engine_scheduler_state(
+    db_path: Path,
+    *,
+    workflow: str,
+    now_iso: str,
+    now_epoch: float,
+) -> dict[str, Any] | None:
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.OperationalError:
+        return None
+    try:
+        if not engine_state_tables_exist(conn):
+            return None
+        return _scheduler_state_from_connection(conn, workflow=workflow, now_iso=now_iso, now_epoch=now_epoch)
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        conn.close()

--- a/daedalus/engine/storage.py
+++ b/daedalus/engine/storage.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    """Write JSON through a sibling temp file, then atomically replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
+
+
+def load_optional_json(path: Path | None) -> dict[str, Any] | None:
+    """Return a JSON object, or None for missing/malformed/non-object payloads."""
+    if path is None or not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")

--- a/daedalus/engine/work_items.py
+++ b/daedalus/engine/work_items.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorkItemRef:
+    """Tracker-neutral reference to one unit of workflow work."""
+
+    id: str
+    identifier: str | None = None
+    state: str | None = None
+    title: str | None = None
+    url: str | None = None
+    source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "identifier": self.identifier,
+            "state": self.state,
+            "title": self.title,
+            "url": self.url,
+            "source": self.source,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class RunningWork:
+    work_item: WorkItemRef
+    worker_id: str
+    attempt: int
+    started_at_epoch: float
+    heartbeat_at_epoch: float
+    worker_status: str = "running"
+    cancel_requested: bool = False
+    cancel_reason: str | None = None
+    thread_id: str | None = None
+    turn_id: str | None = None
+
+    def to_scheduler_entry(self) -> dict[str, Any]:
+        return {
+            "issue_id": self.work_item.id,
+            "worker_id": self.worker_id,
+            "identifier": self.work_item.identifier,
+            "attempt": self.attempt,
+            "state": self.work_item.state,
+            "worker_status": self.worker_status,
+            "started_at_epoch": self.started_at_epoch,
+            "heartbeat_at_epoch": self.heartbeat_at_epoch,
+            "cancel_requested": self.cancel_requested,
+            "cancel_reason": self.cancel_reason,
+            "thread_id": self.thread_id,
+            "turn_id": self.turn_id,
+        }
+
+
+@dataclass(frozen=True)
+class RetryEntry:
+    work_item: WorkItemRef
+    attempt: int
+    due_at_epoch: float
+    error: str
+    current_attempt: int | None = None
+    delay_type: str = "failure"
+
+    def to_scheduler_entry(self) -> dict[str, Any]:
+        return {
+            "issue_id": self.work_item.id,
+            "identifier": self.work_item.identifier,
+            "attempt": self.attempt,
+            "due_at_epoch": self.due_at_epoch,
+            "error": self.error,
+            "current_attempt": self.current_attempt,
+            "delay_type": self.delay_type,
+        }
+
+
+@dataclass(frozen=True)
+class WorkResult:
+    work_item: WorkItemRef
+    ok: bool
+    attempt: int
+    error: str | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+def work_item_from_issue(issue: dict[str, Any], *, source: str | None = None) -> WorkItemRef:
+    issue_id = str(issue.get("id") or "").strip()
+    if not issue_id:
+        raise ValueError("issue is missing id")
+    return WorkItemRef(
+        id=issue_id,
+        identifier=str(issue.get("identifier") or issue_id).strip() or issue_id,
+        state=str(issue.get("state") or "").strip() or None,
+        title=str(issue.get("title") or "").strip() or None,
+        url=str(issue.get("url") or "").strip() or None,
+        source=source,
+        metadata={"raw": issue},
+    )
+
+
+def work_item_from_change_delivery_lane(lane: dict[str, Any]) -> WorkItemRef:
+    lane_id = str(lane.get("lane_id") or lane.get("laneId") or "").strip()
+    issue_number = lane.get("issue_number") or lane.get("issueNumber") or lane.get("github_issue_number")
+    if not lane_id:
+        if issue_number in (None, ""):
+            raise ValueError("change-delivery lane is missing lane_id and issue_number")
+        lane_id = f"lane:{issue_number}"
+    identifier = f"#{issue_number}" if issue_number not in (None, "") else lane_id
+    return WorkItemRef(
+        id=lane_id,
+        identifier=identifier,
+        state=str(lane.get("workflow_state") or lane.get("workflowState") or "").strip() or None,
+        title=str(lane.get("issue_title") or lane.get("issueTitle") or "").strip() or None,
+        url=str(lane.get("issue_url") or lane.get("issueUrl") or "").strip() or None,
+        source="change-delivery",
+        metadata={
+            "issue_number": issue_number,
+            "lane_status": lane.get("lane_status") or lane.get("laneStatus"),
+            "active_actor_id": lane.get("active_actor_id") or lane.get("activeActorId"),
+            "current_action_id": lane.get("current_action_id") or lane.get("currentActionId"),
+        },
+    )

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from engine.state import init_engine_state
 from engine.sqlite import connect_daedalus_db
 from workflows.shared.paths import (
     plugin_entrypoint_path,
@@ -532,6 +533,7 @@ def init_daedalus_db(*, workflow_root: Path, project_key: str) -> dict[str, Any]
             CREATE INDEX IF NOT EXISTS idx_state_projections_lane_type ON state_projections(lane_id, projection_type);
             """
         )
+        init_engine_state(conn)
         now_iso = _now_iso()
         runtime_row = conn.execute(
             "SELECT schema_version FROM daedalus_runtime WHERE runtime_id='daedalus'"

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from engine.sqlite import connect_daedalus_db
 from workflows.shared.paths import (
     plugin_entrypoint_path,
     project_key_for_workflow_root,
@@ -98,14 +99,7 @@ def _parse_json_blob(value: Any) -> Any:
 
 
 def _connect(db_path: Path) -> sqlite3.Connection:
-    _ensure_parent(db_path)
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA synchronous = NORMAL")
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA temp_store = MEMORY")
-    conn.execute("PRAGMA busy_timeout = 5000")
-    return conn
+    return connect_daedalus_db(db_path)
 
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:

--- a/daedalus/skills/daedalus-architecture/SKILL.md
+++ b/daedalus/skills/daedalus-architecture/SKILL.md
@@ -18,7 +18,8 @@ Current Daedalus shape:
 - plugin code is the source of truth under `~/.hermes/plugins/daedalus`
 - workflow instance data lives under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`
 - shared runtimes live under `daedalus/runtimes/`; shared trackers live under `daedalus/trackers/`
-- `change-delivery` uses SQLite lane/action state; `issue-runner` uses persisted status/scheduler/audit JSON/JSONL state
+- shared engine execution state lives in SQLite; workflow JSON/JSONL files are projections and audit trails
+- `change-delivery` adds lane/action/review/failure tables on top of the shared engine tables
 
 ## Core decision model
 
@@ -408,7 +409,7 @@ Useful early file layout proven in practice:
 - phase bootstrap tests under `tests/test_daedalus_phase1_skeleton.py`
 - canonical DB under `runtime/state/daedalus/daedalus.db` for current workflow roots
 - append-only runtime event log under `runtime/memory/daedalus-events.jsonl`
-- workflow-owned scheduler/audit files under `memory/` unless a workflow explicitly configures different storage paths
+- workflow-owned status/scheduler/audit projections under `memory/` unless a workflow explicitly configures different storage paths
 
 Practical lessons learned:
 - do not trust a huge timed-out tarball just because the file exists; validate with `gzip -t` and checksum or it is garbage

--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -18,6 +18,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
 from workflows.contract import WorkflowContractError, load_workflow_contract
 
 # Sibling-import boilerplate.
@@ -115,6 +116,14 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
             if not isinstance(row, dict):
                 continue
             identifier = row.get("identifier") or row.get("issue_id")
+            work_item = work_item_from_issue(
+                {
+                    "id": row.get("issue_id") or identifier or "unknown",
+                    "identifier": identifier,
+                    "state": row.get("state") or "running",
+                },
+                source="issue-runner",
+            ).to_dict()
             out.append(
                 {
                     "lane_id": row.get("issue_id"),
@@ -125,12 +134,21 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                     "issue_identifier": identifier,
                     "lane_status": "active",
                     "kind": "running",
+                    "work_item": work_item,
                 }
             )
         for row in scheduler.get("retry_queue") or []:
             if not isinstance(row, dict):
                 continue
             identifier = row.get("identifier") or row.get("issue_id")
+            work_item = work_item_from_issue(
+                {
+                    "id": row.get("issue_id") or identifier or "unknown",
+                    "identifier": identifier,
+                    "state": "retrying",
+                },
+                source="issue-runner",
+            ).to_dict()
             out.append(
                 {
                     "lane_id": row.get("issue_id"),
@@ -141,6 +159,7 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                     "issue_identifier": identifier,
                     "lane_status": "retrying",
                     "kind": "retrying",
+                    "work_item": work_item,
                 }
             )
         return out
@@ -167,7 +186,7 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
         )
         out = []
         for row in cur.fetchall():
-            out.append({
+            lane = {
                 "lane_id": row[0],
                 # `state` is the key the renderer (watch.py) consumes; we
                 # source it from workflow_state. Both names are exposed for
@@ -177,7 +196,9 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                 "github_issue_number": row[2],
                 "issue_number": row[2],
                 "lane_status": row[3],
-            })
+            }
+            lane["work_item"] = work_item_from_change_delivery_lane(lane).to_dict()
+            out.append(lane)
     except sqlite3.OperationalError:
         out = []
     finally:

--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from pathlib import Path
 from typing import Any
 
+from engine.state import read_engine_scheduler_state
 from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
 from workflows.contract import WorkflowContractError, load_workflow_contract
 
@@ -74,6 +76,20 @@ def _workflow_name(workflow_root: Path) -> str | None:
         return None
 
 
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _engine_scheduler(workflow_root: Path, workflow: str) -> dict[str, Any]:
+    payload = read_engine_scheduler_state(
+        runtime_paths(Path(workflow_root))["db_path"],
+        workflow=workflow,
+        now_iso=_now_iso(),
+        now_epoch=time.time(),
+    )
+    return payload or {}
+
+
 def _resolve_issue_runner_storage_path(workflow_root: Path, key: str, default: str) -> Path | None:
     try:
         contract = load_workflow_contract(Path(workflow_root))
@@ -107,10 +123,7 @@ def recent_workflow_audit(workflow_root: Path, limit: int = 50) -> list[dict[str
 def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
     workflow_root = Path(workflow_root)
     if _workflow_name(workflow_root) == "issue-runner":
-        scheduler_path = _resolve_issue_runner_storage_path(
-            workflow_root, "scheduler", "memory/workflow-scheduler.json"
-        )
-        scheduler = _load_optional_json(scheduler_path) or {}
+        scheduler = _engine_scheduler(workflow_root, "issue-runner")
         out: list[dict[str, Any]] = []
         for row in scheduler.get("running") or []:
             if not isinstance(row, dict):
@@ -245,8 +258,7 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
     if workflow_name not in {"issue-runner", "change-delivery"}:
         return {}
     if workflow_name == "change-delivery":
-        scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
-        scheduler_payload = _load_optional_json(scheduler_path) or {}
+        scheduler_payload = _engine_scheduler(workflow_root, "change-delivery")
         totals = scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {}
         codex_turns = _codex_turn_entries(scheduler_payload)
         return {
@@ -262,9 +274,8 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
             "rate_limits": totals.get("rate_limits"),
         }
     status_path = _resolve_issue_runner_storage_path(workflow_root, "status", "memory/workflow-status.json")
-    scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
     status_payload = _load_optional_json(status_path) or {}
-    scheduler_payload = _load_optional_json(scheduler_path) or {}
+    scheduler_payload = _engine_scheduler(workflow_root, "issue-runner")
     scheduler = {
         "running": scheduler_payload.get("running") or [],
         "retry_queue": scheduler_payload.get("retry_queue") or scheduler_payload.get("retryQueue") or [],

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -8,8 +8,8 @@ JSONL events log on disk per request.
 Shape conforms to Symphony §13.7 (spec §6.4):
 
 - ``state_view`` returns a snapshot of running + retrying work plus a
-  ``codex_totals`` block. `change-delivery` keeps the legacy lane-backed model;
-  `issue-runner` projects from scheduler/status JSON files.
+  ``codex_totals`` block. `change-delivery` keeps the lane-backed domain
+  model; engine execution state is projected from shared SQLite tables.
 - ``issue_view`` returns the per-lane shape, or ``None`` if the
   identifier is unknown.
 
@@ -20,11 +20,14 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from engine.state import read_engine_scheduler_state
 from workflows.contract import WorkflowContractError, load_workflow_contract
+from workflows.shared.paths import runtime_paths
 
 # Lane statuses the spec considers "active" (running). Anything else
 # (merged / closed / archived) is omitted from the running list. The
@@ -197,6 +200,18 @@ def _workflow_name(workflow_root: Path | None) -> str | None:
         return None
 
 
+def _engine_scheduler(workflow_root: Path | None, workflow: str) -> dict[str, Any]:
+    if workflow_root is None:
+        return {}
+    payload = read_engine_scheduler_state(
+        runtime_paths(Path(workflow_root))["db_path"],
+        workflow=workflow,
+        now_iso=_now_iso(),
+        now_epoch=time.time(),
+    )
+    return payload or {}
+
+
 def _epoch_to_iso(value: Any) -> str | None:
     try:
         epoch = float(value)
@@ -290,10 +305,9 @@ def _issue_runner_retry_entry(row: dict[str, Any]) -> dict[str, Any]:
 
 def _issue_runner_state_view(workflow_root: Path, events_log_path: Path) -> dict[str, Any]:
     status_path = _resolve_issue_runner_storage_path(workflow_root, "status", "memory/workflow-status.json")
-    scheduler_path = _resolve_issue_runner_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")
     audit_log_path = _resolve_issue_runner_storage_path(workflow_root, "audit-log", "memory/workflow-audit.jsonl")
     status_payload = _load_optional_json(status_path) or {}
-    scheduler_payload = _load_optional_json(scheduler_path) or {}
+    scheduler_payload = _engine_scheduler(workflow_root, "issue-runner")
     running_rows = [
         _issue_runner_running_entry(row)
         for row in (scheduler_payload.get("running") or [])
@@ -389,7 +403,7 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
     lanes = _query_active_lanes(db_path)
     events = _read_events_tail(events_log_path, _RECENT_EVENTS_LIMIT)
     running = [_lane_to_running_entry(lane, events) for lane in lanes]
-    scheduler = _load_optional_json(_storage_path(workflow_root, "scheduler", "memory/workflow-scheduler.json")) or {}
+    scheduler = _engine_scheduler(workflow_root, "change-delivery")
     codex_totals = dict(scheduler.get("codex_totals") or scheduler.get("codexTotals") or {})
     rate_limits = codex_totals.pop("rate_limits", None)
     codex_turns = _codex_turn_entries(scheduler)

--- a/daedalus/workflows/change_delivery/work_items.py
+++ b/daedalus/workflows/change_delivery/work_items.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+from engine.work_items import WorkItemRef, work_item_from_change_delivery_lane
+
+
+def lane_to_work_item_ref(lane: dict[str, Any]) -> WorkItemRef:
+    """Expose a change-delivery lane through the shared engine work-item shape."""
+    return work_item_from_change_delivery_lane(lane)

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -10,6 +10,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from engine.audit import make_audit_fn as _engine_make_audit_fn
+from engine.storage import append_jsonl as _append_jsonl
+from engine.storage import load_optional_json as _load_optional_json
+from engine.storage import write_json_atomic as _write_json
+from engine.storage import write_text_atomic as _write_text
 from workflows.change_delivery.migrations import get_ledger_field
 from workflows.change_delivery.runtimes import build_runtimes
 
@@ -189,35 +194,6 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return data
 
 
-def _write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp.replace(path)
-
-
-def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, sort_keys=True) + "\n")
-
-
-def _load_optional_json(path: Path | None) -> dict[str, Any] | None:
-    if path is None or not path.exists():
-        return None
-    try:
-        return _load_json(path)
-    except Exception:
-        return None
-
-
-def _write_text(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(content, encoding="utf-8")
-    tmp.replace(path)
-
-
 def _now_ms() -> int:
     return int(time.time() * 1000)
 
@@ -328,24 +304,11 @@ def _make_audit_fn(
          after the write. Publisher exceptions are swallowed — observability
          must never break workflow execution.
     """
-    def audit(action, summary, **extra):
-        _append_jsonl(
-            audit_log_path,
-            {
-                "at": _now_iso(),
-                "action": action,
-                "summary": summary,
-                **extra,
-            },
-        )
-        if publisher is not None:
-            try:
-                publisher(action=action, summary=summary, extra=dict(extra))
-            except Exception:
-                # Best-effort observability hook; never raise into the caller.
-                pass
-
-    return audit
+    return _engine_make_audit_fn(
+        audit_log_path=Path(audit_log_path),
+        now_iso=_now_iso,
+        publisher=publisher,
+    )
 
 
 def _make_comment_publisher(

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -11,12 +11,14 @@ from types import SimpleNamespace
 from typing import Any
 
 from engine.audit import make_audit_fn as _engine_make_audit_fn
+from engine.state import load_engine_scheduler_state, save_engine_scheduler_state
 from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
 from engine.storage import write_text_atomic as _write_text
 from workflows.change_delivery.migrations import get_ledger_field
 from workflows.change_delivery.runtimes import build_runtimes
+from workflows.shared.paths import runtime_paths
 
 
 def _derive_lane_selection_cfg(yaml_cfg, *, active_lane_label):
@@ -421,6 +423,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     health_path = Path(config["healthPath"])
     audit_log_path = Path(config["auditLogPath"])
     scheduler_path = Path(config.get("schedulerPath") or (workspace_root / "memory/workflow-scheduler.json"))
+    db_path = runtime_paths(workspace_root)["db_path"]
     sessions_state_path = workspace_root / "state/sessions"
 
     # -- config constants ------------------------------------------------
@@ -521,9 +524,24 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         _write_json(ledger_path, payload)
 
     def load_scheduler() -> dict[str, Any]:
-        return _load_optional_json(scheduler_path) or {}
+        return load_engine_scheduler_state(
+            db_path,
+            workflow="change-delivery",
+            now_iso=_now_iso(),
+            now_epoch=time.time(),
+        )
 
     def save_scheduler(payload: dict[str, Any]) -> None:
+        save_engine_scheduler_state(
+            db_path,
+            workflow="change-delivery",
+            retry_entries={},
+            running_entries={},
+            codex_totals=payload.get("codex_totals") or payload.get("codexTotals") or {},
+            codex_threads=payload.get("codex_threads") or payload.get("codexThreads") or {},
+            now_iso=payload.get("updatedAt") or _now_iso(),
+            now_epoch=time.time(),
+        )
         _write_json(scheduler_path, payload)
 
     # Wire the comment publisher (returns None when observability is disabled —

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -15,6 +15,18 @@ import yaml
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 
+from engine.scheduler import (
+    build_scheduler_payload,
+    codex_threads_snapshot,
+    restore_scheduler_state,
+    retry_due_at,
+    retry_queue_snapshot,
+    running_snapshot,
+)
+from engine.driver import WorkflowDriver
+from engine.storage import append_jsonl as _append_jsonl
+from engine.storage import load_optional_json as _load_optional_json
+from engine.storage import write_json_atomic as _write_json
 from runtimes import PromptRunResult, Runtime, build_runtimes
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
@@ -84,29 +96,6 @@ def _tracker_config_for_client(config: dict[str, Any]) -> dict[str, Any]:
     return tracker_cfg
 
 
-def _write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp.replace(path)
-
-
-def _load_optional_json(path: Path | None) -> dict[str, Any] | None:
-    if path is None or not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, sort_keys=True) + "\n")
-
-
 def _schema_path() -> Path:
     return Path(__file__).with_name("schema.yaml")
 
@@ -142,17 +131,6 @@ def _assert_workspace_inside_root(workspace_root: Path, issue_workspace: Path) -
     resolved = issue_workspace.expanduser().resolve()
     if resolved == root or not _is_relative_to(resolved, root):
         raise RuntimeError(f"invalid workspace path: {resolved} is not a child of {root}")
-
-
-def _retry_due_at(entry: dict[str, Any] | None, *, default: float | None = None) -> float:
-    payload = entry or {}
-    if payload.get("due_at_monotonic") is not None:
-        return float(payload.get("due_at_monotonic") or 0.0)
-    if payload.get("due_at_epoch") is not None:
-        return float(payload.get("due_at_epoch") or 0.0)
-    if payload.get("dueAtEpoch") is not None:
-        return float(payload.get("dueAtEpoch") or 0.0)
-    return float(default or _now_epoch())
 
 
 def _render_prompt(*, prompt_template: str, issue: dict[str, Any], attempt: int | None) -> str:
@@ -292,7 +270,7 @@ def _scheduler_state_from_config(config: dict[str, Any]) -> dict[str, Any]:
 
 
 @dataclass
-class IssueRunnerWorkspace:
+class IssueRunnerWorkspace(WorkflowDriver):
     path: Path
     config: dict[str, Any]
     snapshot_ref: AtomicRef[ConfigSnapshot]
@@ -511,72 +489,29 @@ class IssueRunnerWorkspace:
     def _persist_scheduler_state(self) -> None:
         _write_json(
             self.scheduler_path,
-            {
-                "workflow": "issue-runner",
-                "updatedAt": _now_iso(),
-                "retry_queue": self._retry_queue_snapshot(),
-                "running": self._running_snapshot(),
-                "codex_totals": dict(self.codex_totals or {}),
-                "codex_threads": self._codex_threads_snapshot(),
-            },
+            build_scheduler_payload(
+                workflow="issue-runner",
+                retry_entries=self.retry_entries,
+                running_entries=self.running_entries,
+                codex_totals=self.codex_totals,
+                codex_threads=self.codex_threads,
+                now_iso=_now_iso(),
+                now_epoch=_now_epoch(),
+            ),
         )
 
     def _restore_scheduler_state(self) -> None:
         payload = self._load_scheduler_state()
-        retry_entries: dict[str, dict[str, Any]] = {}
-        for item in payload.get("retry_queue") or payload.get("retryQueue") or []:
-            if not isinstance(item, dict):
-                continue
-            issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
-            if not issue_id:
-                continue
-            retry_entries[issue_id] = {
-                "issue_id": issue_id,
-                "identifier": item.get("identifier"),
-                "attempt": int(item.get("attempt") or 0),
-                "error": item.get("error"),
-                "due_at_epoch": float(item.get("due_at_epoch") or item.get("dueAtEpoch") or _now_epoch()),
-                "current_attempt": item.get("current_attempt") or item.get("currentAttempt"),
-            }
-
-        running_entries: dict[str, dict[str, Any]] = {}
-        recovered_running: list[dict[str, Any]] = []
-        for item in payload.get("running") or []:
-            if not isinstance(item, dict):
-                continue
-            issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
-            if not issue_id:
-                continue
-            entry = {
-                "issue_id": issue_id,
-                "worker_id": item.get("worker_id") or item.get("workerId") or f"worker:{issue_id}:recovered",
-                "identifier": item.get("identifier"),
-                "attempt": int(item.get("attempt") or 0),
-                "state": item.get("state"),
-                "worker_status": item.get("worker_status") or item.get("workerStatus") or "recovered",
-                "started_at_epoch": float(item.get("started_at_epoch") or item.get("startedAtEpoch") or _now_epoch()),
-                "heartbeat_at_epoch": float(
-                    item.get("heartbeat_at_epoch")
-                    or item.get("heartbeatAtEpoch")
-                    or item.get("started_at_epoch")
-                    or item.get("startedAtEpoch")
-                    or _now_epoch()
-                ),
-                "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
-                "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
-            }
-            running_entries[issue_id] = entry
-            recovered_running.append(entry)
-
-        self.retry_entries = retry_entries
+        restored = restore_scheduler_state(payload, now_epoch=_now_epoch())
+        self.retry_entries = restored.retry_entries
         self.running_entries = {}
-        self.codex_totals = dict(payload.get("codex_totals") or payload.get("codexTotals") or {})
-        self.codex_threads = self._restore_codex_threads(payload.get("codex_threads") or {})
+        self.codex_totals = dict(restored.codex_totals)
+        self.codex_threads = restored.codex_threads
         self.running_issue_id = None
 
-        if recovered_running:
+        if restored.recovered_running:
             now_epoch = _now_epoch()
-            for entry in recovered_running:
+            for entry in restored.recovered_running:
                 issue_id = str(entry.get("issue_id") or "")
                 existing = self.retry_entries.get(issue_id) or {}
                 self.retry_entries[issue_id] = {
@@ -590,76 +525,13 @@ class IssueRunnerWorkspace:
             self._persist_scheduler_state()
 
     def _running_snapshot(self) -> list[dict[str, Any]]:
-        now_epoch = _now_epoch()
-        running = []
-        for issue_id, entry in self.running_entries.items():
-            started_at_epoch = float(entry.get("started_at_epoch") or now_epoch)
-            heartbeat_at_epoch = float(entry.get("heartbeat_at_epoch") or started_at_epoch)
-            running.append(
-                {
-                    "issue_id": issue_id,
-                    "worker_id": entry.get("worker_id"),
-                    "identifier": entry.get("identifier"),
-                    "attempt": int(entry.get("attempt") or 0),
-                    "state": entry.get("state"),
-                    "worker_status": entry.get("worker_status") or "running",
-                    "started_at_epoch": started_at_epoch,
-                    "heartbeat_at_epoch": heartbeat_at_epoch,
-                    "running_for_ms": max(int((now_epoch - started_at_epoch) * 1000), 0),
-                    "heartbeat_age_ms": max(int((now_epoch - heartbeat_at_epoch) * 1000), 0),
-                    "cancel_requested": bool(entry.get("cancel_requested") or False),
-                    "cancel_reason": entry.get("cancel_reason"),
-                    "thread_id": entry.get("thread_id"),
-                    "turn_id": entry.get("turn_id"),
-                }
-            )
-        running.sort(key=lambda item: (item["state"] or "", item["identifier"] or item["issue_id"]))
-        return running
+        return running_snapshot(self.running_entries, now_epoch=_now_epoch())
 
     def _retry_queue_snapshot(self) -> list[dict[str, Any]]:
-        now_epoch = _now_epoch()
-        entries = []
-        for issue_id, entry in self.retry_entries.items():
-            due_at = _retry_due_at(entry, default=now_epoch)
-            entries.append(
-                {
-                    "issue_id": issue_id,
-                    "identifier": entry.get("identifier"),
-                    "attempt": int(entry.get("attempt") or 0),
-                    "error": entry.get("error"),
-                    "due_at_epoch": due_at,
-                    "due_in_ms": max(int((due_at - now_epoch) * 1000), 0),
-                }
-            )
-        entries.sort(key=lambda item: (item["due_in_ms"], item["attempt"], item["identifier"] or item["issue_id"]))
-        return entries
-
-    def _restore_codex_threads(self, raw: Any) -> dict[str, dict[str, Any]]:
-        if not isinstance(raw, dict):
-            return {}
-        restored: dict[str, dict[str, Any]] = {}
-        for issue_id, item in raw.items():
-            if not isinstance(item, dict):
-                continue
-            normalized_issue_id = str(item.get("issue_id") or issue_id or "").strip()
-            thread_id = str(item.get("thread_id") or "").strip()
-            if not normalized_issue_id or not thread_id:
-                continue
-            restored[normalized_issue_id] = {
-                "issue_id": normalized_issue_id,
-                "identifier": item.get("identifier"),
-                "session_name": item.get("session_name"),
-                "thread_id": thread_id,
-                "turn_id": item.get("turn_id"),
-                "updated_at": item.get("updated_at"),
-            }
-        return restored
+        return retry_queue_snapshot(self.retry_entries, now_epoch=_now_epoch())
 
     def _codex_threads_snapshot(self) -> dict[str, dict[str, Any]]:
-        return {
-            issue_id: dict(entry)
-            for issue_id, entry in sorted(self.codex_threads.items(), key=lambda item: item[0])
-        }
+        return codex_threads_snapshot(self.codex_threads)
 
     def _codex_thread_for_issue(self, issue: dict[str, Any]) -> str | None:
         issue_id = str(issue.get("id") or "").strip()
@@ -698,13 +570,13 @@ class IssueRunnerWorkspace:
         due_entries = sorted(
             self.retry_entries.items(),
             key=lambda item: (
-                _retry_due_at(item[1], default=0.0),
+                retry_due_at(item[1], default=0.0),
                 int((item[1] or {}).get("attempt") or 0),
                 str((item[1] or {}).get("identifier") or item[0]),
             ),
         )
         for issue_id, entry in due_entries:
-            if _retry_due_at(entry, default=0.0) > now_epoch:
+            if retry_due_at(entry, default=0.0) > now_epoch:
                 continue
             issue = issues_by_id.get(issue_id)
             if issue is None:
@@ -796,7 +668,7 @@ class IssueRunnerWorkspace:
         pending_retry_ids = {
             issue_id
             for issue_id, entry in self.retry_entries.items()
-            if _retry_due_at(entry, default=0.0) > _now_epoch()
+            if retry_due_at(entry, default=0.0) > _now_epoch()
         }
         running_ids = set(self.running_entries)
         selected: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
@@ -819,10 +691,10 @@ class IssueRunnerWorkspace:
             [
                 (issue_id, entry)
                 for issue_id, entry in self.retry_entries.items()
-                if _retry_due_at(entry, default=0.0) <= _now_epoch()
+                if retry_due_at(entry, default=0.0) <= _now_epoch()
             ],
             key=lambda item: (
-                _retry_due_at(item[1], default=0.0),
+                retry_due_at(item[1], default=0.0),
                 int((item[1] or {}).get("attempt") or 0),
                 str((item[1] or {}).get("identifier") or item[0]),
             ),

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -24,9 +24,16 @@ from engine.scheduler import (
     running_snapshot,
 )
 from engine.driver import WorkflowDriver
+from engine.lifecycle import (
+    clear_work_entries,
+    mark_running_work,
+    recover_running_as_retry,
+    schedule_retry_entry,
+)
 from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
+from engine.work_items import work_item_from_issue
 from runtimes import PromptRunResult, Runtime, build_runtimes
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
@@ -511,17 +518,11 @@ class IssueRunnerWorkspace(WorkflowDriver):
 
         if restored.recovered_running:
             now_epoch = _now_epoch()
-            for entry in restored.recovered_running:
-                issue_id = str(entry.get("issue_id") or "")
-                existing = self.retry_entries.get(issue_id) or {}
-                self.retry_entries[issue_id] = {
-                    "issue_id": issue_id,
-                    "identifier": entry.get("identifier"),
-                    "attempt": max(int(existing.get("attempt") or 0), int(entry.get("attempt") or 0), 1),
-                    "error": "scheduler restarted while issue was running",
-                    "due_at_epoch": now_epoch,
-                    "current_attempt": entry.get("attempt"),
-                }
+            self.retry_entries = recover_running_as_retry(
+                self.retry_entries,
+                restored.recovered_running,
+                now_epoch=now_epoch,
+            )
             self._persist_scheduler_state()
 
     def _running_snapshot(self) -> list[dict[str, Any]]:
@@ -594,45 +595,28 @@ class IssueRunnerWorkspace(WorkflowDriver):
         delay_type: str = "failure",
     ) -> dict[str, Any]:
         max_backoff_ms = int((self.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
-        if delay_type == "continuation":
-            retry_attempt = 1
-            delay_ms = 1000
-        else:
-            retry_attempt = int((self.retry_entries.get(issue["id"]) or {}).get("attempt") or 0) + 1
-            delay_ms = min(max_backoff_ms, 10000 * (2 ** max(retry_attempt - 1, 0)))
-        due_at = _now_epoch() + (delay_ms / 1000.0)
-        entry = {
-            "issue_id": issue.get("id"),
-            "identifier": issue.get("identifier"),
-            "attempt": retry_attempt,
-            "due_at_epoch": due_at,
-            "error": error,
-            "current_attempt": current_attempt,
-            "delay_type": delay_type,
-        }
-        self.retry_entries[str(issue.get("id"))] = entry
+        work_item = work_item_from_issue(issue, source=str((self.config.get("tracker") or {}).get("kind") or "tracker"))
+        entry, retry = schedule_retry_entry(
+            work_item=work_item,
+            existing_entry=self.retry_entries.get(work_item.id),
+            error=error,
+            current_attempt=current_attempt,
+            delay_type=delay_type,
+            max_backoff_ms=max_backoff_ms,
+            now_epoch=_now_epoch(),
+        )
+        self.retry_entries[work_item.id] = entry
         self._emit_event(
             "issue_runner.retry.scheduled",
             {
-                "issue_id": issue.get("id"),
-                "identifier": issue.get("identifier"),
-                "retry_attempt": retry_attempt,
-                "delay_ms": delay_ms,
-                "delay_type": delay_type,
+                **retry,
                 "error": error,
             },
         )
-        return {
-            "issue_id": issue.get("id"),
-            "identifier": issue.get("identifier"),
-            "retry_attempt": retry_attempt,
-            "delay_ms": delay_ms,
-            "delay_type": delay_type,
-        }
+        return retry
 
     def _clear_retry(self, issue_id: str | None) -> None:
-        if issue_id:
-            self.retry_entries.pop(issue_id, None)
+        self.retry_entries = clear_work_entries(self.retry_entries, [issue_id])
 
     def _record_metrics(self, result: PromptRunResult) -> dict[str, Any]:
         metrics = self._metrics_payload(result)
@@ -738,30 +722,24 @@ class IssueRunnerWorkspace(WorkflowDriver):
 
     def _mark_running(self, selections: list[tuple[dict[str, Any], dict[str, Any] | None]]) -> None:
         now_epoch = _now_epoch()
-        entries = dict(self.running_entries)
-        for issue, retry_entry in selections:
-            issue_id = str(issue.get("id") or "").strip()
-            if not issue_id:
-                continue
-            entries[issue_id] = {
-                "issue_id": issue_id,
-                "worker_id": f"worker:{issue_id}:{int(now_epoch * 1000)}",
-                "identifier": issue.get("identifier"),
-                "attempt": self._issue_attempt(issue=issue, retry_entry=retry_entry),
-                "state": issue.get("state"),
-                "worker_status": "running",
-                "started_at_epoch": now_epoch,
-                "heartbeat_at_epoch": now_epoch,
-                "cancel_requested": False,
-                "cancel_reason": None,
-            }
-        self.running_entries = entries
+        tracker_kind = str((self.config.get("tracker") or {}).get("kind") or "tracker")
+        self.running_entries = mark_running_work(
+            self.running_entries,
+            work_items=[
+                (
+                    work_item_from_issue(issue, source=tracker_kind),
+                    self._issue_attempt(issue=issue, retry_entry=retry_entry),
+                )
+                for issue, retry_entry in selections
+                if str(issue.get("id") or "").strip()
+            ],
+            now_epoch=now_epoch,
+        )
         self.running_issue_id = next(iter(self.running_entries), None)
         self._persist_scheduler_state()
 
     def _clear_running(self, issue_ids: list[str]) -> None:
-        for issue_id in issue_ids:
-            self.running_entries.pop(issue_id, None)
+        self.running_entries = clear_work_entries(self.running_entries, issue_ids)
         self.running_issue_id = next(iter(self.running_entries), None)
 
     def _metrics_from_exception(self, exc: Exception, runtime: Runtime | None = None) -> dict[str, Any]:

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -30,6 +30,7 @@ from engine.lifecycle import (
     recover_running_as_retry,
     schedule_retry_entry,
 )
+from engine.state import load_engine_scheduler_state, save_engine_scheduler_state
 from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
@@ -37,6 +38,7 @@ from engine.work_items import work_item_from_issue
 from runtimes import PromptRunResult, Runtime, build_runtimes
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
+from workflows.shared.paths import runtime_paths
 from workflows.issue_runner.tracker import (
     TrackerClient,
     TrackerConfigError,
@@ -289,6 +291,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
     health_path: Path
     audit_log_path: Path
     scheduler_path: Path
+    db_path: Path
     prompt_template: str
     runtimes: dict[str, Runtime]
     _run: Callable[..., Any]
@@ -491,9 +494,26 @@ class IssueRunnerWorkspace(WorkflowDriver):
         return diagnostics
 
     def _load_scheduler_state(self) -> dict[str, Any]:
-        return _load_optional_json(self.scheduler_path) or {}
+        return load_engine_scheduler_state(
+            self.db_path,
+            workflow="issue-runner",
+            now_iso=_now_iso(),
+            now_epoch=_now_epoch(),
+        )
 
     def _persist_scheduler_state(self) -> None:
+        now_iso = _now_iso()
+        now_epoch = _now_epoch()
+        save_engine_scheduler_state(
+            self.db_path,
+            workflow="issue-runner",
+            retry_entries=self.retry_entries,
+            running_entries=self.running_entries,
+            codex_totals=self.codex_totals,
+            codex_threads=self.codex_threads,
+            now_iso=now_iso,
+            now_epoch=now_epoch,
+        )
         _write_json(
             self.scheduler_path,
             build_scheduler_payload(
@@ -502,8 +522,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 running_entries=self.running_entries,
                 codex_totals=self.codex_totals,
                 codex_threads=self.codex_threads,
-                now_iso=_now_iso(),
-                now_epoch=_now_epoch(),
+                now_iso=now_iso,
+                now_epoch=now_epoch,
             ),
         )
 
@@ -1689,6 +1709,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         self.health_path = _resolve_path(storage_cfg.get("health") or "memory/workflow-health.json", "memory/workflow-health.json")
         self.audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
         self.scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
+        self.db_path = runtime_paths(self.path)["db_path"]
         if not self._supervisor_futures:
             self._close_runtimes()
         self.runtimes = _build_runtimes_from_config(cfg, run=self._run, run_json=self._run_json)
@@ -1743,6 +1764,7 @@ def load_workspace_from_config(
     health_path = _resolve_path(storage_cfg.get("health") or "memory/workflow-health.json", "memory/workflow-health.json")
     audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
     scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
+    db_path = runtime_paths(root)["db_path"]
 
     runner = run or _subprocess_run
     runner_json = run_json or _subprocess_run_json
@@ -1760,6 +1782,7 @@ def load_workspace_from_config(
         health_path=health_path,
         audit_log_path=audit_log_path,
         scheduler_path=scheduler_path,
+        db_path=db_path,
         prompt_template=contract.prompt_template,
         runtimes=runtimes,
         _run=runner,

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ What each abstraction *means* — read these before reading code.
 
 | | |
 |---|---|
+| [Engine](concepts/engine.md) | Shared durable mechanics: tick, service loop, state stores, scheduler, audit, SQLite. |
 | [Lanes](concepts/lanes.md) | The unit of work. State machine, lifecycle, terminal states. |
 | [Leases & heartbeats](concepts/leases.md) | How a single owner stays responsible for a lane. |
 | [Runtimes](concepts/runtimes.md) | The shared execution backends: `claude-cli`, `acpx-codex`, `hermes-agent`, `codex-app-server`. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Entry point for everything that won't fit on the [project landing page](../READM
 
 - Generic docs describe the plugin engine: contracts, state stores, runtimes, trackers, service supervision, and observability.
 - Workflow docs describe lifecycle policy. `issue-runner` is the generic tracker-driven path; `change-delivery` is the opinionated GitHub-backed issue-to-merge path.
-- Operator docs describe installed deployments. SQL examples usually apply to `change-delivery`; `issue-runner` uses persisted status, scheduler, and audit files instead.
+- Operator docs describe installed deployments. SQL examples often focus on `change-delivery`, but shared engine execution state is SQLite-backed for both workflows.
 
 ## Concepts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,8 +39,8 @@
 │                                      │  │  Workflow State Machine              │
 │  Leases (heartbeat · TTL · recovery) │  │  Handoffs (explicit, durable)        │
 │                                      │  │                                      │
-│  Durable State ─► SQLite / JSON       │  │  Semantic Actions                    │
-│                 scheduler files      │  │    select_issue                      │
+│  Durable State ─► SQLite source       │  │  Semantic Actions                    │
+│                 JSON projections     │  │    select_issue                      │
 │                                      │  │    render_prompt                     │
 │  JSONL ───► turn_started ·           │  │    publish_ready_pr                  │
 │             turn_completed · stall   │  │                                      │
@@ -156,14 +156,14 @@ This prevents:
 
 | Layer | Storage | Purpose |
 |---|---|---|
-| **Runtime DB** | `runtime/state/daedalus/daedalus.db` | `change-delivery` leases, lanes, actions, reviews, failures |
-| **Scheduler JSON** | `memory/workflow-scheduler.json` | `issue-runner` workers/retries and Codex thread mappings for both workflows |
+| **Runtime DB** | `runtime/state/daedalus/daedalus.db` | Engine work items, running work, retries, runtime sessions, token totals, plus `change-delivery` lanes/actions/reviews/failures |
+| **Scheduler JSON** | `memory/workflow-scheduler.json` | Generated operator snapshot of scheduler state for file-oriented tooling |
 | **Runtime JSONL** | `runtime/memory/daedalus-events.jsonl` | Daedalus orchestration events |
 | **Workflow JSONL** | `memory/workflow-audit.jsonl` | workflow-specific audit trail |
 | **Lane files** | `.lane-state.json` | `change-delivery` lane-local handoff artifacts |
 | **Lane memos** | `.lane-memo.md` | human-readable handoff notes |
 
-Never reconstruct current state by replaying events. For `change-delivery`, current lane state is in SQLite. For `issue-runner`, current worker state is in the persisted scheduler/status files.
+Never reconstruct current state by replaying events. Current engine execution state is in SQLite; status and scheduler JSON files are projections for operators and file-oriented tools.
 
 ### 4. Bad Edits Don't Crash the Loop
 

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -47,6 +47,7 @@ The beating heart of Daedalus. These concepts explain how the engine keeps work 
 
 | Concept | One-Liner | Read This If... |
 |:---|:---|:---|
+| [**Engine**](./engine.md) | Shared durable mechanics: tick, service loop, state stores, scheduler, audit, SQLite. | ...you want the boundary between Daedalus runtime and workflow packages. |
 | [**Leases**](./leases.md) | The thread Theseus carried into the labyrinth. Heartbeat-based ownership with automatic recovery. | ...you want to understand how Daedalus prevents split-brain and claims dead lanes. |
 | [**Actions**](./actions.md) | The `change-delivery` active/shadow action queue. Queued, idempotent, tracked with composite keys. | ...you want to know how the opinionated workflow guarantees exactly-once execution. |
 | [**Shadow → Active**](./shadow-active.md) | Two execution modes: observe safely, then promote to real side effects. | ...you want to validate Daedalus parity before letting it touch real PRs. |
@@ -160,12 +161,13 @@ GitHub Issue ──► [Lanes] ──► [Leases] claim ownership
 
 **New to Daedalus?** Read in this order:
 
-1. [**Architecture**](../architecture.md) — understand the engine/workflow boundary
-2. [**Leases**](./leases.md) — understand how Daedalus stays alive
-3. [**Runtimes**](./runtimes.md) — understand how turns execute
-4. [**Hot-reload**](./hot-reload.md) — understand how policy changes land
-5. [**Workflow docs**](../workflows/README.md) — choose the bundled workflow that matches your use case
-6. [**Actions**](./actions.md) — read this when operating `change-delivery`
+1. [**Architecture**](../architecture.md) — understand the big picture
+2. [**Engine**](./engine.md) — understand shared durable mechanics
+3. [**Leases**](./leases.md) — understand how Daedalus stays alive
+4. [**Runtimes**](./runtimes.md) — understand how turns execute
+5. [**Hot-reload**](./hot-reload.md) — understand how policy changes land
+6. [**Workflow docs**](../workflows/README.md) — choose the bundled workflow that matches your use case
+7. [**Actions**](./actions.md) — read this when operating `change-delivery`
 
 **Operating Daedalus day-to-day?** Keep these open:
 
@@ -187,6 +189,7 @@ GitHub Issue ──► [Lanes] ──► [Leases] claim ownership
 | Doc | What It Covers |
 |---|---|
 | [Architecture Overview](../architecture.md) | The big picture — how all concepts fit together |
+| [Engine](./engine.md) | The shared runtime mechanisms below workflow packages |
 | [Bundled Workflows](../workflows/README.md) | Workflow-specific docs for `change-delivery` and `issue-runner` |
 | [Operator Cheat Sheet](../operator/cheat-sheet.md) | Day-to-day commands, SQL, debugging |
 | [Slash Commands](../operator/slash-commands.md) | Every `/daedalus` command explained |

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -2,7 +2,7 @@
 
 An **action** is the atomic unit of work `change-delivery` queues, executes, and tracks in SQLite. The workflow package decides *what should happen*; Daedalus decides *how to orchestrate it durably* by translating workflow semantic actions into execution actions.
 
-This page describes the `change-delivery` action queue. `issue-runner` uses a scheduler file with running-worker and retry entries instead of the `lane_actions` table.
+This page describes the `change-delivery` action queue. `issue-runner` uses shared engine running-worker and retry entries instead of the `lane_actions` table.
 
 ---
 

--- a/docs/concepts/engine.md
+++ b/docs/concepts/engine.md
@@ -17,8 +17,8 @@ mechanics that make that decision safe to run unattended.
 | Tracker adapters | Normalize issue sources such as GitHub, `local-json`, and experimental Linear. |
 | Runtime adapters | Dispatch prompts/actions to Codex app-server, ACPX Codex, Claude CLI, Hermes Agent, or custom commands. |
 | Workspace lifecycle | Creates isolated workspaces and runs configured lifecycle hooks. |
-| SQLite store | Durable relational state for lane/action-heavy workflows such as `change-delivery`. |
-| Scheduler JSON | Durable worker, retry, Codex thread, token, and rate-limit state for scheduler-style workflows. |
+| SQLite store | Source of truth for engine execution state: work items, running work, retries, runtime sessions, token totals, and workflow-specific tables. |
+| Scheduler snapshot | Generated JSON view of worker, retry, Codex thread, token, and rate-limit state for operator tools that still consume files. |
 | JSONL audit | Append-only workflow/runtime event history for debugging and external publishing. |
 | Retry and recovery | Tracks attempts, due times, errors, restart recovery, and operator-attention thresholds. |
 | Observability | Feeds `/daedalus status`, `/daedalus doctor`, `/daedalus watch`, and optional HTTP status. |
@@ -36,13 +36,14 @@ the plugin-local `engine` package:
 | `engine.work_items` | Neutral work-item/result dataclasses plus issue/lane adapters. |
 | `engine.lifecycle` | Shared running, retry, clear, and restart-recovery mutation helpers. |
 | `engine.sqlite` | Daedalus SQLite connection setup with WAL, foreign keys, and busy timeout. |
+| `engine.state` | Shared SQLite tables and read/write projections for scheduler state. |
 | `engine.scheduler` | Scheduler snapshot/restore helpers for running work, retry queues, and Codex thread mappings. |
 
 `issue-runner` now consumes the shared scheduler, lifecycle, work-item, and
-storage primitives directly. `change-delivery` consumes shared storage,
-audit, and SQLite primitives, and exposes lanes through the shared work-item
-adapter while its richer lane/action state remains workflow-specific until the
-next extraction.
+SQLite state primitives directly, then writes `memory/workflow-scheduler.json`
+as a generated operator snapshot. `change-delivery` keeps its lane/action
+tables for workflow-specific policy, but shares the engine runtime-session and
+token accounting tables used by watch, status, and doctor surfaces.
 
 ## Boundary
 

--- a/docs/concepts/engine.md
+++ b/docs/concepts/engine.md
@@ -1,0 +1,47 @@
+# Daedalus Engine
+
+The engine is the durable runtime layer shared by workflow packages. A workflow
+decides what an issue means and what should happen next; the engine provides the
+mechanics that make that decision safe to run unattended.
+
+## Engine-Owned Mechanisms
+
+| Mechanism | Purpose |
+|---|---|
+| `tick` | One control-loop pass: load contract, inspect state, derive work, dispatch or reconcile, then persist results. |
+| Service loop | Repeats ticks under `systemd --user` supervision for unattended operation. |
+| Workflow root | Durable instance directory under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`. |
+| Contract loading | Reads repo-owned `WORKFLOW.md` / `WORKFLOW-<name>.md` and preserves last-known-good config. |
+| Preflight | Blocks unsafe dispatch when config, tracker, runtime, or storage wiring is invalid. |
+| Tracker adapters | Normalize issue sources such as GitHub, `local-json`, and experimental Linear. |
+| Runtime adapters | Dispatch prompts/actions to Codex app-server, ACPX Codex, Claude CLI, Hermes Agent, or custom commands. |
+| Workspace lifecycle | Creates isolated workspaces and runs configured lifecycle hooks. |
+| SQLite store | Durable relational state for lane/action-heavy workflows such as `change-delivery`. |
+| Scheduler JSON | Durable worker, retry, Codex thread, token, and rate-limit state for scheduler-style workflows. |
+| JSONL audit | Append-only workflow/runtime event history for debugging and external publishing. |
+| Retry and recovery | Tracks attempts, due times, errors, restart recovery, and operator-attention thresholds. |
+| Observability | Feeds `/daedalus status`, `/daedalus doctor`, `/daedalus watch`, and optional HTTP status. |
+
+## Current Shared Code
+
+The first shared engine package lives in `daedalus/engine/` and is installed as
+the plugin-local `engine` package:
+
+| Module | Shared Primitive |
+|---|---|
+| `engine.storage` | Atomic JSON/text writes, optional JSON reads, JSONL append. |
+| `engine.audit` | JSONL audit writer with best-effort subscriber fanout. |
+| `engine.driver` | Minimal workflow driver protocol for status, doctor, and tick surfaces. |
+| `engine.sqlite` | Daedalus SQLite connection setup with WAL, foreign keys, and busy timeout. |
+| `engine.scheduler` | Scheduler snapshot/restore helpers for running work, retry queues, and Codex thread mappings. |
+
+`issue-runner` now consumes the shared scheduler/storage primitives directly.
+`change-delivery` consumes shared storage/audit/SQLite primitives while its
+richer lane/action state remains workflow-specific until the next extraction.
+
+## Boundary
+
+Engine code should not know whether a workflow is doing a PR review, a merge, a
+simple issue prompt, or a custom automation. It should know how to persist,
+supervise, retry, reconcile, and expose state. Workflow packages keep policy,
+prompts, gates, and lifecycle semantics.

--- a/docs/concepts/engine.md
+++ b/docs/concepts/engine.md
@@ -9,6 +9,7 @@ mechanics that make that decision safe to run unattended.
 | Mechanism | Purpose |
 |---|---|
 | `tick` | One control-loop pass: load contract, inspect state, derive work, dispatch or reconcile, then persist results. |
+| Work items | Tracker-neutral `WorkItemRef` objects that let workflows expose issues/lanes through one engine vocabulary. |
 | Service loop | Repeats ticks under `systemd --user` supervision for unattended operation. |
 | Workflow root | Durable instance directory under `~/.hermes/workflows/<owner>-<repo>-<workflow-type>`. |
 | Contract loading | Reads repo-owned `WORKFLOW.md` / `WORKFLOW-<name>.md` and preserves last-known-good config. |
@@ -32,12 +33,16 @@ the plugin-local `engine` package:
 | `engine.storage` | Atomic JSON/text writes, optional JSON reads, JSONL append. |
 | `engine.audit` | JSONL audit writer with best-effort subscriber fanout. |
 | `engine.driver` | Minimal workflow driver protocol for status, doctor, and tick surfaces. |
+| `engine.work_items` | Neutral work-item/result dataclasses plus issue/lane adapters. |
+| `engine.lifecycle` | Shared running, retry, clear, and restart-recovery mutation helpers. |
 | `engine.sqlite` | Daedalus SQLite connection setup with WAL, foreign keys, and busy timeout. |
 | `engine.scheduler` | Scheduler snapshot/restore helpers for running work, retry queues, and Codex thread mappings. |
 
-`issue-runner` now consumes the shared scheduler/storage primitives directly.
-`change-delivery` consumes shared storage/audit/SQLite primitives while its
-richer lane/action state remains workflow-specific until the next extraction.
+`issue-runner` now consumes the shared scheduler, lifecycle, work-item, and
+storage primitives directly. `change-delivery` consumes shared storage,
+audit, and SQLite primitives, and exposes lanes through the shared work-item
+adapter while its richer lane/action state remains workflow-specific until the
+next extraction.
 
 ## Boundary
 

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -11,8 +11,9 @@ These event streams are consumed by:
 
 State is workflow-specific. **History is in events.** Never reconstruct current state by replaying events.
 
-- `change-delivery` current state is in SQLite: lanes, actions, reviews, failures, and leases.
-- `issue-runner` current state is in persisted JSON: status, health, scheduler, running workers, retry queue, and Codex thread mappings.
+- Shared engine execution state is in SQLite: work items, running workers, retry queue, runtime sessions, and token totals.
+- `change-delivery` adds workflow-specific SQLite state: lanes, actions, reviews, failures, and leases.
+- JSON status/health/scheduler files are projections for operators and file-oriented tools.
 - Runtime events and workflow audit events are for debugging, alerting, tests, and post-hoc archaeology.
 
 ## Anatomy of an event

--- a/docs/concepts/failures.md
+++ b/docs/concepts/failures.md
@@ -2,7 +2,7 @@
 
 Daedalus models failures as **first-class runtime state**, not as log lines to grep later. When an active `change-delivery` action fails, the system persists enough context to decide — automatically or with operator guidance — what happens next.
 
-This page documents the `change-delivery` SQLite action/failure model. `issue-runner` stores retry/backoff state in `memory/workflow-scheduler.json`; see [issue-runner](../workflows/issue-runner.md) for that scheduler model.
+This page documents the `change-delivery` SQLite action/failure model. Shared engine retry/backoff state now lives in SQLite for both workflows; `memory/workflow-scheduler.json` is a generated scheduler snapshot.
 
 ---
 

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -43,7 +43,7 @@ The watch frame is assembled from three sources:
 
 1. **`active_lanes`** — workflow-aware projection of active work
    `change-delivery`: `SELECT * FROM lanes WHERE lane_status NOT IN ('merged', 'closed', 'archived')`
-   `issue-runner`: persisted scheduler `running` + `retry_queue`
+   `issue-runner`: shared engine `running` + `retry_queue`
 2. **`alert_state`** — parsed from `daedalus/alerts.py` output
 3. **`recent_events`** — tail of the workflow audit/event log (last 20, reverse-chunked seek)
 
@@ -72,7 +72,7 @@ See [http-status.md](http-status.md) for full endpoint documentation. Summary:
 ### Security
 
 - **Localhost only** (`127.0.0.1`). No auth — port access is the auth.
-- **Read-only state** (`mode=ro` SQLite URI for `change-delivery`, persisted JSON/JSONL state for `issue-runner`).
+- **Read-only state** (SQLite source state plus JSON/JSONL projections).
 - **Refresh is rate-limited by OS** (subprocess fork).
 
 ---

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -63,10 +63,9 @@
 |:---|:---|:---|
 | [**Cheat Sheet**](./cheat-sheet.md) | Quick-reference commands, SQL queries for direct DB inspection, common failure patterns, and recovery procedures for the managed `change-delivery` workflow. | ...you need to debug a stuck lane, find a failed action, or verify lease health. |
 
-SQL examples are `change-delivery`-specific because that workflow stores lanes,
-actions, reviews, and failures in SQLite. `issue-runner` stores current worker
-state in `memory/workflow-status.json`, `memory/workflow-health.json`, and
-`memory/workflow-scheduler.json`.
+SQL examples focus on `change-delivery` lanes/actions, but shared engine
+execution state for both workflows also lives in SQLite. The JSON files under
+`memory/` are status, health, audit, and scheduler projections.
 
 **The narrative arc:** *Observe symptoms* → *Query state* → *Identify root cause* → *Apply fix* → *Verify recovery*.
 

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -136,7 +136,7 @@ systemctl --user restart \
 | `~/.hermes/workflows/<profile>/runtime/memory/daedalus-events.jsonl` | Daedalus runtime event history |
 | `~/.hermes/workflows/<profile>/memory/workflow-status.json` | Workflow status projection |
 | `~/.hermes/workflows/<profile>/memory/workflow-health.json` | Workflow health projection |
-| `~/.hermes/workflows/<profile>/memory/workflow-scheduler.json` | Scheduler state, Codex thread mappings, token/rate-limit totals |
+| `~/.hermes/workflows/<profile>/memory/workflow-scheduler.json` | Generated scheduler snapshot; SQLite remains the source of truth |
 | `/tmp/issue-<N>/.lane-state.json` | Lane-local handoff state |
 | `/tmp/issue-<N>/.lane-memo.md` | Lane-local handoff notes |
 | `~/.config/systemd/user/daedalus-active@<profile>.service` | Service unit file |

--- a/docs/operator/codex-app-server.md
+++ b/docs/operator/codex-app-server.md
@@ -50,15 +50,15 @@ configured token/shared-secret file is missing.
 
 ## Thread Mapping Checks
 
-Daedalus persists Codex thread mappings in the workflow scheduler state:
+Daedalus persists Codex thread mappings in the shared engine SQLite state:
 `issue-runner` stores `issue_id -> thread_id`, and `change-delivery` stores
-`lane:<issue-number> -> thread_id`. The default scheduler path is:
+`lane:<issue-number> -> thread_id`. The generated scheduler snapshot is:
 
 ```text
 <workflow-root>/memory/workflow-scheduler.json
 ```
 
-`doctor --json` surfaces those mappings with issue id, identifier, session
+`doctor --json` surfaces the SQLite mappings with issue id, identifier, session
 name, thread id, turn id, status, cancellation state, and update time. Missing
 thread ids are treated as broken state because future ticks cannot resume the
 right Codex thread.

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -29,10 +29,9 @@ python3 -m workflows.issue_runner serve --workflow-root <root>
 ```
 
 The server is `http.server.ThreadingHTTPServer`, stdlib-only, and reads the
-workflow state read-only. `change-delivery` serves from SQLite + JSONL events;
-`issue-runner` serves from its persisted status, scheduler, and audit files.
-It never writes workflow state itself — `POST /api/v1/refresh` shells out a
-tick subprocess instead.
+workflow state read-only. Both workflows serve engine execution state from
+SQLite plus JSONL/status projections. It never writes workflow state itself —
+`POST /api/v1/refresh` shells out a tick subprocess instead.
 
 ## Endpoints
 
@@ -60,10 +59,10 @@ Conforms to Symphony §13.7 / Daedalus spec §6.4:
 ```
 
 Both bundled workflows report aggregate Codex token totals and latest
-rate-limit data from scheduler state when their active runtime is
+rate-limit data from shared engine state when their active runtime is
 `codex-app-server`. `change-delivery` still derives running lane rows from its
-SQLite lane model; `issue-runner` derives running and retrying rows directly
-from its scheduler file. `change-delivery` also includes `codex_turns` so
+SQLite lane model; `issue-runner` derives running and retrying rows from the
+shared engine tables. `change-delivery` also includes `codex_turns` so
 operators can inspect active or canceling Codex `thread_id` / `turn_id` pairs.
 
 ### `GET /api/v1/<identifier>`
@@ -79,13 +78,12 @@ Shells out the workflow's CLI entry point (resolved via `workflow_cli_argv()` so
 ## Security posture
 
 - **Localhost only.** The server binds `127.0.0.1`. There is no auth — getting access to the port is the auth.
-- **Read-only state.** `change-delivery` uses `mode=ro` SQLite URIs; `issue-runner` reads persisted JSON/JSONL state files. The server itself never becomes a state writer.
+- **Read-only state.** The server reads SQLite and JSON/JSONL projections; it never becomes a state writer.
 - **Refresh is rate-limited at the OS level** by virtue of being a subprocess fork — no separate counter.
 
 ## Performance notes
 
-- `change-delivery` requests open a fresh sqlite connection (cheap, avoids cross-thread state hazards).
-- `issue-runner` requests read the current status/scheduler snapshots from disk, so reads remain bounded and restart-safe.
+- Requests open fresh SQLite connections (cheap, avoids cross-thread state hazards) and read bounded JSON/JSONL projections.
 - The events tail uses an 8 KiB reverse-chunked seek so cost is bounded by `limit` regardless of total log size — the previous `readlines()` implementation was O(file size) and got expensive on long-lived logs.
 
 ## Where this lives in code

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -70,8 +70,9 @@ agents:
 
 When `codex-app-server` is selected, Daedalus stores
 `lane:<issue-number> -> thread_id` plus token/rate-limit totals in
-`memory/workflow-scheduler.json` and resumes that thread on later ticks. During
-supervised active service runs, Daedalus also records the active `turn_id`.
+`runtime/state/daedalus/daedalus.db`, writes `memory/workflow-scheduler.json`
+as a generated operator snapshot, and resumes that thread on later ticks.
+During supervised active service runs, Daedalus also records the active `turn_id`.
 If the active lane disappears, changes, the lease is lost, or the service is
 interrupted, the runtime requests `turn/interrupt` and marks the scheduler
 thread entry as `canceling`. Operators can see those entries in `/daedalus

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -85,14 +85,14 @@ before returning. `run` is the service path: it dispatches eligible workers,
 returns to the polling loop, reconciles completed workers on later iterations,
 and requests cancellation when a running issue enters a terminal tracker state.
 
-Scheduler state is persisted under `storage.scheduler` (default:
-`memory/workflow-scheduler.json`) so continuation retries, failure backoff,
-running-worker recovery, aggregate Codex token totals, and Codex
-`issue_id -> thread_id` mappings survive loop restarts. When a mapped thread
-exists, the Codex app-server adapter resumes it with `thread/resume` before
-starting the next turn. `status` also includes runtime diagnostics when the
-selected runtime exposes them, including Codex app-server transport mode and
-warm-client state.
+Scheduler state is persisted in `runtime/state/daedalus/daedalus.db` so
+continuation retries, failure backoff, running-worker recovery, aggregate Codex
+token totals, and Codex `issue_id -> thread_id` mappings survive loop restarts.
+Daedalus also writes `storage.scheduler` (default:
+`memory/workflow-scheduler.json`) as a generated operator snapshot. When a
+mapped thread exists, the Codex app-server adapter resumes it with
+`thread/resume` before starting the next turn. `status` also includes runtime
+diagnostics when the selected runtime exposes them.
 
 ## Operator path
 
@@ -142,9 +142,8 @@ For direct workflow operations:
 resolution when `tracker.kind: github`.
 
 If `server.port` is set in the repo-owned contract, `serve` exposes the same
-localhost JSON + HTML status surface used by `change-delivery`, but backed by
-the `issue-runner` scheduler/status/audit files instead of the lane SQLite
-tables.
+localhost JSON + HTML status surface used by `change-delivery`, backed by
+shared engine SQLite state plus the `issue-runner` status/audit projections.
 
 ## Current limitation
 

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,16 @@
+"""Repo-root engine wrapper package for local development."""
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
+if _PLUGIN_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT_STR)
+
+_REAL_ENGINE_DIR = _PLUGIN_ROOT / "daedalus" / "engine"
+_real_dir_str = str(_REAL_ENGINE_DIR)
+if _real_dir_str not in __path__:
+    __path__.append(_real_dir_str)
+
+from daedalus.engine import *  # noqa: F401,F403

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -20,6 +20,7 @@ PAYLOAD_ITEMS = [
     "observability_overrides.py",
     "plugin.yaml",
     "runtime.py",
+    "engine",
     "runtimes",
     "schemas.py",
     "trackers",

--- a/tests/test_daedalus_watch_render.py
+++ b/tests/test_daedalus_watch_render.py
@@ -178,7 +178,9 @@ def test_build_snapshot_combines_all_sources(tmp_path):
 
 
 def test_build_snapshot_includes_issue_runner_workflow_status(tmp_path):
+    from engine.state import save_engine_scheduler_state
     from workflows.contract import render_workflow_markdown
+    from workflows.shared.paths import runtime_paths
 
     watch = _module()
     root = _make_workflow_root(tmp_path)
@@ -207,14 +209,15 @@ def test_build_snapshot_includes_issue_runner_workflow_status(tmp_path):
     (root / "memory" / "workflow-status.json").write_text(
         json.dumps({"workflow": "issue-runner", "health": "healthy", "lastRun": {"updatedAt": "2026-04-30T12:00:15Z"}})
     )
-    (root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "running": [{"issue_id": "123", "identifier": "#123", "state": "open"}],
-                "retry_queue": [],
-                "codex_totals": {"total_tokens": 18},
-            }
-        )
+    save_engine_scheduler_state(
+        runtime_paths(root)["db_path"],
+        workflow="issue-runner",
+        running_entries={"123": {"issue_id": "123", "identifier": "#123", "state": "open"}},
+        retry_entries={},
+        codex_totals={"total_tokens": 18},
+        codex_threads={},
+        now_iso="2026-04-30T12:00:20Z",
+        now_epoch=1714478420.0,
     )
 
     snap = watch.build_snapshot(root)

--- a/tests/test_daedalus_watch_sources.py
+++ b/tests/test_daedalus_watch_sources.py
@@ -121,6 +121,7 @@ def test_read_alert_state_when_present(tmp_path):
 
 
 def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
+    from engine.state import save_engine_scheduler_state
     from workflows.contract import render_workflow_markdown
 
     sources = _module()
@@ -150,14 +151,15 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     (root / "memory" / "workflow-status.json").write_text(
         json.dumps({"workflow": "issue-runner", "health": "healthy", "lastRun": {"updatedAt": "2026-04-30T12:00:15Z"}})
     )
-    (root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "running": [{"issue_id": "123", "identifier": "#123", "state": "open"}],
-                "retry_queue": [{"issue_id": "124", "identifier": "#124", "error": "x"}],
-                "codex_totals": {"total_tokens": 18, "rate_limits": {"requests_remaining": 88}},
-            }
-        )
+    save_engine_scheduler_state(
+        root / "runtime" / "state" / "daedalus" / "daedalus.db",
+        workflow="issue-runner",
+        running_entries={"123": {"issue_id": "123", "identifier": "#123", "state": "open"}},
+        retry_entries={"124": {"issue_id": "124", "identifier": "#124", "error": "x", "due_at_epoch": 1714478410.0}},
+        codex_totals={"total_tokens": 18, "rate_limits": {"requests_remaining": 88}},
+        codex_threads={},
+        now_iso="2026-04-30T12:00:20Z",
+        now_epoch=1714478400.0,
     )
     (root / "memory" / "workflow-audit.jsonl").write_text(
         json.dumps({"at": "2026-04-30T12:00:20Z", "event": "issue_runner.tick.completed", "issue_id": "123"}) + "\n"
@@ -178,6 +180,7 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
 
 
 def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
+    from engine.state import save_engine_scheduler_state
     from workflows.contract import render_workflow_markdown
 
     sources = _module()
@@ -200,26 +203,26 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
         encoding="utf-8",
     )
     (root / "memory").mkdir(exist_ok=True)
-    (root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "workflow": "change-delivery",
-                "updatedAt": "2026-04-30T12:00:20Z",
-                "codex_threads": {
-                    "lane:42": {
-                        "issue_id": "lane:42",
-                        "issue_number": 42,
-                        "identifier": "#42",
-                        "thread_id": "thread-42",
-                        "turn_id": "turn-42",
-                        "status": "canceling",
-                        "cancel_requested": True,
-                        "cancel_reason": "operator-interrupt",
-                    }
-                },
-                "codex_totals": {"total_tokens": 18},
+    save_engine_scheduler_state(
+        root / "runtime" / "state" / "daedalus" / "daedalus.db",
+        workflow="change-delivery",
+        running_entries={},
+        retry_entries={},
+        codex_totals={"total_tokens": 18},
+        codex_threads={
+            "lane:42": {
+                "issue_id": "lane:42",
+                "issue_number": 42,
+                "identifier": "#42",
+                "thread_id": "thread-42",
+                "turn_id": "turn-42",
+                "status": "canceling",
+                "cancel_requested": True,
+                "cancel_reason": "operator-interrupt",
             }
-        )
+        },
+        now_iso="2026-04-30T12:00:20Z",
+        now_epoch=1714478420.0,
     )
 
     workflow_status = sources.workflow_status(root)

--- a/tests/test_daedalus_watch_sources.py
+++ b/tests/test_daedalus_watch_sources.py
@@ -79,6 +79,9 @@ def test_read_active_lanes_from_db(tmp_path):
     assert lanes[0]["issue_number"] == 329
     assert lanes[0]["github_issue_number"] == 329          # consumer-facing alias
     assert lanes[0]["lane_status"] == "active"
+    assert lanes[0]["work_item"]["id"] == "lane-329"
+    assert lanes[0]["work_item"]["identifier"] == "#329"
+    assert lanes[0]["work_item"]["source"] == "change-delivery"
 
 
 def test_active_lanes_returns_empty_when_query_fails():
@@ -165,6 +168,8 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     workflow_status = sources.workflow_status(root)
 
     assert [lane["issue_identifier"] for lane in lanes] == ["#123", "#124"]
+    assert [lane["work_item"]["id"] for lane in lanes] == ["123", "124"]
+    assert all(lane["work_item"]["source"] == "issue-runner" for lane in lanes)
     assert audit[0]["event"] == "issue_runner.tick.completed"
     assert workflow_status["workflow"] == "issue-runner"
     assert workflow_status["running_count"] == 1

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -76,6 +76,58 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
     assert payload["codex_threads"]["42"]["thread_id"] == "thread-1"
 
 
+def test_engine_work_items_and_lifecycle_helpers():
+    from engine.lifecycle import clear_work_entries, mark_running_work, recover_running_as_retry, schedule_retry_entry
+    from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
+
+    issue_work = work_item_from_issue(
+        {
+            "id": "ISSUE-1",
+            "identifier": "ISSUE-1",
+            "state": "todo",
+            "title": "Implement it",
+            "url": "https://tracker.example/ISSUE-1",
+        },
+        source="local-json",
+    )
+    assert issue_work.to_dict()["source"] == "local-json"
+
+    running = mark_running_work({}, work_items=[(issue_work, 2)], now_epoch=100.0)
+    assert running["ISSUE-1"]["worker_id"] == "worker:ISSUE-1:100000"
+    assert running["ISSUE-1"]["attempt"] == 2
+    assert clear_work_entries(running, ["ISSUE-1"]) == {}
+
+    retry, summary = schedule_retry_entry(
+        work_item=issue_work,
+        existing_entry=None,
+        error="temporary failure",
+        current_attempt=2,
+        delay_type="failure",
+        max_backoff_ms=300000,
+        now_epoch=100.0,
+    )
+    assert retry["due_at_epoch"] == 110.0
+    assert summary["retry_attempt"] == 1
+    assert summary["delay_ms"] == 10000
+
+    recovered = recover_running_as_retry({}, [running["ISSUE-1"]], now_epoch=200.0)
+    assert recovered["ISSUE-1"]["error"] == "scheduler restarted while issue was running"
+    assert recovered["ISSUE-1"]["due_at_epoch"] == 200.0
+
+    lane_work = work_item_from_change_delivery_lane(
+        {
+            "lane_id": "lane-42",
+            "issue_number": 42,
+            "workflow_state": "under_review",
+            "lane_status": "active",
+        }
+    )
+    assert lane_work.id == "lane-42"
+    assert lane_work.identifier == "#42"
+    assert lane_work.source == "change-delivery"
+    assert lane_work.metadata["lane_status"] == "active"
+
+
 def test_engine_audit_writer_fans_out_best_effort(tmp_path):
     from engine.audit import make_audit_fn
 

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -1,0 +1,123 @@
+import json
+import sqlite3
+
+
+def test_engine_storage_writes_json_and_jsonl(tmp_path):
+    from engine.storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
+
+    payload_path = tmp_path / "state" / "payload.json"
+    write_json_atomic(payload_path, {"b": 2, "a": 1})
+
+    assert payload_path.read_text(encoding="utf-8") == '{\n  "a": 1,\n  "b": 2\n}\n'
+    assert load_optional_json(payload_path) == {"a": 1, "b": 2}
+
+    list_path = tmp_path / "state" / "list.json"
+    list_path.write_text("[]", encoding="utf-8")
+    assert load_optional_json(list_path) is None
+
+    text_path = tmp_path / "state" / "note.txt"
+    write_text_atomic(text_path, "hello")
+    assert text_path.read_text(encoding="utf-8") == "hello"
+
+    log_path = tmp_path / "audit" / "events.jsonl"
+    append_jsonl(log_path, {"event": "b", "at": "now"})
+    assert json.loads(log_path.read_text(encoding="utf-8")) == {"at": "now", "event": "b"}
+
+
+def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
+    from engine.scheduler import build_scheduler_payload, restore_scheduler_state, retry_due_at
+
+    restored = restore_scheduler_state(
+        {
+            "retryQueue": [
+                {
+                    "issueId": "42",
+                    "identifier": "#42",
+                    "attempt": 2,
+                    "dueAtEpoch": 125.0,
+                    "currentAttempt": 1,
+                }
+            ],
+            "running": [
+                {
+                    "issueId": "43",
+                    "workerId": "worker:43",
+                    "startedAtEpoch": 100.0,
+                    "heartbeatAtEpoch": 110.0,
+                    "cancelRequested": True,
+                }
+            ],
+            "codexTotals": {"total_tokens": 5},
+            "codex_threads": {"42": {"thread_id": "thread-1", "turn_id": "turn-1"}},
+        },
+        now_epoch=200.0,
+    )
+
+    assert restored.retry_entries["42"]["due_at_epoch"] == 125.0
+    assert restored.recovered_running[0]["issue_id"] == "43"
+    assert restored.recovered_running[0]["cancel_requested"] is True
+    assert restored.codex_totals == {"total_tokens": 5}
+    assert restored.codex_threads["42"]["thread_id"] == "thread-1"
+    assert retry_due_at(restored.retry_entries["42"], default=999.0) == 125.0
+
+    payload = build_scheduler_payload(
+        workflow="issue-runner",
+        retry_entries=restored.retry_entries,
+        running_entries={"43": restored.recovered_running[0]},
+        codex_totals=restored.codex_totals,
+        codex_threads=restored.codex_threads,
+        now_iso="2026-04-30T00:00:00Z",
+        now_epoch=200.0,
+    )
+
+    assert payload["workflow"] == "issue-runner"
+    assert payload["retry_queue"][0]["due_in_ms"] == 0
+    assert payload["running"][0]["running_for_ms"] == 100000
+    assert payload["codex_threads"]["42"]["thread_id"] == "thread-1"
+
+
+def test_engine_audit_writer_fans_out_best_effort(tmp_path):
+    from engine.audit import make_audit_fn
+
+    calls = []
+
+    def publisher(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("subscriber failed")
+
+    audit = make_audit_fn(
+        audit_log_path=tmp_path / "audit.jsonl",
+        now_iso=lambda: "2026-04-30T00:00:00Z",
+        publisher=publisher,
+    )
+
+    audit("tick", "ran one tick", issue_id="42")
+
+    row = json.loads((tmp_path / "audit.jsonl").read_text(encoding="utf-8"))
+    assert row == {
+        "action": "tick",
+        "at": "2026-04-30T00:00:00Z",
+        "issue_id": "42",
+        "summary": "ran one tick",
+    }
+    assert calls == [{"action": "tick", "summary": "ran one tick", "extra": {"issue_id": "42"}}]
+
+
+def test_engine_sqlite_connection_sets_runtime_pragmas(tmp_path):
+    from engine.sqlite import connect_daedalus_db
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    conn = connect_daedalus_db(db_path)
+    try:
+        assert db_path.exists()
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    finally:
+        conn.close()
+
+    reopened = sqlite3.connect(db_path)
+    try:
+        assert reopened.execute("SELECT 1").fetchone()[0] == 1
+    finally:
+        reopened.close()

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -173,3 +173,68 @@ def test_engine_sqlite_connection_sets_runtime_pragmas(tmp_path):
         assert reopened.execute("SELECT 1").fetchone()[0] == 1
     finally:
         reopened.close()
+
+
+def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
+    from engine.state import load_engine_scheduler_state, read_engine_scheduler_state, save_engine_scheduler_state
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    save_engine_scheduler_state(
+        db_path,
+        workflow="issue-runner",
+        running_entries={
+            "ISSUE-1": {
+                "issue_id": "ISSUE-1",
+                "identifier": "DAE-1",
+                "state": "open",
+                "worker_id": "worker-1",
+                "attempt": 2,
+                "started_at_epoch": 100.0,
+                "heartbeat_at_epoch": 110.0,
+            }
+        },
+        retry_entries={
+            "ISSUE-2": {
+                "issue_id": "ISSUE-2",
+                "identifier": "DAE-2",
+                "attempt": 1,
+                "due_at_epoch": 130.0,
+                "error": "temporary failure",
+            }
+        },
+        codex_threads={
+            "ISSUE-1": {
+                "issue_id": "ISSUE-1",
+                "identifier": "DAE-1",
+                "session_name": "issue-1",
+                "runtime_kind": "codex-app-server",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "updated_at": "2026-04-30T00:00:00Z",
+            }
+        },
+        codex_totals={"input_tokens": 3, "output_tokens": 4, "total_tokens": 7, "turn_count": 1},
+        now_iso="2026-04-30T00:00:00Z",
+        now_epoch=120.0,
+    )
+
+    loaded = load_engine_scheduler_state(
+        db_path,
+        workflow="issue-runner",
+        now_iso="2026-04-30T00:00:10Z",
+        now_epoch=125.0,
+    )
+    readonly = read_engine_scheduler_state(
+        db_path,
+        workflow="issue-runner",
+        now_iso="2026-04-30T00:00:10Z",
+        now_epoch=125.0,
+    )
+
+    assert loaded["running"][0]["issue_id"] == "ISSUE-1"
+    assert loaded["running"][0]["running_for_ms"] == 25000
+    assert loaded["retry_queue"][0]["issue_id"] == "ISSUE-2"
+    assert loaded["retry_queue"][0]["due_in_ms"] == 5000
+    assert loaded["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert loaded["codex_totals"]["total_tokens"] == 7
+    assert readonly == loaded

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -23,6 +23,7 @@ def test_install_into_default_hermes_home_copies_plugin_tree(tmp_path):
     plugin_dir = hermes_home / "plugins" / "daedalus"
     assert result == plugin_dir
     assert (plugin_dir / "plugin.yaml").exists()
+    assert (plugin_dir / "engine" / "__init__.py").exists()
     assert (plugin_dir / "runtimes" / "__init__.py").exists()
     assert (plugin_dir / "runtime.py").exists()
     assert (plugin_dir / "alerts.py").exists()
@@ -43,6 +44,7 @@ def test_install_into_explicit_destination_uses_given_path(tmp_path):
     result = install.install_plugin(repo_root=repo_root, destination=target)
 
     assert result == target
+    assert (target / "engine" / "scheduler.py").exists()
     assert (target / "runtimes" / "codex_app_server.py").exists()
     assert (target / "plugin.yaml").exists()
     assert (target / "trackers" / "linear.py").exists()

--- a/tests/test_official_plugin_layout.py
+++ b/tests/test_official_plugin_layout.py
@@ -21,6 +21,7 @@ def test_repo_root_exposes_official_hermes_plugin_layout():
     expected = [
         REPO_ROOT / "plugin.yaml",
         REPO_ROOT / "__init__.py",
+        REPO_ROOT / "engine" / "__init__.py",
         REPO_ROOT / "runtimes" / "__init__.py",
         REPO_ROOT / "schemas.py",
         REPO_ROOT / "daedalus_cli.py",
@@ -132,6 +133,21 @@ def test_repo_root_runtimes_wrapper_exposes_shared_runtime_modules():
     assert runtimes_pkg.__file__ is not None
     assert codex.__file__ is not None
     assert "daedalus/runtimes/codex_app_server" in codex.__file__
+
+
+def test_repo_root_engine_wrapper_exposes_shared_engine_modules():
+    for module_name in list(sys.modules):
+        if module_name == "engine" or module_name.startswith("engine."):
+            del sys.modules[module_name]
+
+    import importlib
+
+    engine_pkg = importlib.import_module("engine")
+    scheduler = importlib.import_module("engine.scheduler")
+
+    assert engine_pkg.__file__ is not None
+    assert scheduler.__file__ is not None
+    assert "daedalus/engine/scheduler" in scheduler.__file__
 
 
 def test_repo_root_trackers_wrapper_exposes_shared_tracker_modules():

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -108,7 +108,9 @@ def _make_events_log(events_path: Path, entries: list[dict]) -> None:
 
 
 def _make_issue_runner_root(root: Path) -> None:
+    from engine.state import save_engine_scheduler_state
     from workflows.contract import render_workflow_markdown
+    from workflows.shared.paths import runtime_paths
 
     root.mkdir(parents=True, exist_ok=True)
     (root / "memory").mkdir()
@@ -153,40 +155,37 @@ def _make_issue_runner_root(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    (root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "workflow": "issue-runner",
-                "updatedAt": "2026-04-30T12:00:20Z",
-                "running": [
-                    {
-                        "issue_id": "123",
-                        "identifier": "#123",
-                        "attempt": 2,
-                        "state": "open",
-                        "started_at_epoch": 1714478400.0,
-                        "running_for_ms": 15000,
-                    }
-                ],
-                "retry_queue": [
-                    {
-                        "issue_id": "124",
-                        "identifier": "#124",
-                        "attempt": 1,
-                        "error": "tool call rejected",
-                        "due_at_epoch": 1714478410.0,
-                        "due_in_ms": 5000,
-                    }
-                ],
-                "codex_totals": {
-                    "input_tokens": 11,
-                    "output_tokens": 7,
-                    "total_tokens": 18,
-                    "rate_limits": {"requests_remaining": 88},
-                },
+    save_engine_scheduler_state(
+        runtime_paths(root)["db_path"],
+        workflow="issue-runner",
+        running_entries={
+            "123": {
+                "issue_id": "123",
+                "identifier": "#123",
+                "attempt": 2,
+                "state": "open",
+                "started_at_epoch": 1714478400.0,
+                "heartbeat_at_epoch": 1714478415.0,
             }
-        ),
-        encoding="utf-8",
+        },
+        retry_entries={
+            "124": {
+                "issue_id": "124",
+                "identifier": "#124",
+                "attempt": 1,
+                "error": "tool call rejected",
+                "due_at_epoch": 1714478410.0,
+            }
+        },
+        codex_totals={
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "rate_limits": {"requests_remaining": 88},
+        },
+        codex_threads={},
+        now_iso="2026-04-30T12:00:20Z",
+        now_epoch=1714478415.0,
     )
     _make_events_log(
         root / "memory" / "workflow-audit.jsonl",
@@ -198,7 +197,9 @@ def _make_issue_runner_root(root: Path) -> None:
 
 
 def _make_change_delivery_root(root: Path) -> None:
+    from engine.state import save_engine_scheduler_state
     from workflows.contract import render_workflow_markdown
+    from workflows.shared.paths import runtime_paths
 
     root.mkdir(parents=True, exist_ok=True)
     (root / "memory").mkdir()
@@ -231,35 +232,34 @@ def _make_change_delivery_root(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    (root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "workflow": "change-delivery",
-                "updatedAt": "2026-04-30T12:00:20Z",
-                "codex_threads": {
-                    "lane:42": {
-                        "issue_id": "lane:42",
-                        "issue_number": 42,
-                        "identifier": "#42",
-                        "runtime_name": "coder-runtime",
-                        "runtime_kind": "codex-app-server",
-                        "thread_id": "thread-42",
-                        "turn_id": "turn-42",
-                        "status": "canceling",
-                        "cancel_requested": True,
-                        "cancel_reason": "operator-interrupt",
-                        "updated_at": "2026-04-30T12:00:20Z",
-                    }
-                },
-                "codex_totals": {
-                    "input_tokens": 11,
-                    "output_tokens": 7,
-                    "total_tokens": 18,
-                    "rate_limits": {"requests_remaining": 88},
-                },
+    save_engine_scheduler_state(
+        runtime_paths(root)["db_path"],
+        workflow="change-delivery",
+        running_entries={},
+        retry_entries={},
+        codex_threads={
+            "lane:42": {
+                "issue_id": "lane:42",
+                "issue_number": 42,
+                "identifier": "#42",
+                "runtime_name": "coder-runtime",
+                "runtime_kind": "codex-app-server",
+                "thread_id": "thread-42",
+                "turn_id": "turn-42",
+                "status": "canceling",
+                "cancel_requested": True,
+                "cancel_reason": "operator-interrupt",
+                "updated_at": "2026-04-30T12:00:20Z",
             }
-        ),
-        encoding="utf-8",
+        },
+        codex_totals={
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "rate_limits": {"requests_remaining": 88},
+        },
+        now_iso="2026-04-30T12:00:20Z",
+        now_epoch=1714478420.0,
     )
 
 

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -180,30 +180,34 @@ def test_codex_app_server_status_includes_ready_probe(tmp_path, monkeypatch):
 
 
 def test_codex_app_server_doctor_reports_managed_health_and_threads(tmp_path, monkeypatch):
+    from engine.state import save_engine_scheduler_state
+    from workflows.shared.paths import runtime_paths
+
     tools = load_tools()
     systemd_dir = tmp_path / "systemd"
     monkeypatch.setenv("DAEDALUS_SYSTEMD_USER_DIR", str(systemd_dir))
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     workflow_root.mkdir()
     (workflow_root / "memory").mkdir()
-    (workflow_root / "memory" / "workflow-scheduler.json").write_text(
-        json.dumps(
-            {
-                "codex_threads": {
-                    "ISSUE-1": {
-                        "issue_id": "ISSUE-1",
-                        "identifier": "DAE-1",
-                        "session_name": "issue-1",
-                        "runtime_kind": "codex-app-server",
-                        "thread_id": "thread-1",
-                        "turn_id": "turn-1",
-                        "updated_at": "2026-04-30T00:00:00Z",
-                    }
-                },
-                "codex_totals": {"total_tokens": 42, "turn_count": 1},
+    save_engine_scheduler_state(
+        runtime_paths(workflow_root)["db_path"],
+        workflow="issue-runner",
+        running_entries={},
+        retry_entries={},
+        codex_threads={
+            "ISSUE-1": {
+                "issue_id": "ISSUE-1",
+                "identifier": "DAE-1",
+                "session_name": "issue-1",
+                "runtime_kind": "codex-app-server",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "updated_at": "2026-04-30T00:00:00Z",
             }
-        ),
-        encoding="utf-8",
+        },
+        codex_totals={"total_tokens": 42, "turn_count": 1},
+        now_iso="2026-04-30T00:00:00Z",
+        now_epoch=1777507200.0,
     )
     token_file = tmp_path / "codex.token"
     token_file.write_text("secret", encoding="utf-8")

--- a/tests/test_workflows_change_delivery_work_items.py
+++ b/tests/test_workflows_change_delivery_work_items.py
@@ -1,0 +1,22 @@
+def test_change_delivery_lane_to_work_item_ref():
+    from workflows.change_delivery.work_items import lane_to_work_item_ref
+
+    work_item = lane_to_work_item_ref(
+        {
+            "lane_id": "lane-329",
+            "issue_number": 329,
+            "issue_title": "Ship the change",
+            "issue_url": "https://github.example/issues/329",
+            "workflow_state": "awaiting_review",
+            "lane_status": "active",
+            "active_actor_id": "actor-1",
+            "current_action_id": "action-1",
+        }
+    )
+
+    assert work_item.id == "lane-329"
+    assert work_item.identifier == "#329"
+    assert work_item.title == "Ship the change"
+    assert work_item.state == "awaiting_review"
+    assert work_item.source == "change-delivery"
+    assert work_item.metadata["active_actor_id"] == "actor-1"


### PR DESCRIPTION
## Summary

This PR extracts Daedalus engine mechanics into shared primitives used by both bundled workflows.

- Adds shared engine modules for durable storage, audit fanout, SQLite setup, scheduler snapshots, work-item references, lifecycle mutation helpers, and SQLite-backed engine state.
- Wires `issue-runner` through the shared lifecycle and SQLite scheduler/runtime state while keeping `memory/workflow-scheduler.json` as a generated operator snapshot.
- Wires `change-delivery` Codex thread mappings and token/rate-limit totals into the same shared engine state.
- Updates `/daedalus watch`, HTTP status views, Codex app-server doctor, and docs to treat SQLite as the execution-state source of truth.

## Impact

Workflow packages keep policy, prompts, and domain state. The engine now owns neutral execution state: work items, running work, retries, runtime sessions, token totals, and projections for operator tools.

## Validation

- `pytest -q` -> `838 passed, 8 skipped`
