### PR TITLE
[codex] Add engine store and shared leases

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import yaml
 
 from engine.state import read_engine_scheduler_state
+from engine.store import EngineStore
 from workflows.contract import (
     WorkflowContractError,
     find_repo_workflow_contract_path,
@@ -1570,70 +1571,26 @@ def build_shadow_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
         owner_summary["service_healthy"] = None
 
     paths = daedalus._runtime_paths(workflow_root)
+    engine_store = EngineStore(
+        db_path=paths["db_path"],
+        workflow="change-delivery",
+        now_iso=lambda: now_iso,
+        now_epoch=lambda: float(now_epoch or time.time()),
+    )
+    lease_info = engine_store.lease_status(
+        lease_scope=daedalus.RUNTIME_LEASE_SCOPE,
+        lease_key=daedalus.RUNTIME_LEASE_KEY,
+        heartbeat_at=runtime_status.get("latest_heartbeat_at"),
+        active_owner_instance_id=runtime_status.get("active_orchestrator_instance_id"),
+    )
+    if lease_info.get("stale"):
+        warnings.append(
+            "stale runtime heartbeat/lease: " + ", ".join(lease_info.get("stale_reasons") or [])
+        )
+
     conn = sqlite3.connect(paths["db_path"])
     conn.row_factory = sqlite3.Row
     try:
-        lease_row = conn.execute(
-            """
-            SELECT lease_scope, lease_key, owner_instance_id, owner_role, acquired_at, expires_at, released_at, release_reason
-            FROM leases
-            WHERE lease_scope=? AND lease_key=?
-            """,
-            (daedalus.RUNTIME_LEASE_SCOPE, daedalus.RUNTIME_LEASE_KEY),
-        ).fetchone()
-        if lease_row:
-            lease = dict(lease_row)
-            expires_epoch = daedalus._iso_to_epoch(lease.get("expires_at"))
-            heartbeat_epoch = daedalus._iso_to_epoch(runtime_status.get("latest_heartbeat_at"))
-            heartbeat_age_seconds = (
-                max(0, now_epoch - heartbeat_epoch)
-                if now_epoch is not None and heartbeat_epoch is not None
-                else None
-            )
-            expired = bool(
-                lease.get("released_at")
-                or (expires_epoch is not None and now_epoch is not None and now_epoch > expires_epoch)
-            )
-            stale_reasons = []
-            if lease.get("released_at"):
-                stale_reasons.append("lease-released")
-            if expires_epoch is not None and now_epoch is not None and now_epoch > expires_epoch:
-                stale_reasons.append("lease-expired")
-            if heartbeat_age_seconds is not None and heartbeat_age_seconds > 120:
-                stale_reasons.append("heartbeat-old")
-            if runtime_status.get("active_orchestrator_instance_id") and lease.get("owner_instance_id") != runtime_status.get("active_orchestrator_instance_id"):
-                stale_reasons.append("owner-mismatch")
-            lease_info = {
-                "owner_instance_id": lease.get("owner_instance_id"),
-                "owner_role": lease.get("owner_role"),
-                "acquired_at": lease.get("acquired_at"),
-                "expires_at": lease.get("expires_at"),
-                "released_at": lease.get("released_at"),
-                "release_reason": lease.get("release_reason"),
-                "heartbeat_age_seconds": heartbeat_age_seconds,
-                "expired": expired,
-                "stale": bool(stale_reasons),
-                "stale_reasons": stale_reasons,
-            }
-            if stale_reasons:
-                warnings.append(
-                    "stale runtime heartbeat/lease: " + ", ".join(stale_reasons)
-                )
-        else:
-            lease_info = {
-                "owner_instance_id": None,
-                "owner_role": None,
-                "acquired_at": None,
-                "expires_at": None,
-                "released_at": None,
-                "release_reason": None,
-                "heartbeat_age_seconds": None,
-                "expired": False,
-                "stale": True,
-                "stale_reasons": ["lease-missing"],
-            }
-            warnings.append("stale runtime heartbeat/lease: lease-missing")
-
         if lane_id:
             lane_row = conn.execute("SELECT * FROM lanes WHERE lane_id=?", (lane_id,)).fetchone()
             if lane_row:

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -13,6 +13,12 @@ from .lifecycle import (
     retry_delay,
     schedule_retry_entry,
 )
+from .leases import (
+    acquire_engine_lease,
+    init_engine_leases,
+    read_engine_lease,
+    release_engine_lease,
+)
 from .scheduler import (
     RestoredSchedulerState,
     build_scheduler_payload,
@@ -29,7 +35,9 @@ from .state import (
     load_engine_scheduler_state,
     read_engine_scheduler_state,
     save_engine_scheduler_state,
+    save_engine_scheduler_state_to_connection,
 )
+from .store import EngineStore
 from .storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
 from .work_items import (
     RetryEntry,
@@ -43,10 +51,12 @@ from .work_items import (
 __all__ = [
     "RestoredSchedulerState",
     "WorkflowDriver",
+    "EngineStore",
     "RetryEntry",
     "RunningWork",
     "WorkItemRef",
     "WorkResult",
+    "acquire_engine_lease",
     "append_jsonl",
     "build_scheduler_payload",
     "clear_work_entries",
@@ -54,10 +64,12 @@ __all__ = [
     "connect_daedalus_db",
     "engine_state_tables_exist",
     "init_engine_state",
+    "init_engine_leases",
     "load_engine_scheduler_state",
     "load_optional_json",
     "mark_running_work",
     "make_audit_fn",
+    "read_engine_lease",
     "read_engine_scheduler_state",
     "recover_running_as_retry",
     "restore_scheduler_state",
@@ -67,6 +79,8 @@ __all__ = [
     "running_snapshot",
     "schedule_retry_entry",
     "save_engine_scheduler_state",
+    "save_engine_scheduler_state_to_connection",
+    "release_engine_lease",
     "work_item_from_change_delivery_lane",
     "work_item_from_issue",
     "write_json_atomic",

--- a/daedalus/engine/leases.py
+++ b/daedalus/engine/leases.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import calendar
+import json
+import sqlite3
+import time
+from typing import Any
+
+
+def iso_to_epoch(value: str | None) -> int | None:
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S.%fZ"):
+        try:
+            return int(calendar.timegm(time.strptime(value, fmt)))
+        except Exception:
+            continue
+    return None
+
+
+def epoch_to_iso(value: int | float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(value))
+
+
+def init_engine_leases(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS leases (
+          lease_id TEXT PRIMARY KEY,
+          lease_scope TEXT NOT NULL,
+          lease_key TEXT NOT NULL,
+          owner_instance_id TEXT NOT NULL,
+          owner_role TEXT NOT NULL,
+          acquired_at TEXT NOT NULL,
+          expires_at TEXT NOT NULL,
+          released_at TEXT,
+          release_reason TEXT,
+          metadata_json TEXT,
+          UNIQUE (lease_scope, lease_key)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_leases_scope_key ON leases(lease_scope, lease_key);
+        CREATE INDEX IF NOT EXISTS idx_leases_owner ON leases(owner_instance_id);
+        """
+    )
+
+
+def acquire_engine_lease(
+    conn: sqlite3.Connection,
+    *,
+    lease_scope: str,
+    lease_key: str,
+    owner_instance_id: str,
+    owner_role: str,
+    now_iso: str,
+    ttl_seconds: int = 60,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    init_engine_leases(conn)
+    now_epoch = iso_to_epoch(now_iso) or int(time.time())
+    expires_iso = epoch_to_iso(now_epoch + ttl_seconds)
+    lease_id = f"lease:{lease_scope}:{lease_key}"
+    row = conn.execute(
+        "SELECT owner_instance_id, expires_at, released_at FROM leases WHERE lease_scope=? AND lease_key=?",
+        (lease_scope, lease_key),
+    ).fetchone()
+    if row:
+        current_owner, expires_at, released_at = row
+        expires_at_epoch = iso_to_epoch(expires_at)
+        if not released_at and expires_at_epoch and expires_at_epoch > now_epoch and current_owner != owner_instance_id:
+            return {"acquired": False, "lease_id": lease_id, "owner_instance_id": current_owner}
+        conn.execute(
+            """
+            UPDATE leases
+            SET owner_instance_id=?, owner_role=?, acquired_at=?, expires_at=?,
+                released_at=NULL, release_reason=NULL, metadata_json=?
+            WHERE lease_scope=? AND lease_key=?
+            """,
+            (
+                owner_instance_id,
+                owner_role,
+                now_iso,
+                expires_iso,
+                json.dumps(metadata, sort_keys=True) if metadata else None,
+                lease_scope,
+                lease_key,
+            ),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO leases (
+              lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
+              acquired_at, expires_at, released_at, release_reason, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+            """,
+            (
+                lease_id,
+                lease_scope,
+                lease_key,
+                owner_instance_id,
+                owner_role,
+                now_iso,
+                expires_iso,
+                json.dumps(metadata, sort_keys=True) if metadata else None,
+            ),
+        )
+    return {
+        "acquired": True,
+        "lease_id": lease_id,
+        "owner_instance_id": owner_instance_id,
+        "expires_at": expires_iso,
+    }
+
+
+def release_engine_lease(
+    conn: sqlite3.Connection,
+    *,
+    lease_scope: str,
+    lease_key: str,
+    owner_instance_id: str,
+    now_iso: str,
+    release_reason: str | None = None,
+) -> dict[str, Any]:
+    init_engine_leases(conn)
+    row = conn.execute(
+        "SELECT owner_instance_id FROM leases WHERE lease_scope=? AND lease_key=?",
+        (lease_scope, lease_key),
+    ).fetchone()
+    if not row or row[0] != owner_instance_id:
+        return {"released": False, "reason": "not-owner"}
+    conn.execute(
+        """
+        UPDATE leases
+        SET released_at=?, release_reason=?
+        WHERE lease_scope=? AND lease_key=?
+        """,
+        (now_iso, release_reason, lease_scope, lease_key),
+    )
+    return {
+        "released": True,
+        "lease_id": f"lease:{lease_scope}:{lease_key}",
+        "owner_instance_id": owner_instance_id,
+    }
+
+
+def read_engine_lease(
+    conn: sqlite3.Connection,
+    *,
+    lease_scope: str,
+    lease_key: str,
+    now_epoch: int | float,
+    heartbeat_at: str | None = None,
+    active_owner_instance_id: str | None = None,
+    stale_after_seconds: int = 120,
+) -> dict[str, Any]:
+    init_engine_leases(conn)
+    row = conn.execute(
+        """
+        SELECT lease_scope, lease_key, owner_instance_id, owner_role, acquired_at, expires_at,
+               released_at, release_reason, metadata_json
+        FROM leases
+        WHERE lease_scope=? AND lease_key=?
+        """,
+        (lease_scope, lease_key),
+    ).fetchone()
+    if not row:
+        return {
+            "owner_instance_id": None,
+            "owner_role": None,
+            "acquired_at": None,
+            "expires_at": None,
+            "released_at": None,
+            "release_reason": None,
+            "heartbeat_age_seconds": None,
+            "expired": False,
+            "stale": True,
+            "stale_reasons": ["lease-missing"],
+            "metadata": {},
+        }
+    (
+        _scope,
+        _key,
+        owner_instance_id,
+        owner_role,
+        acquired_at,
+        expires_at,
+        released_at,
+        release_reason,
+        metadata_json,
+    ) = row
+    expires_epoch = iso_to_epoch(expires_at)
+    heartbeat_epoch = iso_to_epoch(heartbeat_at)
+    heartbeat_age_seconds = (
+        max(0, int(now_epoch) - heartbeat_epoch)
+        if now_epoch is not None and heartbeat_epoch is not None
+        else None
+    )
+    stale_reasons: list[str] = []
+    if released_at:
+        stale_reasons.append("lease-released")
+    if expires_epoch is not None and now_epoch is not None and int(now_epoch) > expires_epoch:
+        stale_reasons.append("lease-expired")
+    if heartbeat_age_seconds is not None and heartbeat_age_seconds > stale_after_seconds:
+        stale_reasons.append("heartbeat-old")
+    if active_owner_instance_id and owner_instance_id != active_owner_instance_id:
+        stale_reasons.append("owner-mismatch")
+    try:
+        metadata = json.loads(metadata_json) if metadata_json else {}
+    except json.JSONDecodeError:
+        metadata = {}
+    return {
+        "owner_instance_id": owner_instance_id,
+        "owner_role": owner_role,
+        "acquired_at": acquired_at,
+        "expires_at": expires_at,
+        "released_at": released_at,
+        "release_reason": release_reason,
+        "heartbeat_age_seconds": heartbeat_age_seconds,
+        "expired": bool(released_at or (expires_epoch is not None and now_epoch is not None and int(now_epoch) > expires_epoch)),
+        "stale": bool(stale_reasons),
+        "stale_reasons": stale_reasons,
+        "metadata": metadata,
+    }

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -207,6 +207,156 @@ def _upsert_work_item(
     )
 
 
+def save_engine_scheduler_state_to_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    retry_entries: dict[str, dict[str, Any]],
+    running_entries: dict[str, dict[str, Any]],
+    codex_totals: dict[str, Any] | None,
+    codex_threads: dict[str, dict[str, Any]],
+    now_iso: str,
+    now_epoch: float,
+) -> None:
+    init_engine_state(conn)
+    conn.execute("DELETE FROM engine_running_work WHERE workflow=?", (workflow,))
+    conn.execute("DELETE FROM engine_retry_queue WHERE workflow=?", (workflow,))
+    conn.execute("DELETE FROM engine_runtime_sessions WHERE workflow=?", (workflow,))
+
+    for work_id, entry in sorted(running_entries.items(), key=lambda item: str(item[0])):
+        work_id = str(entry.get("issue_id") or work_id or "").strip()
+        if not work_id:
+            continue
+        _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+        conn.execute(
+            """
+            INSERT INTO engine_running_work (
+              workflow, work_id, worker_id, attempt, worker_status, started_at_epoch, heartbeat_at_epoch,
+              cancel_requested, cancel_reason, thread_id, turn_id, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workflow,
+                work_id,
+                entry.get("worker_id"),
+                int(entry.get("attempt") or 0),
+                entry.get("worker_status") or "running",
+                float(entry.get("started_at_epoch") or now_epoch),
+                float(entry.get("heartbeat_at_epoch") or entry.get("started_at_epoch") or now_epoch),
+                1 if entry.get("cancel_requested") else 0,
+                entry.get("cancel_reason"),
+                entry.get("thread_id"),
+                entry.get("turn_id"),
+                now_iso,
+                now_epoch,
+            ),
+        )
+
+    for work_id, entry in sorted(retry_entries.items(), key=lambda item: str(item[0])):
+        work_id = str(entry.get("issue_id") or work_id or "").strip()
+        if not work_id:
+            continue
+        _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+        conn.execute(
+            """
+            INSERT INTO engine_retry_queue (
+              workflow, work_id, attempt, due_at_epoch, error, current_attempt, delay_type, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workflow,
+                work_id,
+                int(entry.get("attempt") or 0),
+                float(entry.get("due_at_epoch") or now_epoch),
+                entry.get("error"),
+                entry.get("current_attempt"),
+                entry.get("delay_type") or "failure",
+                now_iso,
+                now_epoch,
+            ),
+        )
+
+    for work_id, entry in sorted(codex_threads.items(), key=lambda item: str(item[0])):
+        if not isinstance(entry, dict):
+            continue
+        work_id = str(entry.get("issue_id") or work_id or "").strip()
+        thread_id = str(entry.get("thread_id") or "").strip()
+        if not work_id or not thread_id:
+            continue
+        _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
+        metadata = {
+            key: value
+            for key, value in entry.items()
+            if key
+            not in {
+                "issue_id",
+                "identifier",
+                "session_name",
+                "runtime_name",
+                "runtime_kind",
+                "session_id",
+                "thread_id",
+                "turn_id",
+                "status",
+                "cancel_requested",
+                "cancel_reason",
+                "updated_at",
+                "updatedAt",
+            }
+        }
+        conn.execute(
+            """
+            INSERT INTO engine_runtime_sessions (
+              workflow, work_id, session_name, runtime_name, runtime_kind, session_id, thread_id, turn_id,
+              status, cancel_requested, cancel_reason, metadata_json, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workflow,
+                work_id,
+                entry.get("session_name") or entry.get("sessionName"),
+                entry.get("runtime_name") or entry.get("runtimeName"),
+                entry.get("runtime_kind") or entry.get("runtimeKind"),
+                entry.get("session_id") or entry.get("sessionId"),
+                thread_id,
+                entry.get("turn_id") or entry.get("turnId"),
+                entry.get("status"),
+                1 if (entry.get("cancel_requested") or entry.get("cancelRequested")) else 0,
+                entry.get("cancel_reason") or entry.get("cancelReason"),
+                _json_dumps(metadata),
+                entry.get("updated_at") or entry.get("updatedAt") or now_iso,
+                now_epoch,
+            ),
+        )
+
+    totals = dict(codex_totals or {})
+    conn.execute(
+        """
+        INSERT INTO engine_runtime_totals (
+          workflow, input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json, updated_at, updated_at_epoch
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(workflow) DO UPDATE SET
+          input_tokens=excluded.input_tokens,
+          output_tokens=excluded.output_tokens,
+          total_tokens=excluded.total_tokens,
+          turn_count=excluded.turn_count,
+          rate_limits_json=excluded.rate_limits_json,
+          updated_at=excluded.updated_at,
+          updated_at_epoch=excluded.updated_at_epoch
+        """,
+        (
+            workflow,
+            int(totals.get("input_tokens") or 0),
+            int(totals.get("output_tokens") or 0),
+            int(totals.get("total_tokens") or 0),
+            int(totals.get("turn_count") or 0),
+            _json_dumps(totals.get("rate_limits")),
+            now_iso,
+            now_epoch,
+        ),
+    )
+
+
 def save_engine_scheduler_state(
     db_path: Path,
     *,
@@ -220,141 +370,15 @@ def save_engine_scheduler_state(
 ) -> None:
     conn = _open_engine_state_db(db_path)
     try:
-        conn.execute("DELETE FROM engine_running_work WHERE workflow=?", (workflow,))
-        conn.execute("DELETE FROM engine_retry_queue WHERE workflow=?", (workflow,))
-        conn.execute("DELETE FROM engine_runtime_sessions WHERE workflow=?", (workflow,))
-
-        for work_id, entry in sorted(running_entries.items(), key=lambda item: str(item[0])):
-            work_id = str(entry.get("issue_id") or work_id or "").strip()
-            if not work_id:
-                continue
-            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
-            conn.execute(
-                """
-                INSERT INTO engine_running_work (
-                  workflow, work_id, worker_id, attempt, worker_status, started_at_epoch, heartbeat_at_epoch,
-                  cancel_requested, cancel_reason, thread_id, turn_id, updated_at, updated_at_epoch
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    workflow,
-                    work_id,
-                    entry.get("worker_id"),
-                    int(entry.get("attempt") or 0),
-                    entry.get("worker_status") or "running",
-                    float(entry.get("started_at_epoch") or now_epoch),
-                    float(entry.get("heartbeat_at_epoch") or entry.get("started_at_epoch") or now_epoch),
-                    1 if entry.get("cancel_requested") else 0,
-                    entry.get("cancel_reason"),
-                    entry.get("thread_id"),
-                    entry.get("turn_id"),
-                    now_iso,
-                    now_epoch,
-                ),
-            )
-
-        for work_id, entry in sorted(retry_entries.items(), key=lambda item: str(item[0])):
-            work_id = str(entry.get("issue_id") or work_id or "").strip()
-            if not work_id:
-                continue
-            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
-            conn.execute(
-                """
-                INSERT INTO engine_retry_queue (
-                  workflow, work_id, attempt, due_at_epoch, error, current_attempt, delay_type, updated_at, updated_at_epoch
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    workflow,
-                    work_id,
-                    int(entry.get("attempt") or 0),
-                    float(entry.get("due_at_epoch") or now_epoch),
-                    entry.get("error"),
-                    entry.get("current_attempt"),
-                    entry.get("delay_type") or "failure",
-                    now_iso,
-                    now_epoch,
-                ),
-            )
-
-        for work_id, entry in sorted(codex_threads.items(), key=lambda item: str(item[0])):
-            if not isinstance(entry, dict):
-                continue
-            work_id = str(entry.get("issue_id") or work_id or "").strip()
-            thread_id = str(entry.get("thread_id") or "").strip()
-            if not work_id or not thread_id:
-                continue
-            _upsert_work_item(conn, workflow=workflow, work_id=work_id, entry=entry, now_iso=now_iso, now_epoch=now_epoch)
-            metadata = {
-                key: value
-                for key, value in entry.items()
-                if key
-                not in {
-                    "issue_id",
-                    "identifier",
-                    "session_name",
-                    "runtime_name",
-                    "runtime_kind",
-                    "session_id",
-                    "thread_id",
-                    "turn_id",
-                    "status",
-                    "cancel_requested",
-                    "cancel_reason",
-                    "updated_at",
-                    "updatedAt",
-                }
-            }
-            conn.execute(
-                """
-                INSERT INTO engine_runtime_sessions (
-                  workflow, work_id, session_name, runtime_name, runtime_kind, session_id, thread_id, turn_id,
-                  status, cancel_requested, cancel_reason, metadata_json, updated_at, updated_at_epoch
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    workflow,
-                    work_id,
-                    entry.get("session_name") or entry.get("sessionName"),
-                    entry.get("runtime_name") or entry.get("runtimeName"),
-                    entry.get("runtime_kind") or entry.get("runtimeKind"),
-                    entry.get("session_id") or entry.get("sessionId"),
-                    thread_id,
-                    entry.get("turn_id") or entry.get("turnId"),
-                    entry.get("status"),
-                    1 if (entry.get("cancel_requested") or entry.get("cancelRequested")) else 0,
-                    entry.get("cancel_reason") or entry.get("cancelReason"),
-                    _json_dumps(metadata),
-                    entry.get("updated_at") or entry.get("updatedAt") or now_iso,
-                    now_epoch,
-                ),
-            )
-
-        totals = dict(codex_totals or {})
-        conn.execute(
-            """
-            INSERT INTO engine_runtime_totals (
-              workflow, input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json, updated_at, updated_at_epoch
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(workflow) DO UPDATE SET
-              input_tokens=excluded.input_tokens,
-              output_tokens=excluded.output_tokens,
-              total_tokens=excluded.total_tokens,
-              turn_count=excluded.turn_count,
-              rate_limits_json=excluded.rate_limits_json,
-              updated_at=excluded.updated_at,
-              updated_at_epoch=excluded.updated_at_epoch
-            """,
-            (
-                workflow,
-                int(totals.get("input_tokens") or 0),
-                int(totals.get("output_tokens") or 0),
-                int(totals.get("total_tokens") or 0),
-                int(totals.get("turn_count") or 0),
-                _json_dumps(totals.get("rate_limits")),
-                now_iso,
-                now_epoch,
-            ),
+        save_engine_scheduler_state_to_connection(
+            conn,
+            workflow=workflow,
+            retry_entries=retry_entries,
+            running_entries=running_entries,
+            codex_totals=codex_totals,
+            codex_threads=codex_threads,
+            now_iso=now_iso,
+            now_epoch=now_epoch,
         )
         conn.commit()
     finally:
@@ -518,6 +542,17 @@ def load_engine_scheduler_state(
         return _scheduler_state_from_connection(conn, workflow=workflow, now_iso=now_iso, now_epoch=now_epoch)
     finally:
         conn.close()
+
+
+def load_engine_scheduler_state_from_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    now_iso: str,
+    now_epoch: float,
+) -> dict[str, Any]:
+    init_engine_state(conn)
+    return _scheduler_state_from_connection(conn, workflow=workflow, now_iso=now_iso, now_epoch=now_epoch)
 
 
 def read_engine_scheduler_state(

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from .leases import (
+    acquire_engine_lease,
+    init_engine_leases,
+    read_engine_lease,
+    release_engine_lease,
+)
+from .sqlite import connect_daedalus_db
+from .state import (
+    ENGINE_STATE_TABLES,
+    engine_state_tables_exist,
+    init_engine_state,
+    load_engine_scheduler_state_from_connection,
+    read_engine_scheduler_state,
+    save_engine_scheduler_state_to_connection,
+)
+
+
+def _default_now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+class EngineStore:
+    """Workflow-scoped API for shared Daedalus engine state.
+
+    Workflows should depend on this class instead of reaching directly into
+    SQLite tables. That keeps engine-owned state changes transactional and
+    leaves workflow packages focused on policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        workflow: str,
+        now_iso: Callable[[], str] = _default_now_iso,
+        now_epoch: Callable[[], float] = time.time,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.workflow = workflow
+        self._now_iso = now_iso
+        self._now_epoch = now_epoch
+
+    def connect(self) -> sqlite3.Connection:
+        conn = connect_daedalus_db(self.db_path)
+        init_engine_state(conn)
+        init_engine_leases(conn)
+        return conn
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        conn = self.connect()
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def load_scheduler(self) -> dict[str, Any]:
+        conn = self.connect()
+        try:
+            return load_engine_scheduler_state_from_connection(
+                conn,
+                workflow=self.workflow,
+                now_iso=self._now_iso(),
+                now_epoch=self._now_epoch(),
+            )
+        finally:
+            conn.close()
+
+    def read_scheduler(self) -> dict[str, Any] | None:
+        return read_engine_scheduler_state(
+            self.db_path,
+            workflow=self.workflow,
+            now_iso=self._now_iso(),
+            now_epoch=self._now_epoch(),
+        )
+
+    def save_scheduler(
+        self,
+        *,
+        retry_entries: dict[str, dict[str, Any]],
+        running_entries: dict[str, dict[str, Any]],
+        codex_totals: dict[str, Any] | None,
+        codex_threads: dict[str, dict[str, Any]],
+        now_iso: str | None = None,
+        now_epoch: float | None = None,
+    ) -> None:
+        with self.transaction() as conn:
+            save_engine_scheduler_state_to_connection(
+                conn,
+                workflow=self.workflow,
+                retry_entries=retry_entries,
+                running_entries=running_entries,
+                codex_totals=codex_totals,
+                codex_threads=codex_threads,
+                now_iso=now_iso or self._now_iso(),
+                now_epoch=self._now_epoch() if now_epoch is None else now_epoch,
+            )
+
+    def acquire_lease(
+        self,
+        *,
+        lease_scope: str,
+        lease_key: str,
+        owner_instance_id: str,
+        owner_role: str,
+        ttl_seconds: int = 60,
+        now_iso: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        with self.transaction() as conn:
+            return acquire_engine_lease(
+                conn,
+                lease_scope=lease_scope,
+                lease_key=lease_key,
+                owner_instance_id=owner_instance_id,
+                owner_role=owner_role,
+                now_iso=now_iso or self._now_iso(),
+                ttl_seconds=ttl_seconds,
+                metadata=metadata,
+            )
+
+    def release_lease(
+        self,
+        *,
+        lease_scope: str,
+        lease_key: str,
+        owner_instance_id: str,
+        now_iso: str | None = None,
+        release_reason: str | None = None,
+    ) -> dict[str, Any]:
+        with self.transaction() as conn:
+            return release_engine_lease(
+                conn,
+                lease_scope=lease_scope,
+                lease_key=lease_key,
+                owner_instance_id=owner_instance_id,
+                now_iso=now_iso or self._now_iso(),
+                release_reason=release_reason,
+            )
+
+    def lease_status(
+        self,
+        *,
+        lease_scope: str,
+        lease_key: str,
+        heartbeat_at: str | None = None,
+        active_owner_instance_id: str | None = None,
+        stale_after_seconds: int = 120,
+    ) -> dict[str, Any]:
+        conn = self.connect()
+        try:
+            return read_engine_lease(
+                conn,
+                lease_scope=lease_scope,
+                lease_key=lease_key,
+                now_epoch=self._now_epoch(),
+                heartbeat_at=heartbeat_at,
+                active_owner_instance_id=active_owner_instance_id,
+                stale_after_seconds=stale_after_seconds,
+            )
+        finally:
+            conn.close()
+
+    def doctor(self, *, stale_running_seconds: int = 600) -> list[dict[str, Any]]:
+        checks: list[dict[str, Any]] = []
+        try:
+            conn = self.connect()
+        except Exception as exc:
+            return [{"name": "engine-db", "status": "fail", "detail": f"{type(exc).__name__}: {exc}"}]
+        try:
+            missing_tables = [
+                table
+                for table in (*ENGINE_STATE_TABLES, "leases")
+                if not conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                ).fetchone()
+            ]
+            checks.append(
+                {
+                    "name": "engine-schema",
+                    "status": "pass" if not missing_tables and engine_state_tables_exist(conn) else "fail",
+                    "detail": "ok" if not missing_tables else "missing: " + ", ".join(missing_tables),
+                }
+            )
+
+            now_epoch = self._now_epoch()
+            stale_running = conn.execute(
+                """
+                SELECT work_id, heartbeat_at_epoch
+                FROM engine_running_work
+                WHERE workflow=? AND heartbeat_at_epoch < ?
+                ORDER BY heartbeat_at_epoch ASC
+                LIMIT 10
+                """,
+                (self.workflow, now_epoch - stale_running_seconds),
+            ).fetchall()
+            checks.append(
+                {
+                    "name": "engine-running-work",
+                    "status": "warn" if stale_running else "pass",
+                    "detail": (
+                        f"{len(stale_running)} stale running work item(s)"
+                        if stale_running
+                        else "no stale running work"
+                    ),
+                    "items": [row[0] for row in stale_running],
+                }
+            )
+
+            retry_count = conn.execute(
+                "SELECT COUNT(*) FROM engine_retry_queue WHERE workflow=?",
+                (self.workflow,),
+            ).fetchone()[0]
+            checks.append(
+                {
+                    "name": "engine-retry-queue",
+                    "status": "pass",
+                    "detail": f"{int(retry_count or 0)} queued retry item(s)",
+                }
+            )
+
+            invalid_sessions = conn.execute(
+                """
+                SELECT work_id
+                FROM engine_runtime_sessions
+                WHERE workflow=? AND (thread_id IS NULL OR thread_id = '')
+                LIMIT 10
+                """,
+                (self.workflow,),
+            ).fetchall()
+            checks.append(
+                {
+                    "name": "engine-runtime-sessions",
+                    "status": "fail" if invalid_sessions else "pass",
+                    "detail": (
+                        f"{len(invalid_sessions)} runtime session(s) missing thread_id"
+                        if invalid_sessions
+                        else "runtime sessions have valid thread mappings"
+                    ),
+                    "items": [row[0] for row in invalid_sessions],
+                }
+            )
+            return checks
+        except Exception as exc:
+            checks.append({"name": "engine-state", "status": "fail", "detail": f"{type(exc).__name__}: {exc}"})
+            return checks
+        finally:
+            conn.close()

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from engine.leases import acquire_engine_lease, init_engine_leases, release_engine_lease
 from engine.state import init_engine_state
 from engine.sqlite import connect_daedalus_db
 from workflows.shared.paths import (
@@ -534,6 +535,7 @@ def init_daedalus_db(*, workflow_root: Path, project_key: str) -> dict[str, Any]
             """
         )
         init_engine_state(conn)
+        init_engine_leases(conn)
         now_iso = _now_iso()
         runtime_row = conn.execute(
             "SELECT schema_version FROM daedalus_runtime WHERE runtime_id='daedalus'"
@@ -625,41 +627,19 @@ def acquire_lease(
     ttl_seconds: int = 60,
 ) -> dict[str, Any]:
     now_iso = now_iso or _now_iso()
-    now_epoch = _iso_to_epoch(now_iso)
-    expires_epoch = (now_epoch or int(time.time())) + ttl_seconds
-    expires_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(expires_epoch))
-    lease_id = f"lease:{lease_scope}:{lease_key}"
     conn = _connect(db_path)
     try:
-        row = conn.execute(
-            "SELECT owner_instance_id, expires_at, released_at FROM leases WHERE lease_scope=? AND lease_key=?",
-            (lease_scope, lease_key),
-        ).fetchone()
-        if row:
-            current_owner, expires_at, released_at = row
-            expires_at_epoch = _iso_to_epoch(expires_at)
-            if not released_at and expires_at_epoch and expires_at_epoch > (now_epoch or 0) and current_owner != owner_instance_id:
-                return {"acquired": False, "lease_id": lease_id, "owner_instance_id": current_owner}
-            conn.execute(
-                """
-                UPDATE leases
-                SET owner_instance_id=?, owner_role=?, acquired_at=?, expires_at=?, released_at=NULL, release_reason=NULL
-                WHERE lease_scope=? AND lease_key=?
-                """,
-                (owner_instance_id, owner_role, now_iso, expires_iso, lease_scope, lease_key),
-            )
-        else:
-            conn.execute(
-                """
-                INSERT INTO leases (
-                  lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
-                  acquired_at, expires_at, released_at, release_reason, metadata_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
-                """,
-                (lease_id, lease_scope, lease_key, owner_instance_id, owner_role, now_iso, expires_iso),
-            )
+        result = acquire_engine_lease(
+            conn,
+            lease_scope=lease_scope,
+            lease_key=lease_key,
+            owner_instance_id=owner_instance_id,
+            owner_role=owner_role,
+            now_iso=now_iso,
+            ttl_seconds=ttl_seconds,
+        )
         conn.commit()
-        return {"acquired": True, "lease_id": lease_id, "owner_instance_id": owner_instance_id, "expires_at": expires_iso}
+        return result
     finally:
         conn.close()
 
@@ -676,22 +656,16 @@ def release_lease(
     now_iso = now_iso or _now_iso()
     conn = _connect(db_path)
     try:
-        row = conn.execute(
-            "SELECT owner_instance_id FROM leases WHERE lease_scope=? AND lease_key=?",
-            (lease_scope, lease_key),
-        ).fetchone()
-        if not row or row[0] != owner_instance_id:
-            return {"released": False, "reason": "not-owner"}
-        conn.execute(
-            """
-            UPDATE leases
-            SET released_at=?, release_reason=?
-            WHERE lease_scope=? AND lease_key=?
-            """,
-            (now_iso, release_reason, lease_scope, lease_key),
+        result = release_engine_lease(
+            conn,
+            lease_scope=lease_scope,
+            lease_key=lease_key,
+            owner_instance_id=owner_instance_id,
+            now_iso=now_iso,
+            release_reason=release_reason,
         )
         conn.commit()
-        return {"released": True, "lease_id": f"lease:{lease_scope}:{lease_key}", "owner_instance_id": owner_instance_id}
+        return result
     finally:
         conn.close()
 

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from engine.audit import make_audit_fn as _engine_make_audit_fn
-from engine.state import load_engine_scheduler_state, save_engine_scheduler_state
+from engine.store import EngineStore
 from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
@@ -424,6 +424,12 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     audit_log_path = Path(config["auditLogPath"])
     scheduler_path = Path(config.get("schedulerPath") or (workspace_root / "memory/workflow-scheduler.json"))
     db_path = runtime_paths(workspace_root)["db_path"]
+    engine_store = EngineStore(
+        db_path=db_path,
+        workflow="change-delivery",
+        now_iso=_now_iso,
+        now_epoch=time.time,
+    )
     sessions_state_path = workspace_root / "state/sessions"
 
     # -- config constants ------------------------------------------------
@@ -524,17 +530,10 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         _write_json(ledger_path, payload)
 
     def load_scheduler() -> dict[str, Any]:
-        return load_engine_scheduler_state(
-            db_path,
-            workflow="change-delivery",
-            now_iso=_now_iso(),
-            now_epoch=time.time(),
-        )
+        return engine_store.load_scheduler()
 
     def save_scheduler(payload: dict[str, Any]) -> None:
-        save_engine_scheduler_state(
-            db_path,
-            workflow="change-delivery",
+        engine_store.save_scheduler(
             retry_entries={},
             running_entries={},
             codex_totals=payload.get("codex_totals") or payload.get("codexTotals") or {},
@@ -611,6 +610,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         CONFIG=config,
         WORKFLOW_YAML=yaml_cfg or {},
         WORKFLOW_POLICY=workflow_policy,
+        ENGINE_STORE=engine_store,
         ACTIVE_CANCEL_EVENT=None,
         DEFAULT_CONFIG_PATH=workspace_root / DEFAULT_WORKFLOW_MARKDOWN_FILENAME,
         SESSIONS_STATE_PATH=sessions_state_path,
@@ -2073,15 +2073,18 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         after = before
         if before["health"] != "healthy" or fix_watchers:
             after = ns.reconcile(fix_watchers=fix_watchers)
+        engine_checks = ns.ENGINE_STORE.doctor()
         ns.audit(
             "doctor",
             f"Doctor checked workflow: {before['health']} -> {after['health']}",
             before=before["health"],
             after=after["health"],
+            engineChecks=engine_checks,
         )
         return {
             "before": before,
             "after": after,
+            "engineChecks": engine_checks,
             "fixed": before["health"] != after["health"] or bool(after.get("actionsTaken", {}).get("jobs")),
         }
 

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -30,7 +30,7 @@ from engine.lifecycle import (
     recover_running_as_retry,
     schedule_retry_entry,
 )
-from engine.state import load_engine_scheduler_state, save_engine_scheduler_state
+from engine.store import EngineStore
 from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
@@ -292,6 +292,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
     audit_log_path: Path
     scheduler_path: Path
     db_path: Path
+    engine_store: EngineStore
     prompt_template: str
     runtimes: dict[str, Runtime]
     _run: Callable[..., Any]
@@ -420,6 +421,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         except Exception as exc:
             checks.append({"name": "agent-runtime", "status": "fail", "detail": str(exc)})
 
+        checks.extend(self.engine_store.doctor())
         ok = all(check["status"] == "pass" for check in checks)
         return {
             "ok": ok,
@@ -494,19 +496,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
         return diagnostics
 
     def _load_scheduler_state(self) -> dict[str, Any]:
-        return load_engine_scheduler_state(
-            self.db_path,
-            workflow="issue-runner",
-            now_iso=_now_iso(),
-            now_epoch=_now_epoch(),
-        )
+        return self.engine_store.load_scheduler()
 
     def _persist_scheduler_state(self) -> None:
         now_iso = _now_iso()
         now_epoch = _now_epoch()
-        save_engine_scheduler_state(
-            self.db_path,
-            workflow="issue-runner",
+        self.engine_store.save_scheduler(
             retry_entries=self.retry_entries,
             running_entries=self.running_entries,
             codex_totals=self.codex_totals,
@@ -1710,6 +1705,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
         self.audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
         self.scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
         self.db_path = runtime_paths(self.path)["db_path"]
+        self.engine_store = EngineStore(
+            db_path=self.db_path,
+            workflow="issue-runner",
+            now_iso=_now_iso,
+            now_epoch=_now_epoch,
+        )
         if not self._supervisor_futures:
             self._close_runtimes()
         self.runtimes = _build_runtimes_from_config(cfg, run=self._run, run_json=self._run_json)
@@ -1765,6 +1766,12 @@ def load_workspace_from_config(
     audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
     scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
     db_path = runtime_paths(root)["db_path"]
+    engine_store = EngineStore(
+        db_path=db_path,
+        workflow="issue-runner",
+        now_iso=_now_iso,
+        now_epoch=_now_epoch,
+    )
 
     runner = run or _subprocess_run
     runner_json = run_json or _subprocess_run_json
@@ -1783,6 +1790,7 @@ def load_workspace_from_config(
         audit_log_path=audit_log_path,
         scheduler_path=scheduler_path,
         db_path=db_path,
+        engine_store=engine_store,
         prompt_template=contract.prompt_template,
         runtimes=runtimes,
         _run=runner,

--- a/docs/concepts/engine.md
+++ b/docs/concepts/engine.md
@@ -37,13 +37,16 @@ the plugin-local `engine` package:
 | `engine.lifecycle` | Shared running, retry, clear, and restart-recovery mutation helpers. |
 | `engine.sqlite` | Daedalus SQLite connection setup with WAL, foreign keys, and busy timeout. |
 | `engine.state` | Shared SQLite tables and read/write projections for scheduler state. |
+| `engine.leases` | Shared lease acquire/release/status helpers for ownership and heartbeat checks. |
+| `engine.store` | Workflow-scoped `EngineStore` API for transactions, scheduler state, leases, and doctor checks. |
 | `engine.scheduler` | Scheduler snapshot/restore helpers for running work, retry queues, and Codex thread mappings. |
 
 `issue-runner` now consumes the shared scheduler, lifecycle, work-item, and
-SQLite state primitives directly, then writes `memory/workflow-scheduler.json`
+`EngineStore` primitives directly, then writes `memory/workflow-scheduler.json`
 as a generated operator snapshot. `change-delivery` keeps its lane/action
-tables for workflow-specific policy, but shares the engine runtime-session and
-token accounting tables used by watch, status, and doctor surfaces.
+tables for workflow-specific policy, but shares the engine runtime-session,
+token accounting, and lease primitives used by watch, status, and doctor
+surfaces.
 
 ## Boundary
 

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -238,3 +238,105 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
     assert loaded["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
     assert loaded["codex_totals"]["total_tokens"] == 7
     assert readonly == loaded
+
+
+def test_engine_store_wraps_scheduler_state_and_doctor(tmp_path):
+    from engine.store import EngineStore
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    store = EngineStore(
+        db_path=db_path,
+        workflow="issue-runner",
+        now_iso=lambda: "2026-04-30T00:00:20Z",
+        now_epoch=lambda: 120.0,
+    )
+    store.save_scheduler(
+        running_entries={
+            "ISSUE-1": {
+                "issue_id": "ISSUE-1",
+                "identifier": "DAE-1",
+                "state": "open",
+                "worker_id": "worker-1",
+                "attempt": 1,
+                "started_at_epoch": 100.0,
+                "heartbeat_at_epoch": 110.0,
+            }
+        },
+        retry_entries={},
+        codex_threads={
+            "ISSUE-1": {
+                "issue_id": "ISSUE-1",
+                "identifier": "DAE-1",
+                "thread_id": "thread-1",
+            }
+        },
+        codex_totals={"total_tokens": 3},
+    )
+
+    snapshot = store.load_scheduler()
+    checks = {check["name"]: check for check in store.doctor(stale_running_seconds=60)}
+
+    assert snapshot["running"][0]["issue_id"] == "ISSUE-1"
+    assert snapshot["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert checks["engine-schema"]["status"] == "pass"
+    assert checks["engine-running-work"]["status"] == "pass"
+    assert checks["engine-retry-queue"]["detail"] == "0 queued retry item(s)"
+    assert checks["engine-runtime-sessions"]["status"] == "pass"
+
+
+def test_engine_store_lease_lifecycle_and_stale_status(tmp_path):
+    from engine.store import EngineStore
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    store = EngineStore(
+        db_path=db_path,
+        workflow="change-delivery",
+        now_iso=lambda: "2026-04-30T00:00:00Z",
+        now_epoch=lambda: 1777507200.0,
+    )
+
+    acquired = store.acquire_lease(
+        lease_scope="runtime",
+        lease_key="primary",
+        owner_instance_id="owner-1",
+        owner_role="Workflow_Orchestrator",
+        ttl_seconds=60,
+    )
+    blocked = store.acquire_lease(
+        lease_scope="runtime",
+        lease_key="primary",
+        owner_instance_id="owner-2",
+        owner_role="Workflow_Orchestrator",
+        ttl_seconds=60,
+    )
+    status = store.lease_status(
+        lease_scope="runtime",
+        lease_key="primary",
+        heartbeat_at="2026-04-30T00:00:00Z",
+        active_owner_instance_id="owner-1",
+    )
+    released = store.release_lease(
+        lease_scope="runtime",
+        lease_key="primary",
+        owner_instance_id="owner-1",
+        release_reason="shutdown",
+    )
+    released_status = store.lease_status(
+        lease_scope="runtime",
+        lease_key="primary",
+        heartbeat_at="2026-04-29T23:55:00Z",
+        active_owner_instance_id="owner-1",
+    )
+
+    assert acquired["acquired"] is True
+    assert acquired["expires_at"] == "2026-04-30T00:01:00Z"
+    assert blocked == {
+        "acquired": False,
+        "lease_id": "lease:runtime:primary",
+        "owner_instance_id": "owner-1",
+    }
+    assert status["stale"] is False
+    assert released["released"] is True
+    assert released_status["stale"] is True
+    assert "lease-released" in released_status["stale_reasons"]
+    assert "heartbeat-old" in released_status["stale_reasons"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -24,6 +24,8 @@ def test_install_into_default_hermes_home_copies_plugin_tree(tmp_path):
     assert result == plugin_dir
     assert (plugin_dir / "plugin.yaml").exists()
     assert (plugin_dir / "engine" / "__init__.py").exists()
+    assert (plugin_dir / "engine" / "store.py").exists()
+    assert (plugin_dir / "engine" / "leases.py").exists()
     assert (plugin_dir / "runtimes" / "__init__.py").exists()
     assert (plugin_dir / "runtime.py").exists()
     assert (plugin_dir / "alerts.py").exists()
@@ -45,6 +47,8 @@ def test_install_into_explicit_destination_uses_given_path(tmp_path):
 
     assert result == target
     assert (target / "engine" / "scheduler.py").exists()
+    assert (target / "engine" / "store.py").exists()
+    assert (target / "engine" / "leases.py").exists()
     assert (target / "runtimes" / "codex_app_server.py").exists()
     assert (target / "plugin.yaml").exists()
     assert (target / "trackers" / "linear.py").exists()


### PR DESCRIPTION
## Summary

This PR turns the shared engine state layer into a workflow-scoped API and extracts lease handling into shared engine primitives.

- Adds `engine.store.EngineStore` for transactional scheduler state, lease operations, and engine doctor checks.
- Adds `engine.leases` for shared lease acquire/release/status behavior.
- Wires `issue-runner` and `change-delivery` to use `EngineStore` instead of direct scheduler-state helpers.
- Keeps runtime lease public functions stable while delegating implementation to shared engine lease helpers.
- Surfaces engine doctor checks through both bundled workflow doctor paths.
- Updates engine docs and install/engine primitive tests.

## Impact

Workflows keep policy and domain state. Engine-owned concerns now have a clearer API boundary: DB transactions, scheduler projections, lease ownership, stale-running checks, retry queue visibility, and runtime session consistency.

## Validation

- `pytest -q` -> `840 passed, 8 skipped`
