### PR TITLE
[codex] Add engine run ledger

### DIFF
--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -31,11 +31,15 @@ from .scheduler import (
 from .sqlite import connect_daedalus_db
 from .state import (
     engine_state_tables_exist,
+    finish_engine_run_to_connection,
     init_engine_state,
+    latest_engine_runs_from_connection,
     load_engine_scheduler_state,
+    read_engine_runs,
     read_engine_scheduler_state,
     save_engine_scheduler_state,
     save_engine_scheduler_state_to_connection,
+    start_engine_run_to_connection,
 )
 from .store import EngineStore
 from .storage import append_jsonl, load_optional_json, write_json_atomic, write_text_atomic
@@ -63,13 +67,16 @@ __all__ = [
     "codex_threads_snapshot",
     "connect_daedalus_db",
     "engine_state_tables_exist",
+    "finish_engine_run_to_connection",
     "init_engine_state",
     "init_engine_leases",
+    "latest_engine_runs_from_connection",
     "load_engine_scheduler_state",
     "load_optional_json",
     "mark_running_work",
     "make_audit_fn",
     "read_engine_lease",
+    "read_engine_runs",
     "read_engine_scheduler_state",
     "recover_running_as_retry",
     "restore_scheduler_state",
@@ -81,6 +88,7 @@ __all__ = [
     "save_engine_scheduler_state",
     "save_engine_scheduler_state_to_connection",
     "release_engine_lease",
+    "start_engine_run_to_connection",
     "work_item_from_change_delivery_lane",
     "work_item_from_issue",
     "write_json_atomic",

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -9,12 +10,17 @@ from .scheduler import build_scheduler_payload
 from .sqlite import connect_daedalus_db
 
 
-ENGINE_STATE_TABLES = (
+ENGINE_SCHEDULER_TABLES = (
     "engine_work_items",
     "engine_running_work",
     "engine_retry_queue",
     "engine_runtime_sessions",
     "engine_runtime_totals",
+)
+
+ENGINE_STATE_TABLES = (
+    *ENGINE_SCHEDULER_TABLES,
+    "engine_runs",
 )
 
 
@@ -134,12 +140,31 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           updated_at_epoch REAL NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS engine_runs (
+          workflow TEXT NOT NULL,
+          run_id TEXT PRIMARY KEY,
+          mode TEXT NOT NULL,
+          status TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          started_at_epoch REAL NOT NULL,
+          completed_at TEXT,
+          completed_at_epoch REAL,
+          selected_count INTEGER NOT NULL DEFAULT 0,
+          completed_count INTEGER NOT NULL DEFAULT 0,
+          error TEXT,
+          metadata_json TEXT
+        );
+
         CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_status
           ON engine_running_work(workflow, worker_status);
         CREATE INDEX IF NOT EXISTS idx_engine_retry_workflow_due
           ON engine_retry_queue(workflow, due_at_epoch);
         CREATE INDEX IF NOT EXISTS idx_engine_runtime_sessions_thread
           ON engine_runtime_sessions(workflow, thread_id);
+        CREATE INDEX IF NOT EXISTS idx_engine_runs_workflow_started
+          ON engine_runs(workflow, started_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_runs_workflow_status
+          ON engine_runs(workflow, status);
         """
     )
 
@@ -569,10 +594,218 @@ def read_engine_scheduler_state(
     except sqlite3.OperationalError:
         return None
     try:
-        if not engine_state_tables_exist(conn):
+        if not all(_table_exists(conn, name) for name in ENGINE_SCHEDULER_TABLES):
             return None
         return _scheduler_state_from_connection(conn, workflow=workflow, now_iso=now_iso, now_epoch=now_epoch)
     except sqlite3.OperationalError:
         return None
+    finally:
+        conn.close()
+
+
+def _run_row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:
+    (
+        workflow,
+        run_id,
+        mode,
+        status,
+        started_at,
+        started_at_epoch,
+        completed_at,
+        completed_at_epoch,
+        selected_count,
+        completed_count,
+        error,
+        metadata_json,
+    ) = row
+    return {
+        "workflow": workflow,
+        "run_id": run_id,
+        "mode": mode,
+        "status": status,
+        "started_at": started_at,
+        "started_at_epoch": float(started_at_epoch or 0),
+        "completed_at": completed_at,
+        "completed_at_epoch": None if completed_at_epoch is None else float(completed_at_epoch),
+        "selected_count": int(selected_count or 0),
+        "completed_count": int(completed_count or 0),
+        "error": error,
+        "metadata": _json_loads(metadata_json) or {},
+    }
+
+
+def start_engine_run_to_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    mode: str,
+    now_iso: str,
+    now_epoch: float,
+    run_id: str | None = None,
+    selected_count: int = 0,
+    completed_count: int = 0,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    init_engine_state(conn)
+    safe_mode = str(mode or "run").strip() or "run"
+    safe_run_id = str(run_id or "").strip() or (
+        f"{workflow}:{safe_mode}:{int(now_epoch * 1000)}:{uuid.uuid4().hex[:8]}"
+    )
+    conn.execute(
+        """
+        INSERT INTO engine_runs (
+          workflow, run_id, mode, status, started_at, started_at_epoch,
+          selected_count, completed_count, metadata_json
+        ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
+        """,
+        (
+            workflow,
+            safe_run_id,
+            safe_mode,
+            now_iso,
+            float(now_epoch),
+            int(selected_count or 0),
+            int(completed_count or 0),
+            _json_dumps(metadata or {}),
+        ),
+    )
+    return {
+        "workflow": workflow,
+        "run_id": safe_run_id,
+        "mode": safe_mode,
+        "status": "running",
+        "started_at": now_iso,
+        "started_at_epoch": float(now_epoch),
+        "completed_at": None,
+        "completed_at_epoch": None,
+        "selected_count": int(selected_count or 0),
+        "completed_count": int(completed_count or 0),
+        "error": None,
+        "metadata": dict(metadata or {}),
+    }
+
+
+def finish_engine_run_to_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    run_id: str,
+    status: str,
+    now_iso: str,
+    now_epoch: float,
+    selected_count: int | None = None,
+    completed_count: int | None = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    init_engine_state(conn)
+    row = conn.execute(
+        """
+        SELECT workflow, run_id, mode, status, started_at, started_at_epoch,
+               completed_at, completed_at_epoch, selected_count, completed_count,
+               error, metadata_json
+        FROM engine_runs
+        WHERE workflow=? AND run_id=?
+        """,
+        (workflow, run_id),
+    ).fetchone()
+    if row is None:
+        raise KeyError(f"unknown engine run: {run_id}")
+    current = _run_row_to_dict(row)
+    merged_metadata = dict(current.get("metadata") or {})
+    if metadata:
+        merged_metadata.update(metadata)
+    final_status = str(status or "completed").strip() or "completed"
+    final_selected_count = current["selected_count"] if selected_count is None else int(selected_count or 0)
+    final_completed_count = current["completed_count"] if completed_count is None else int(completed_count or 0)
+    final_error = error if error is not None else current.get("error")
+    conn.execute(
+        """
+        UPDATE engine_runs
+           SET status=?,
+               completed_at=?,
+               completed_at_epoch=?,
+               selected_count=?,
+               completed_count=?,
+               error=?,
+               metadata_json=?
+         WHERE workflow=? AND run_id=?
+        """,
+        (
+            final_status,
+            now_iso,
+            float(now_epoch),
+            final_selected_count,
+            final_completed_count,
+            final_error,
+            _json_dumps(merged_metadata),
+            workflow,
+            run_id,
+        ),
+    )
+    return {
+        **current,
+        "status": final_status,
+        "completed_at": now_iso,
+        "completed_at_epoch": float(now_epoch),
+        "selected_count": final_selected_count,
+        "completed_count": final_completed_count,
+        "error": final_error,
+        "metadata": merged_metadata,
+    }
+
+
+def latest_engine_runs_from_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    init_engine_state(conn)
+    rows = conn.execute(
+        """
+        SELECT workflow, run_id, mode, status, started_at, started_at_epoch,
+               completed_at, completed_at_epoch, selected_count, completed_count,
+               error, metadata_json
+        FROM engine_runs
+        WHERE workflow=?
+        ORDER BY started_at_epoch DESC, run_id DESC
+        LIMIT ?
+        """,
+        (workflow, max(int(limit or 10), 1)),
+    ).fetchall()
+    return [_run_row_to_dict(row) for row in rows]
+
+
+def read_engine_runs(
+    db_path: Path,
+    *,
+    workflow: str,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    if not db_path.exists():
+        return []
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.OperationalError:
+        return []
+    try:
+        if not _table_exists(conn, "engine_runs"):
+            return []
+        rows = conn.execute(
+            """
+            SELECT workflow, run_id, mode, status, started_at, started_at_epoch,
+                   completed_at, completed_at_epoch, selected_count, completed_count,
+                   error, metadata_json
+            FROM engine_runs
+            WHERE workflow=?
+            ORDER BY started_at_epoch DESC, run_id DESC
+            LIMIT ?
+            """,
+            (workflow, max(int(limit or 10), 1)),
+        ).fetchall()
+        return [_run_row_to_dict(row) for row in rows]
+    except sqlite3.OperationalError:
+        return []
     finally:
         conn.close()

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -16,10 +16,13 @@ from .sqlite import connect_daedalus_db
 from .state import (
     ENGINE_STATE_TABLES,
     engine_state_tables_exist,
+    finish_engine_run_to_connection,
     init_engine_state,
+    latest_engine_runs_from_connection,
     load_engine_scheduler_state_from_connection,
     read_engine_scheduler_state,
     save_engine_scheduler_state_to_connection,
+    start_engine_run_to_connection,
 )
 
 
@@ -173,6 +176,105 @@ class EngineStore:
         finally:
             conn.close()
 
+    def start_run(
+        self,
+        *,
+        mode: str,
+        metadata: dict[str, Any] | None = None,
+        run_id: str | None = None,
+        selected_count: int = 0,
+        completed_count: int = 0,
+        now_iso: str | None = None,
+        now_epoch: float | None = None,
+    ) -> dict[str, Any]:
+        with self.transaction() as conn:
+            return start_engine_run_to_connection(
+                conn,
+                workflow=self.workflow,
+                mode=mode,
+                now_iso=now_iso or self._now_iso(),
+                now_epoch=self._now_epoch() if now_epoch is None else now_epoch,
+                run_id=run_id,
+                selected_count=selected_count,
+                completed_count=completed_count,
+                metadata=metadata,
+            )
+
+    def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        selected_count: int | None = None,
+        completed_count: int | None = None,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        now_iso: str | None = None,
+        now_epoch: float | None = None,
+    ) -> dict[str, Any]:
+        with self.transaction() as conn:
+            return finish_engine_run_to_connection(
+                conn,
+                workflow=self.workflow,
+                run_id=run_id,
+                status=status,
+                now_iso=now_iso or self._now_iso(),
+                now_epoch=self._now_epoch() if now_epoch is None else now_epoch,
+                selected_count=selected_count,
+                completed_count=completed_count,
+                error=error,
+                metadata=metadata,
+            )
+
+    def complete_run(
+        self,
+        run_id: str,
+        *,
+        selected_count: int | None = None,
+        completed_count: int | None = None,
+        metadata: dict[str, Any] | None = None,
+        now_iso: str | None = None,
+        now_epoch: float | None = None,
+    ) -> dict[str, Any]:
+        return self.finish_run(
+            run_id,
+            status="completed",
+            selected_count=selected_count,
+            completed_count=completed_count,
+            metadata=metadata,
+            now_iso=now_iso,
+            now_epoch=now_epoch,
+        )
+
+    def fail_run(
+        self,
+        run_id: str,
+        *,
+        error: str,
+        selected_count: int | None = None,
+        completed_count: int | None = None,
+        metadata: dict[str, Any] | None = None,
+        now_iso: str | None = None,
+        now_epoch: float | None = None,
+    ) -> dict[str, Any]:
+        return self.finish_run(
+            run_id,
+            status="failed",
+            selected_count=selected_count,
+            completed_count=completed_count,
+            error=error,
+            metadata=metadata,
+            now_iso=now_iso,
+            now_epoch=now_epoch,
+        )
+
+    def latest_runs(self, *, limit: int = 10) -> list[dict[str, Any]]:
+        conn = self.connect()
+        try:
+            return latest_engine_runs_from_connection(conn, workflow=self.workflow, limit=limit)
+        finally:
+            conn.close()
+
     def doctor(self, *, stale_running_seconds: int = 600) -> list[dict[str, Any]]:
         checks: list[dict[str, Any]] = []
         try:
@@ -229,6 +331,29 @@ class EngineStore:
                     "name": "engine-retry-queue",
                     "status": "pass",
                     "detail": f"{int(retry_count or 0)} queued retry item(s)",
+                }
+            )
+
+            stale_runs = conn.execute(
+                """
+                SELECT run_id, mode, started_at
+                FROM engine_runs
+                WHERE workflow=? AND status='running' AND completed_at IS NULL AND started_at_epoch < ?
+                ORDER BY started_at_epoch ASC
+                LIMIT 10
+                """,
+                (self.workflow, now_epoch - stale_running_seconds),
+            ).fetchall()
+            checks.append(
+                {
+                    "name": "engine-runs",
+                    "status": "warn" if stale_runs else "pass",
+                    "detail": (
+                        f"{len(stale_runs)} stale running engine run(s)"
+                        if stale_runs
+                        else "no stale running engine runs"
+                    ),
+                    "items": [row[0] for row in stale_runs],
                 }
             )
 

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from engine.leases import acquire_engine_lease, init_engine_leases, release_engine_lease
+from engine.store import EngineStore
 from engine.state import init_engine_state
 from engine.sqlite import connect_daedalus_db
 from workflows.shared.paths import (
@@ -3668,7 +3669,7 @@ def run_shadow_loop(
     }
 
 
-def run_active_iteration(
+def _run_active_iteration_body(
     *,
     workflow_root: Path,
     instance_id: str,
@@ -3762,6 +3763,65 @@ def run_active_iteration(
         "stalled_recoveries": stalled_recoveries,
         "dispatched_reap": dispatched_reap,
     }
+
+
+def run_active_iteration(
+    *,
+    workflow_root: Path,
+    instance_id: str,
+    legacy_status: dict[str, Any] | None = None,
+    now_iso: str | None = None,
+    action_runners: dict[str, Any] | None = None,
+    cancel_event: Any | None = None,
+) -> dict[str, Any]:
+    now_iso = now_iso or _now_iso()
+    engine_store = EngineStore(
+        db_path=runtime_paths(Path(workflow_root))["db_path"],
+        workflow="change-delivery",
+        now_iso=_now_iso,
+        now_epoch=time.time,
+    )
+    engine_run = engine_store.start_run(
+        mode="active-iteration",
+        metadata={"instance_id": instance_id},
+        now_iso=now_iso,
+    )
+    try:
+        result = _run_active_iteration_body(
+            workflow_root=workflow_root,
+            instance_id=instance_id,
+            legacy_status=legacy_status,
+            now_iso=now_iso,
+            action_runners=action_runners,
+            cancel_event=cancel_event,
+        )
+        ingested = result.get("ingested") or {}
+        requested_actions = result.get("requested_actions") or []
+        executed_action = result.get("executed_action")
+        final_run = engine_store.complete_run(
+            engine_run["run_id"],
+            selected_count=1 if ingested.get("lane_id") or requested_actions else 0,
+            completed_count=1 if executed_action else 0,
+            metadata={
+                "instance_id": instance_id,
+                "iteration_status": result.get("iteration_status"),
+                "reason": result.get("reason"),
+                "lane_id": ingested.get("lane_id"),
+                "action_id": (executed_action or {}).get("action_id"),
+            },
+        )
+        result["engineRun"] = final_run
+        return result
+    except Exception as exc:
+        try:
+            engine_store.fail_run(
+                engine_run["run_id"],
+                error=f"{type(exc).__name__}: {exc}",
+                metadata={"instance_id": instance_id},
+            )
+        except Exception:
+            pass
+        raise
 
 
 def _active_loop_running_snapshot(supervised_iteration: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/daedalus/watch.py
+++ b/daedalus/watch.py
@@ -79,6 +79,13 @@ def _workflow_status_panel(workflow_status: Mapping[str, Any]) -> Panel | None:
         lines.append(f"selected={workflow_status.get('selected_issue')}")
     if workflow_status.get("rate_limits"):
         lines.append(f"rate_limits={workflow_status.get('rate_limits')}")
+    for run in (workflow_status.get("latest_runs") or [])[:3]:
+        lines.append(
+            "run="
+            f"{run.get('mode') or '?'}:{run.get('status') or '?'} "
+            f"selected={run.get('selected_count') or 0} "
+            f"completed={run.get('completed_count') or 0}"
+        )
     for turn in workflow_status.get("codex_turns") or []:
         if turn.get("status") == "canceling" or turn.get("cancel_requested"):
             lines.append(

--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from engine.state import read_engine_scheduler_state
+from engine.state import read_engine_runs, read_engine_scheduler_state
 from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
 from workflows.contract import WorkflowContractError, load_workflow_contract
 
@@ -88,6 +88,14 @@ def _engine_scheduler(workflow_root: Path, workflow: str) -> dict[str, Any]:
         now_epoch=time.time(),
     )
     return payload or {}
+
+
+def _engine_runs(workflow_root: Path, workflow: str, *, limit: int = 5) -> list[dict[str, Any]]:
+    return read_engine_runs(
+        runtime_paths(Path(workflow_root))["db_path"],
+        workflow=workflow,
+        limit=limit,
+    )
 
 
 def _resolve_issue_runner_storage_path(workflow_root: Path, key: str, default: str) -> Path | None:
@@ -261,6 +269,7 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
         scheduler_payload = _engine_scheduler(workflow_root, "change-delivery")
         totals = scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {}
         codex_turns = _codex_turn_entries(scheduler_payload)
+        latest_runs = _engine_runs(workflow_root, "change-delivery")
         return {
             "workflow": "change-delivery",
             "health": None,
@@ -270,6 +279,7 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
             "canceling_count": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
             "selected_issue": None,
             "codex_turns": codex_turns,
+            "latest_runs": latest_runs,
             "total_tokens": int(totals.get("total_tokens") or 0),
             "rate_limits": totals.get("rate_limits"),
         }
@@ -282,6 +292,7 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
         "codex_totals": scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {},
     }
     last_run = status_payload.get("lastRun") or {}
+    latest_runs = _engine_runs(workflow_root, "issue-runner")
     return {
         "workflow": "issue-runner",
         "health": status_payload.get("health"),
@@ -289,6 +300,7 @@ def workflow_status(workflow_root: Path) -> dict[str, Any]:
         "running_count": len(scheduler["running"]),
         "retry_count": len(scheduler["retry_queue"]),
         "selected_issue": ((last_run.get("issue") or {}).get("identifier") or (last_run.get("issue") or {}).get("id")),
+        "latest_runs": latest_runs,
         "total_tokens": int((scheduler["codex_totals"].get("total_tokens") or 0)),
         "rate_limits": scheduler["codex_totals"].get("rate_limits"),
     }

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from engine.state import read_engine_scheduler_state
+from engine.state import read_engine_runs, read_engine_scheduler_state
 from workflows.contract import WorkflowContractError, load_workflow_contract
 from workflows.shared.paths import runtime_paths
 
@@ -212,6 +212,16 @@ def _engine_scheduler(workflow_root: Path | None, workflow: str) -> dict[str, An
     return payload or {}
 
 
+def _engine_runs(workflow_root: Path | None, workflow: str, *, limit: int = 5) -> list[dict[str, Any]]:
+    if workflow_root is None:
+        return []
+    return read_engine_runs(
+        runtime_paths(Path(workflow_root))["db_path"],
+        workflow=workflow,
+        limit=limit,
+    )
+
+
 def _epoch_to_iso(value: Any) -> str | None:
     try:
         epoch = float(value)
@@ -337,6 +347,7 @@ def _issue_runner_state_view(workflow_root: Path, events_log_path: Path) -> dict
         "counts": {"running": len(running_rows), "retrying": len(retry_rows)},
         "running": running_rows,
         "retrying": retry_rows,
+        "latest_runs": _engine_runs(workflow_root, "issue-runner"),
         "codex_totals": totals,
         "rate_limits": rate_limits,
         "recent_events": recent_events,
@@ -417,6 +428,7 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
             "running": len([entry for entry in codex_turns if entry.get("status") == "running"]),
             "canceling": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
         },
+        "latest_runs": _engine_runs(workflow_root, "change-delivery"),
         "codex_totals": {
             "input_tokens": int(codex_totals.get("input_tokens") or 0),
             "output_tokens": int(codex_totals.get("output_tokens") or 0),

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -2321,7 +2321,35 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         return ns.dispatch_repair_handoff_raw()
 
     def tick():
-        return ns.tick_raw()
+        engine_run = ns.ENGINE_STORE.start_run(mode="tick")
+        try:
+            result = ns.tick_raw()
+            action = result.get("action") if isinstance(result, dict) else {}
+            executed = result.get("executed") if isinstance(result, dict) else None
+            action_type = (action or {}).get("type")
+            completed = 1 if executed is not None else 0
+            final_run = ns.ENGINE_STORE.complete_run(
+                engine_run["run_id"],
+                selected_count=1 if action_type and action_type != "noop" else 0,
+                completed_count=completed,
+                metadata={
+                    "action_type": action_type,
+                    "reason": (action or {}).get("reason"),
+                    "executed": executed is not None,
+                },
+            )
+            if isinstance(result, dict):
+                result["engineRun"] = final_run
+            return result
+        except Exception as exc:
+            try:
+                ns.ENGINE_STORE.fail_run(
+                    engine_run["run_id"],
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            except Exception:
+                pass
+            raise
 
     def dispatch_implementation_turn():
         return ns.dispatch_implementation_turn_raw()

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -522,6 +522,49 @@ class IssueRunnerWorkspace(WorkflowDriver):
             ),
         )
 
+    def _finish_engine_run_for_status(
+        self,
+        engine_run: dict[str, Any],
+        status: dict[str, Any],
+        *,
+        selected_count: int | None = None,
+        completed_count: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        selected = status.get("selectedIssues") or []
+        completed = status.get("completedResults") or status.get("results") or []
+        final_selected_count = len(selected) if selected_count is None else selected_count
+        final_completed_count = len(completed) if completed_count is None else completed_count
+        run_metadata = {
+            "status_mode": status.get("mode") or "tick",
+            **(metadata or {}),
+        }
+        if status.get("message"):
+            run_metadata["message"] = status.get("message")
+        if status.get("ok"):
+            return self.engine_store.complete_run(
+                engine_run["run_id"],
+                selected_count=final_selected_count,
+                completed_count=final_completed_count,
+                metadata=run_metadata,
+            )
+        return self.engine_store.fail_run(
+            engine_run["run_id"],
+            error=str(status.get("error") or "workflow run reported failure"),
+            selected_count=final_selected_count,
+            completed_count=final_completed_count,
+            metadata=run_metadata,
+        )
+
+    def _fail_engine_run_after_exception(self, engine_run: dict[str, Any], exc: Exception) -> None:
+        try:
+            self.engine_store.fail_run(
+                engine_run["run_id"],
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        except Exception:
+            pass
+
     def _restore_scheduler_state(self) -> None:
         payload = self._load_scheduler_state()
         restored = restore_scheduler_state(payload, now_epoch=_now_epoch())
@@ -1210,6 +1253,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         return dispatched
 
     def supervise_once(self) -> dict[str, Any]:
+        engine_run = self.engine_store.start_run(mode="supervised")
         status = {
             "ok": True,
             "workflow": "issue-runner",
@@ -1226,79 +1270,117 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "cancellationRequests": [],
         }
         try:
-            issues = self.tracker_client.list_all()
-            terminal_issues = self.tracker_client.list_terminal()
-        except Exception as exc:
-            status["ok"] = False
-            status["error"] = f"{type(exc).__name__}: {exc}"
-            self._write_status(status, health="error")
-            self._emit_event(
-                "issue_runner.tick.failed",
-                {
-                    "error": status["error"],
-                    "reason": "tracker-load-failed",
+            try:
+                issues = self.tracker_client.list_all()
+                terminal_issues = self.tracker_client.list_terminal()
+            except Exception as exc:
+                status["ok"] = False
+                status["error"] = f"{type(exc).__name__}: {exc}"
+                status["engineRun"] = self._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "tracker-load-failed"},
+                )
+                self._write_status(status, health="error")
+                self._emit_event(
+                    "issue_runner.tick.failed",
+                    {
+                        "error": status["error"],
+                        "reason": "tracker-load-failed",
+                    },
+                )
+                return status
+
+            status["cancellationRequests"] = self._request_terminal_cancellations(terminal_issues)
+            completed = self._reconcile_supervised_workers()
+            if completed:
+                status = self._status_from_results(base_status=status, results=completed)
+                status["completedResults"] = status.get("results") or []
+            cleanup = self._cleanup_terminal_workspaces(terminal_issues)
+            status["cleanup"] = cleanup
+
+            issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
+            selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
+            refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+            for selected, retry_entry in selections:
+                issue_id = str(selected.get("id") or "").strip()
+                if issue_id:
+                    selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
+                refreshed_selections.append((selected, retry_entry))
+            selections = refreshed_selections
+            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
+            status["selectedIssue"] = selections[0][0] if selections else None
+            dispatched = self._dispatch_supervised_workers(selections)
+            status["dispatchedWorkers"] = dispatched
+            if not completed and not dispatched:
+                status["message"] = "no dispatchable issues"
+                self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
+
+            if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
+                status["ok"] = False
+            status["engineRun"] = self._finish_engine_run_for_status(
+                engine_run,
+                status,
+                metadata={
+                    "dispatched_count": len(dispatched),
+                    "cancellation_count": len(status.get("cancellationRequests") or []),
                 },
             )
+            self._write_status(status, health="healthy" if status["ok"] else "error")
+            self._persist_scheduler_state()
             return status
-
-        status["cancellationRequests"] = self._request_terminal_cancellations(terminal_issues)
-        completed = self._reconcile_supervised_workers()
-        if completed:
-            status = self._status_from_results(base_status=status, results=completed)
-            status["completedResults"] = status.get("results") or []
-        cleanup = self._cleanup_terminal_workspaces(terminal_issues)
-        status["cleanup"] = cleanup
-
-        issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
-        selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
-        refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
-        for selected, retry_entry in selections:
-            issue_id = str(selected.get("id") or "").strip()
-            if issue_id:
-                selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
-            refreshed_selections.append((selected, retry_entry))
-        selections = refreshed_selections
-        status["selectedIssues"] = [issue for issue, _retry_entry in selections]
-        status["selectedIssue"] = selections[0][0] if selections else None
-        dispatched = self._dispatch_supervised_workers(selections)
-        status["dispatchedWorkers"] = dispatched
-        if not completed and not dispatched:
-            status["message"] = "no dispatchable issues"
-            self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
-
-        if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
-            status["ok"] = False
-        self._write_status(status, health="healthy" if status["ok"] else "error")
-        self._persist_scheduler_state()
-        return status
+        except Exception as exc:
+            self._fail_engine_run_after_exception(engine_run, exc)
+            raise
 
     def _reconcile_before_loop_exit(self, last_result: dict[str, Any] | None) -> dict[str, Any] | None:
-        completed = self._reconcile_supervised_workers()
-        if not completed:
+        engine_run = self.engine_store.start_run(mode="supervised-exit-reconcile")
+        try:
+            completed = self._reconcile_supervised_workers()
+            if not completed:
+                self._persist_scheduler_state()
+                self.engine_store.complete_run(
+                    engine_run["run_id"],
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"changed": False},
+                )
+                return last_result
+            status = {
+                "ok": True,
+                "workflow": "issue-runner",
+                "mode": "supervised-exit-reconcile",
+                "updatedAt": _now_iso(),
+                "selectedIssue": None,
+                "selectedIssues": [],
+                "attempt": None,
+                "outputPath": None,
+                "metrics": {},
+                "results": [],
+                "completedResults": [],
+                "dispatchedWorkers": [],
+                "cancellationRequests": [],
+            }
+            status = self._status_from_results(base_status=status, results=completed)
+            status["completedResults"] = status.get("results") or []
+            status["engineRun"] = self._finish_engine_run_for_status(
+                engine_run,
+                status,
+                selected_count=0,
+                completed_count=len(completed),
+                metadata={"changed": True},
+            )
+            self._write_status(status, health="healthy" if status["ok"] else "error")
             self._persist_scheduler_state()
-            return last_result
-        status = {
-            "ok": True,
-            "workflow": "issue-runner",
-            "mode": "supervised-exit-reconcile",
-            "updatedAt": _now_iso(),
-            "selectedIssue": None,
-            "selectedIssues": [],
-            "attempt": None,
-            "outputPath": None,
-            "metrics": {},
-            "results": [],
-            "completedResults": [],
-            "dispatchedWorkers": [],
-            "cancellationRequests": [],
-        }
-        status = self._status_from_results(base_status=status, results=completed)
-        status["completedResults"] = status.get("results") or []
-        self._write_status(status, health="healthy" if status["ok"] else "error")
-        self._persist_scheduler_state()
-        return status
+            return status
+        except Exception as exc:
+            self._fail_engine_run_after_exception(engine_run, exc)
+            raise
 
     def tick(self) -> dict[str, Any]:
+        engine_run = self.engine_store.start_run(mode="tick")
         status = {
             "ok": False,
             "workflow": "issue-runner",
@@ -1309,62 +1391,85 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "outputPath": None,
             "metrics": {},
         }
-        tracker_cfg = self.config.get("tracker") or {}
         try:
-            issues = self.tracker_client.list_all()
-            cleanup = self._cleanup_terminal_workspaces(self.tracker_client.list_terminal())
+            try:
+                issues = self.tracker_client.list_all()
+                cleanup = self._cleanup_terminal_workspaces(self.tracker_client.list_terminal())
+            except Exception as exc:
+                status["error"] = f"{type(exc).__name__}: {exc}"
+                status["engineRun"] = self._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "tracker-load-failed"},
+                )
+                self._write_status(status, health="error")
+                self._emit_event(
+                    "issue_runner.tick.failed",
+                    {
+                        "error": status["error"],
+                        "reason": "tracker-load-failed",
+                    },
+                )
+                return status
+            issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
+            selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
+            refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+            for selected, retry_entry in selections:
+                issue_id = str(selected.get("id") or "").strip()
+                if issue_id:
+                    selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
+                refreshed_selections.append((selected, retry_entry))
+            selections = refreshed_selections
+            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
+            status["selectedIssue"] = selections[0][0] if selections else None
+            status["cleanup"] = cleanup
+            if not selections:
+                status["ok"] = True
+                status["message"] = "no dispatchable issues"
+                status["engineRun"] = self._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "no-dispatchable-issues"},
+                )
+                self._write_status(status, health="healthy")
+                self._persist_scheduler_state()
+                self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
+                return status
+
+            self._mark_running(selections)
+            results: list[dict[str, Any]] = []
+            try:
+                if len(selections) == 1:
+                    issue, retry_entry = selections[0]
+                    results = [self._execute_issue(issue=issue, retry_entry=retry_entry)]
+                else:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=len(selections)) as executor:
+                        future_map = {
+                            executor.submit(self._execute_issue, issue=issue, retry_entry=retry_entry): (issue, retry_entry)
+                            for issue, retry_entry in selections
+                        }
+                        for future in concurrent.futures.as_completed(future_map):
+                            results.append(future.result())
+
+                status = self._status_from_results(base_status=status, results=results)
+                status["engineRun"] = self._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=len(selections),
+                    completed_count=len(results),
+                )
+                self._write_status(status, health="healthy" if status["ok"] else "error")
+                return status
+            finally:
+                self._clear_running([str(issue.get("id") or "") for issue, _retry_entry in selections])
+                self._persist_scheduler_state()
         except Exception as exc:
-            status["error"] = f"{type(exc).__name__}: {exc}"
-            self._write_status(status, health="error")
-            self._emit_event(
-                "issue_runner.tick.failed",
-                {
-                    "error": status["error"],
-                    "reason": "tracker-load-failed",
-                },
-            )
-            return status
-        issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
-        selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
-        refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
-        for selected, retry_entry in selections:
-            issue_id = str(selected.get("id") or "").strip()
-            if issue_id:
-                selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
-            refreshed_selections.append((selected, retry_entry))
-        selections = refreshed_selections
-        status["selectedIssues"] = [issue for issue, _retry_entry in selections]
-        status["selectedIssue"] = selections[0][0] if selections else None
-        status["cleanup"] = cleanup
-        if not selections:
-            status["ok"] = True
-            status["message"] = "no dispatchable issues"
-            self._write_status(status, health="healthy")
-            self._persist_scheduler_state()
-            self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
-            return status
-
-        self._mark_running(selections)
-        results: list[dict[str, Any]] = []
-        try:
-            if len(selections) == 1:
-                issue, retry_entry = selections[0]
-                results = [self._execute_issue(issue=issue, retry_entry=retry_entry)]
-            else:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=len(selections)) as executor:
-                    future_map = {
-                        executor.submit(self._execute_issue, issue=issue, retry_entry=retry_entry): (issue, retry_entry)
-                        for issue, retry_entry in selections
-                    }
-                    for future in concurrent.futures.as_completed(future_map):
-                        results.append(future.result())
-
-            status = self._status_from_results(base_status=status, results=results)
-            self._write_status(status, health="healthy" if status["ok"] else "error")
-            return status
-        finally:
-            self._clear_running([str(issue.get("id") or "") for issue, _retry_entry in selections])
-            self._persist_scheduler_state()
+            self._fail_engine_run_after_exception(engine_run, exc)
+            raise
 
     def _cleanup_terminal_workspaces(self, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
         tracker_cfg = self.config.get("tracker") or {}

--- a/tests/test_daedalus_watch_render.py
+++ b/tests/test_daedalus_watch_render.py
@@ -85,6 +85,7 @@ def test_render_frame_includes_issue_runner_workflow_status():
             "total_tokens": 18,
             "rate_limits": {"requests_remaining": 88},
             "selected_issue": "#123",
+            "latest_runs": [{"mode": "tick", "status": "completed", "selected_count": 1, "completed_count": 1}],
             "updated_at": "2026-04-30T12:00:15Z",
         },
         "alert_state": {},
@@ -94,6 +95,7 @@ def test_render_frame_includes_issue_runner_workflow_status():
     assert "issue-runner" in out
     assert "tokens=18" in out
     assert "selected=#123" in out
+    assert "run=tick:completed selected=1 completed=1" in out
 
 
 def test_render_frame_includes_canceling_codex_turns():

--- a/tests/test_daedalus_watch_sources.py
+++ b/tests/test_daedalus_watch_sources.py
@@ -122,10 +122,12 @@ def test_read_alert_state_when_present(tmp_path):
 
 def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     from engine.state import save_engine_scheduler_state
+    from engine.store import EngineStore
     from workflows.contract import render_workflow_markdown
 
     sources = _module()
     root = _make_workflow_root(tmp_path)
+    db_path = root / "runtime" / "state" / "daedalus" / "daedalus.db"
     (root / "WORKFLOW.md").write_text(
         render_workflow_markdown(
             config={
@@ -152,7 +154,7 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
         json.dumps({"workflow": "issue-runner", "health": "healthy", "lastRun": {"updatedAt": "2026-04-30T12:00:15Z"}})
     )
     save_engine_scheduler_state(
-        root / "runtime" / "state" / "daedalus" / "daedalus.db",
+        db_path,
         workflow="issue-runner",
         running_entries={"123": {"issue_id": "123", "identifier": "#123", "state": "open"}},
         retry_entries={"124": {"issue_id": "124", "identifier": "#124", "error": "x", "due_at_epoch": 1714478410.0}},
@@ -161,6 +163,14 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478400.0,
     )
+    engine_store = EngineStore(
+        db_path=db_path,
+        workflow="issue-runner",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    engine_run = engine_store.start_run(mode="tick")
+    engine_store.complete_run(engine_run["run_id"], selected_count=1, completed_count=1)
     (root / "memory" / "workflow-audit.jsonl").write_text(
         json.dumps({"at": "2026-04-30T12:00:20Z", "event": "issue_runner.tick.completed", "issue_id": "123"}) + "\n"
     )
@@ -177,14 +187,18 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     assert workflow_status["running_count"] == 1
     assert workflow_status["retry_count"] == 1
     assert workflow_status["total_tokens"] == 18
+    assert workflow_status["latest_runs"][0]["mode"] == "tick"
+    assert workflow_status["latest_runs"][0]["selected_count"] == 1
 
 
 def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
     from engine.state import save_engine_scheduler_state
+    from engine.store import EngineStore
     from workflows.contract import render_workflow_markdown
 
     sources = _module()
     root = _make_workflow_root(tmp_path)
+    db_path = root / "runtime" / "state" / "daedalus" / "daedalus.db"
     (root / "WORKFLOW.md").write_text(
         render_workflow_markdown(
             config={
@@ -204,7 +218,7 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
     )
     (root / "memory").mkdir(exist_ok=True)
     save_engine_scheduler_state(
-        root / "runtime" / "state" / "daedalus" / "daedalus.db",
+        db_path,
         workflow="change-delivery",
         running_entries={},
         retry_entries={},
@@ -224,6 +238,14 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478420.0,
     )
+    engine_store = EngineStore(
+        db_path=db_path,
+        workflow="change-delivery",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    engine_run = engine_store.start_run(mode="active-iteration")
+    engine_store.complete_run(engine_run["run_id"], selected_count=1, completed_count=0)
 
     workflow_status = sources.workflow_status(root)
 
@@ -234,3 +256,4 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
     assert workflow_status["codex_turns"][0]["thread_id"] == "thread-42"
     assert workflow_status["codex_turns"][0]["turn_id"] == "turn-42"
     assert workflow_status["codex_turns"][0]["cancel_reason"] == "operator-interrupt"
+    assert workflow_status["latest_runs"][0]["mode"] == "active-iteration"

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -281,7 +281,42 @@ def test_engine_store_wraps_scheduler_state_and_doctor(tmp_path):
     assert checks["engine-schema"]["status"] == "pass"
     assert checks["engine-running-work"]["status"] == "pass"
     assert checks["engine-retry-queue"]["detail"] == "0 queued retry item(s)"
+    assert checks["engine-runs"]["status"] == "pass"
     assert checks["engine-runtime-sessions"]["status"] == "pass"
+
+
+def test_engine_store_tracks_run_ledger_and_stale_runs(tmp_path):
+    from engine.store import EngineStore
+
+    clock = {"iso": "2026-04-30T00:00:00Z", "epoch": 100.0}
+    store = EngineStore(
+        db_path=tmp_path / "runtime" / "state" / "daedalus.db",
+        workflow="issue-runner",
+        now_iso=lambda: clock["iso"],
+        now_epoch=lambda: clock["epoch"],
+    )
+
+    first = store.start_run(mode="tick", metadata={"source": "test"})
+    clock.update({"iso": "2026-04-30T00:00:05Z", "epoch": 105.0})
+    completed = store.complete_run(
+        first["run_id"],
+        selected_count=2,
+        completed_count=2,
+        metadata={"result": "ok"},
+    )
+    stale = store.start_run(mode="supervised")
+    clock.update({"iso": "2026-04-30T00:20:00Z", "epoch": 1300.0})
+
+    latest = store.latest_runs(limit=5)
+    checks = {check["name"]: check for check in store.doctor(stale_running_seconds=60)}
+
+    assert completed["status"] == "completed"
+    assert completed["metadata"] == {"source": "test", "result": "ok"}
+    assert latest[0]["run_id"] == stale["run_id"]
+    assert latest[0]["status"] == "running"
+    assert latest[1]["completed_count"] == 2
+    assert checks["engine-runs"]["status"] == "warn"
+    assert stale["run_id"] in checks["engine-runs"]["items"]
 
 
 def test_engine_store_lease_lifecycle_and_stale_status(tmp_path):

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -109,6 +109,7 @@ def _make_events_log(events_path: Path, entries: list[dict]) -> None:
 
 def _make_issue_runner_root(root: Path) -> None:
     from engine.state import save_engine_scheduler_state
+    from engine.store import EngineStore
     from workflows.contract import render_workflow_markdown
     from workflows.shared.paths import runtime_paths
 
@@ -187,6 +188,14 @@ def _make_issue_runner_root(root: Path) -> None:
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478415.0,
     )
+    engine_store = EngineStore(
+        db_path=runtime_paths(root)["db_path"],
+        workflow="issue-runner",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    engine_run = engine_store.start_run(mode="tick")
+    engine_store.complete_run(engine_run["run_id"], selected_count=1, completed_count=1)
     _make_events_log(
         root / "memory" / "workflow-audit.jsonl",
         [
@@ -198,6 +207,7 @@ def _make_issue_runner_root(root: Path) -> None:
 
 def _make_change_delivery_root(root: Path) -> None:
     from engine.state import save_engine_scheduler_state
+    from engine.store import EngineStore
     from workflows.contract import render_workflow_markdown
     from workflows.shared.paths import runtime_paths
 
@@ -261,6 +271,14 @@ def _make_change_delivery_root(root: Path) -> None:
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478420.0,
     )
+    engine_store = EngineStore(
+        db_path=runtime_paths(root)["db_path"],
+        workflow="change-delivery",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    engine_run = engine_store.start_run(mode="active-iteration")
+    engine_store.complete_run(engine_run["run_id"], selected_count=1, completed_count=0)
 
 
 # --------------------------------------------------------------------- views
@@ -345,6 +363,7 @@ def test_issue_runner_state_view_reads_scheduler_and_audit_files(tmp_path: Path)
     assert view["counts"] == {"running": 1, "retrying": 1}
     assert view["running"][0]["issue_identifier"] == "#123"
     assert view["retrying"][0]["issue_identifier"] == "#124"
+    assert view["latest_runs"][0]["mode"] == "tick"
     assert view["codex_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
     assert view["recent_events"][0]["event"] == "issue_runner.tick.completed"
@@ -366,6 +385,7 @@ def test_change_delivery_state_view_reads_codex_scheduler_totals(tmp_path: Path)
     assert view["codex_turn_counts"] == {"running": 0, "canceling": 1}
     assert view["codex_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
+    assert view["latest_runs"][0]["mode"] == "active-iteration"
     assert view["codex_turns"][0]["issue_id"] == "lane:42"
     assert view["codex_turns"][0]["thread_id"] == "thread-42"
     assert view["codex_turns"][0]["turn_id"] == "turn-42"

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -238,6 +238,9 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     result = workspace.tick()
 
     assert result["ok"] is True
+    assert result["engineRun"]["mode"] == "tick"
+    assert result["engineRun"]["status"] == "completed"
+    assert workspace.engine_store.latest_runs(limit=1)[0]["run_id"] == result["engineRun"]["run_id"]
     assert result["selectedIssue"]["id"] == "ISSUE-1"
     assert result["results"][0]["retry"]["delay_type"] == "continuation"
     assert result["results"][0]["retry"]["delay_ms"] == 1000
@@ -703,6 +706,8 @@ def test_issue_runner_supervise_once_dispatches_and_reconciles_worker(tmp_path):
 
     assert dispatched["ok"] is True
     assert dispatched["mode"] == "supervised"
+    assert dispatched["engineRun"]["mode"] == "supervised"
+    assert dispatched["engineRun"]["selected_count"] == 1
     assert dispatched["dispatchedWorkers"][0]["issue_id"] == "ISSUE-1"
     assert started.wait(timeout=2)
     running = workspace.build_status()["scheduler"]["running"]
@@ -719,6 +724,8 @@ def test_issue_runner_supervise_once_dispatches_and_reconciles_worker(tmp_path):
         time.sleep(0.01)
 
     assert completed is not None
+    assert completed["engineRun"]["mode"] == "supervised"
+    assert completed["engineRun"]["completed_count"] == 1
     assert completed["completedResults"][0]["ok"] is True
     assert workspace.build_status()["scheduler"]["running"] == []
     assert workspace.build_status()["scheduler"]["retry_queue"][0]["error"] == "continuation"


### PR DESCRIPTION
## Summary

Adds an engine-owned run ledger so Daedalus records each workflow execution in shared SQLite state instead of relying only on workflow-specific status files.

## Changes

- Add the shared `engine_runs` table and `EngineStore` APIs for starting, completing, failing, and listing runs.
- Instrument issue-runner ticks, supervised ticks, exit reconciliation, change-delivery ticks, and active runtime iterations.
- Surface recent runs in `/daedalus watch` and HTTP `state_view` responses.
- Extend `doctor` with stale in-progress run diagnostics.
- Add coverage for run-ledger primitives, watch/status visibility, and issue-runner instrumentation.

## Impact

Operators can now see a durable run history for both workflows and diagnose stale or failed engine runs from shared engine state.

## Validation

- `git diff --check`
- `pytest -q` -> `841 passed, 8 skipped`