### PR TITLE
[codex] Correlate engine runs with workflow activity

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import yaml
 
-from engine.state import read_engine_scheduler_state
+from engine.state import read_engine_run, read_engine_runs, read_engine_scheduler_state
 from engine.store import EngineStore
 from workflows.contract import (
     WorkflowContractError,
@@ -538,6 +538,113 @@ def _build_issue_runner_status(workflow_root: Path) -> dict[str, Any]:
 
 def _build_issue_runner_doctor(workflow_root: Path) -> dict[str, Any]:
     return _load_issue_runner_workspace(workflow_root).doctor()
+
+
+def _run_event_id(event: dict[str, Any]) -> str | None:
+    value = event.get("run_id") or event.get("runId")
+    return str(value) if value not in (None, "") else None
+
+
+def _workflow_audit_path(workflow_root: Path, workflow_name: str) -> Path:
+    paths = runtime_paths(workflow_root)
+    if workflow_name != "issue-runner":
+        return paths["event_log_path"].parent / "workflow-audit.jsonl"
+    contract = load_workflow_contract(workflow_root)
+    storage_cfg = contract.config.get("storage") or {}
+    raw = str(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl").strip()
+    path = Path(raw).expanduser()
+    return path if path.is_absolute() else (workflow_root / path).resolve()
+
+
+def _read_jsonl_events(path: Path, *, limit: int = 500) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    events: list[dict[str, Any]] = []
+    for line in lines[-limit:]:
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def _run_timeline_for_cli(workflow_root: Path, workflow_name: str, run_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+    paths = runtime_paths(workflow_root)
+    source_paths = [paths["event_log_path"], _workflow_audit_path(workflow_root, workflow_name)]
+    timeline: list[dict[str, Any]] = []
+    for path in dict.fromkeys(source_paths):
+        for event in _read_jsonl_events(path, limit=max(limit * 5, limit)):
+            if _run_event_id(event) == run_id:
+                timeline.append({**event, "source_path": str(path)})
+    timeline.sort(key=lambda item: str(item.get("at") or item.get("created_at") or item.get("time") or ""))
+    return timeline[-limit:]
+
+
+def build_runs_report(
+    *,
+    workflow_root: Path,
+    action: str = "list",
+    run_id: str | None = None,
+    limit: int = 20,
+    stale_seconds: int = 600,
+) -> dict[str, Any]:
+    workflow_root = Path(workflow_root).resolve()
+    workflow_name = _workflow_name_for_root(workflow_root)
+    db_path = runtime_paths(workflow_root)["db_path"]
+    now_epoch = time.time()
+    if action == "show":
+        if not run_id:
+            raise DaedalusCommandError("runs show requires a run_id")
+        run = read_engine_run(db_path, workflow=workflow_name, run_id=run_id)
+        if run is None:
+            raise DaedalusCommandError(f"unknown engine run: {run_id}")
+        age_seconds = max(int(now_epoch - float(run.get("started_at_epoch") or now_epoch)), 0)
+        return {
+            "mode": "show",
+            "workflow": workflow_name,
+            "run": {
+                **run,
+                "age_seconds": age_seconds,
+                "stale": run.get("status") == "running" and age_seconds > stale_seconds,
+            },
+            "timeline": _run_timeline_for_cli(workflow_root, workflow_name, run_id, limit=max(limit, 1)),
+        }
+
+    runs = read_engine_runs(db_path, workflow=workflow_name, limit=max(limit, 1) * 5)
+    enriched = []
+    for run in runs:
+        age_seconds = max(int(now_epoch - float(run.get("started_at_epoch") or now_epoch)), 0)
+        item = {
+            **run,
+            "age_seconds": age_seconds,
+            "stale": run.get("status") == "running" and age_seconds > stale_seconds,
+        }
+        if action == "failed" and item.get("status") != "failed":
+            continue
+        if action == "stale" and not item.get("stale"):
+            continue
+        enriched.append(item)
+        if len(enriched) >= limit:
+            break
+    return {
+        "mode": action,
+        "workflow": workflow_name,
+        "counts": {
+            "shown": len(enriched),
+            "failed": len([run for run in enriched if run.get("status") == "failed"]),
+            "running": len([run for run in enriched if run.get("status") == "running"]),
+            "stale": len([run for run in enriched if run.get("stale")]),
+        },
+        "runs": enriched,
+    }
 
 
 def service_loop(
@@ -2697,6 +2804,21 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     )
     doctor_cmd.set_defaults(func=run_cli_command)
 
+    runs_cmd = sub.add_parser("runs", help="Inspect durable engine run history and run timelines.")
+    runs_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    runs_cmd.add_argument("runs_action", nargs="?", default="list", choices=["list", "failed", "stale", "show"])
+    runs_cmd.add_argument("run_id", nargs="?")
+    runs_cmd.add_argument("--limit", type=int, default=20)
+    runs_cmd.add_argument("--stale-seconds", type=int, default=600)
+    runs_cmd.add_argument("--json", action="store_true")
+    runs_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    runs_cmd.set_defaults(func=run_cli_command)
+
     service_install_cmd = sub.add_parser("service-install", help="Install the supervised Daedalus systemd user service.")
     service_install_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     service_install_cmd.add_argument("--project-key")
@@ -3124,7 +3246,7 @@ def _resolve_format(format_arg: str | None, json_flag: bool | None) -> str:
 def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     workflow_root = Path(args.workflow_root).resolve() if hasattr(args, "workflow_root") else None
     daedalus = _load_daedalus_module(workflow_root) if workflow_root is not None else None
-    eventless_commands = {"codex-app-server"}
+    eventless_commands = {"codex-app-server", "runs"}
     if (
         workflow_root is not None
         and daedalus is not None
@@ -3171,6 +3293,14 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
         return build_doctor_report(
             workflow_root=workflow_root,
             recent_actions_limit=args.recent_actions_limit,
+        )
+    if args.daedalus_command == "runs":
+        return build_runs_report(
+            workflow_root=workflow_root,
+            action=args.runs_action,
+            run_id=args.run_id,
+            limit=args.limit,
+            stale_seconds=args.stale_seconds,
         )
     if args.daedalus_command == "service-install":
         return install_supervised_service(
@@ -3442,6 +3572,37 @@ def render_result(
             spec.loader.exec_module(mod)
             _fmt = mod.format_doctor
         return _fmt(result)
+    if command == "runs":
+        if result.get("mode") == "show":
+            run = result.get("run") or {}
+            lines = [
+                f"run={run.get('run_id')}",
+                f"workflow={result.get('workflow')} mode={run.get('mode')} status={run.get('status')}",
+                f"started_at={run.get('started_at')} completed_at={run.get('completed_at')}",
+                f"selected={run.get('selected_count')} completed={run.get('completed_count')} age_seconds={run.get('age_seconds')}",
+            ]
+            if run.get("error"):
+                lines.append(f"error={run.get('error')}")
+            timeline = result.get("timeline") or []
+            lines.append(f"timeline_events={len(timeline)}")
+            for event in timeline[:10]:
+                kind = event.get("event") or event.get("action") or event.get("event_type") or "event"
+                at = event.get("at") or event.get("created_at") or event.get("time") or ""
+                detail = event.get("summary") or event.get("error") or event.get("reason") or ""
+                lines.append(f"- {at} {kind} {detail}".strip())
+            return "\n".join(lines)
+        runs = result.get("runs") or []
+        if not runs:
+            return f"workflow={result.get('workflow')} runs=0 mode={result.get('mode')}"
+        lines = [f"workflow={result.get('workflow')} mode={result.get('mode')} runs={len(runs)}"]
+        for run in runs:
+            stale = " stale=true" if run.get("stale") else ""
+            lines.append(
+                f"- {run.get('run_id')} {run.get('mode')} {run.get('status')} "
+                f"selected={run.get('selected_count')} completed={run.get('completed_count')} "
+                f"started={run.get('started_at')}{stale}"
+            )
+        return "\n".join(lines)
     if command == "service-install":
         return f"service installed mode={result.get('service_mode')} unit={result.get('unit_path')} ok={result.get('installed')}"
     if command == "service-up":

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -30,11 +30,13 @@ from .scheduler import (
 )
 from .sqlite import connect_daedalus_db
 from .state import (
+    engine_run_from_connection,
     engine_state_tables_exist,
     finish_engine_run_to_connection,
     init_engine_state,
     latest_engine_runs_from_connection,
     load_engine_scheduler_state,
+    read_engine_run,
     read_engine_runs,
     read_engine_scheduler_state,
     save_engine_scheduler_state,
@@ -66,6 +68,7 @@ __all__ = [
     "clear_work_entries",
     "codex_threads_snapshot",
     "connect_daedalus_db",
+    "engine_run_from_connection",
     "engine_state_tables_exist",
     "finish_engine_run_to_connection",
     "init_engine_state",
@@ -76,6 +79,7 @@ __all__ = [
     "mark_running_work",
     "make_audit_fn",
     "read_engine_lease",
+    "read_engine_run",
     "read_engine_runs",
     "read_engine_scheduler_state",
     "recover_running_as_retry",

--- a/daedalus/engine/lifecycle.py
+++ b/daedalus/engine/lifecycle.py
@@ -95,5 +95,6 @@ def recover_running_as_retry(
             "error": error,
             "due_at_epoch": now_epoch,
             "current_attempt": running.get("attempt"),
+            "run_id": running.get("run_id") or running.get("runId"),
         }
     return entries

--- a/daedalus/engine/scheduler.py
+++ b/daedalus/engine/scheduler.py
@@ -46,6 +46,7 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
             "error": item.get("error"),
             "due_at_epoch": float(item.get("due_at_epoch") or item.get("dueAtEpoch") or now_epoch),
             "current_attempt": item.get("current_attempt") or item.get("currentAttempt"),
+            "run_id": item.get("run_id") or item.get("runId"),
         }
 
     recovered_running: list[dict[str, Any]] = []
@@ -72,6 +73,7 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
                 ),
                 "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
                 "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
+                "run_id": item.get("run_id") or item.get("runId"),
             }
         )
 
@@ -108,6 +110,7 @@ def running_snapshot(
                 "cancel_reason": entry.get("cancel_reason"),
                 "thread_id": entry.get("thread_id"),
                 "turn_id": entry.get("turn_id"),
+                "run_id": entry.get("run_id") or entry.get("runId"),
             }
         )
     running.sort(key=lambda item: (item["state"] or "", item["identifier"] or item["issue_id"]))
@@ -130,6 +133,7 @@ def retry_queue_snapshot(
                 "error": entry.get("error"),
                 "due_at_epoch": due_at,
                 "due_in_ms": max(int((due_at - now_epoch) * 1000), 0),
+                "run_id": entry.get("run_id") or entry.get("runId"),
             }
         )
     entries.sort(key=lambda item: (item["due_in_ms"], item["attempt"], item["identifier"] or item["issue_id"]))
@@ -153,6 +157,7 @@ def restore_codex_threads(raw: Any) -> dict[str, dict[str, Any]]:
             "session_name": item.get("session_name"),
             "thread_id": thread_id,
             "turn_id": item.get("turn_id"),
+            "run_id": item.get("run_id") or item.get("runId"),
             "updated_at": item.get("updated_at"),
         }
     return restored

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -51,6 +51,20 @@ def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
     return bool(row)
 
 
+def _column_exists(conn: sqlite3.Connection, table_name: str, column_name: str) -> bool:
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    except sqlite3.OperationalError:
+        return False
+    return any(str(row[1]) == column_name for row in rows)
+
+
+def _ensure_column(conn: sqlite3.Connection, table_name: str, column_sql: str) -> None:
+    column_name = column_sql.split()[0]
+    if _table_exists(conn, table_name) and not _column_exists(conn, table_name, column_name):
+        conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_sql}")
+
+
 def engine_state_tables_exist(conn: sqlite3.Connection) -> bool:
     return all(_table_exists(conn, name) for name in ENGINE_STATE_TABLES)
 
@@ -90,6 +104,7 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           cancel_reason TEXT,
           thread_id TEXT,
           turn_id TEXT,
+          run_id TEXT,
           updated_at TEXT NOT NULL,
           updated_at_epoch REAL NOT NULL,
           PRIMARY KEY (workflow, work_id),
@@ -104,6 +119,7 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           error TEXT,
           current_attempt INTEGER,
           delay_type TEXT NOT NULL DEFAULT 'failure',
+          run_id TEXT,
           updated_at TEXT NOT NULL,
           updated_at_epoch REAL NOT NULL,
           PRIMARY KEY (workflow, work_id),
@@ -122,6 +138,7 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           status TEXT,
           cancel_requested INTEGER NOT NULL DEFAULT 0,
           cancel_reason TEXT,
+          run_id TEXT,
           metadata_json TEXT,
           updated_at TEXT NOT NULL,
           updated_at_epoch REAL NOT NULL,
@@ -165,6 +182,19 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           ON engine_runs(workflow, started_at_epoch);
         CREATE INDEX IF NOT EXISTS idx_engine_runs_workflow_status
           ON engine_runs(workflow, status);
+        """
+    )
+    _ensure_column(conn, "engine_running_work", "run_id TEXT")
+    _ensure_column(conn, "engine_retry_queue", "run_id TEXT")
+    _ensure_column(conn, "engine_runtime_sessions", "run_id TEXT")
+    conn.executescript(
+        """
+        CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_run
+          ON engine_running_work(workflow, run_id);
+        CREATE INDEX IF NOT EXISTS idx_engine_retry_workflow_run
+          ON engine_retry_queue(workflow, run_id);
+        CREATE INDEX IF NOT EXISTS idx_engine_runtime_sessions_run
+          ON engine_runtime_sessions(workflow, run_id);
         """
     )
 
@@ -257,8 +287,8 @@ def save_engine_scheduler_state_to_connection(
             """
             INSERT INTO engine_running_work (
               workflow, work_id, worker_id, attempt, worker_status, started_at_epoch, heartbeat_at_epoch,
-              cancel_requested, cancel_reason, thread_id, turn_id, updated_at, updated_at_epoch
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              cancel_requested, cancel_reason, thread_id, turn_id, run_id, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 workflow,
@@ -272,6 +302,7 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("cancel_reason"),
                 entry.get("thread_id"),
                 entry.get("turn_id"),
+                entry.get("run_id") or entry.get("runId"),
                 now_iso,
                 now_epoch,
             ),
@@ -285,8 +316,8 @@ def save_engine_scheduler_state_to_connection(
         conn.execute(
             """
             INSERT INTO engine_retry_queue (
-              workflow, work_id, attempt, due_at_epoch, error, current_attempt, delay_type, updated_at, updated_at_epoch
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+              workflow, work_id, attempt, due_at_epoch, error, current_attempt, delay_type, run_id, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 workflow,
@@ -296,6 +327,7 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("error"),
                 entry.get("current_attempt"),
                 entry.get("delay_type") or "failure",
+                entry.get("run_id") or entry.get("runId"),
                 now_iso,
                 now_epoch,
             ),
@@ -325,6 +357,8 @@ def save_engine_scheduler_state_to_connection(
                 "status",
                 "cancel_requested",
                 "cancel_reason",
+                "run_id",
+                "runId",
                 "updated_at",
                 "updatedAt",
             }
@@ -333,8 +367,8 @@ def save_engine_scheduler_state_to_connection(
             """
             INSERT INTO engine_runtime_sessions (
               workflow, work_id, session_name, runtime_name, runtime_kind, session_id, thread_id, turn_id,
-              status, cancel_requested, cancel_reason, metadata_json, updated_at, updated_at_epoch
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              status, cancel_requested, cancel_reason, run_id, metadata_json, updated_at, updated_at_epoch
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 workflow,
@@ -348,6 +382,7 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("status"),
                 1 if (entry.get("cancel_requested") or entry.get("cancelRequested")) else 0,
                 entry.get("cancel_reason") or entry.get("cancelReason"),
+                entry.get("run_id") or entry.get("runId"),
                 _json_dumps(metadata),
                 entry.get("updated_at") or entry.get("updatedAt") or now_iso,
                 now_epoch,
@@ -418,11 +453,12 @@ def _scheduler_state_from_connection(
     now_epoch: float,
 ) -> dict[str, Any]:
     running_entries: dict[str, dict[str, Any]] = {}
+    running_run_id_expr = "r.run_id" if _column_exists(conn, "engine_running_work", "run_id") else "NULL"
     for row in conn.execute(
-        """
+        f"""
         SELECT r.work_id, w.identifier, w.state, r.worker_id, r.attempt, r.worker_status,
                r.started_at_epoch, r.heartbeat_at_epoch, r.cancel_requested, r.cancel_reason,
-               r.thread_id, r.turn_id
+               r.thread_id, r.turn_id, {running_run_id_expr}
         FROM engine_running_work r
         LEFT JOIN engine_work_items w ON w.workflow = r.workflow AND w.work_id = r.work_id
         WHERE r.workflow=?
@@ -442,6 +478,7 @@ def _scheduler_state_from_connection(
             cancel_reason,
             thread_id,
             turn_id,
+            run_id,
         ) = row
         running_entries[str(work_id)] = {
             "issue_id": str(work_id),
@@ -456,19 +493,21 @@ def _scheduler_state_from_connection(
             "cancel_reason": cancel_reason,
             "thread_id": thread_id,
             "turn_id": turn_id,
+            "run_id": run_id,
         }
 
     retry_entries: dict[str, dict[str, Any]] = {}
+    retry_run_id_expr = "q.run_id" if _column_exists(conn, "engine_retry_queue", "run_id") else "NULL"
     for row in conn.execute(
-        """
-        SELECT q.work_id, w.identifier, q.attempt, q.due_at_epoch, q.error, q.current_attempt, q.delay_type
+        f"""
+        SELECT q.work_id, w.identifier, q.attempt, q.due_at_epoch, q.error, q.current_attempt, q.delay_type, {retry_run_id_expr}
         FROM engine_retry_queue q
         LEFT JOIN engine_work_items w ON w.workflow = q.workflow AND w.work_id = q.work_id
         WHERE q.workflow=?
         """,
         (workflow,),
     ).fetchall():
-        work_id, identifier, attempt, due_at_epoch, error, current_attempt, delay_type = row
+        work_id, identifier, attempt, due_at_epoch, error, current_attempt, delay_type, run_id = row
         retry_entries[str(work_id)] = {
             "issue_id": str(work_id),
             "identifier": identifier,
@@ -477,13 +516,15 @@ def _scheduler_state_from_connection(
             "error": error,
             "current_attempt": current_attempt,
             "delay_type": delay_type or "failure",
+            "run_id": run_id,
         }
 
     codex_threads: dict[str, dict[str, Any]] = {}
+    session_run_id_expr = "s.run_id" if _column_exists(conn, "engine_runtime_sessions", "run_id") else "NULL"
     for row in conn.execute(
-        """
+        f"""
         SELECT s.work_id, w.identifier, s.session_name, s.runtime_name, s.runtime_kind, s.session_id,
-               s.thread_id, s.turn_id, s.status, s.cancel_requested, s.cancel_reason, s.metadata_json, s.updated_at
+               s.thread_id, s.turn_id, s.status, s.cancel_requested, s.cancel_reason, {session_run_id_expr}, s.metadata_json, s.updated_at
         FROM engine_runtime_sessions s
         LEFT JOIN engine_work_items w ON w.workflow = s.workflow AND w.work_id = s.work_id
         WHERE s.workflow=? AND s.thread_id IS NOT NULL AND s.thread_id != ''
@@ -502,6 +543,7 @@ def _scheduler_state_from_connection(
             status,
             cancel_requested,
             cancel_reason,
+            run_id,
             metadata_json,
             updated_at,
         ) = row
@@ -519,6 +561,7 @@ def _scheduler_state_from_connection(
             "status": status,
             "cancel_requested": bool(cancel_requested),
             "cancel_reason": cancel_reason,
+            "run_id": run_id,
             "updated_at": updated_at,
         }
         codex_threads[str(work_id)] = {key: value for key, value in entry.items() if value is not None}
@@ -775,6 +818,58 @@ def latest_engine_runs_from_connection(
         (workflow, max(int(limit or 10), 1)),
     ).fetchall()
     return [_run_row_to_dict(row) for row in rows]
+
+
+def engine_run_from_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    run_id: str,
+) -> dict[str, Any] | None:
+    init_engine_state(conn)
+    row = conn.execute(
+        """
+        SELECT workflow, run_id, mode, status, started_at, started_at_epoch,
+               completed_at, completed_at_epoch, selected_count, completed_count,
+               error, metadata_json
+        FROM engine_runs
+        WHERE workflow=? AND run_id=?
+        """,
+        (workflow, run_id),
+    ).fetchone()
+    return _run_row_to_dict(row) if row is not None else None
+
+
+def read_engine_run(
+    db_path: Path,
+    *,
+    workflow: str,
+    run_id: str,
+) -> dict[str, Any] | None:
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.OperationalError:
+        return None
+    try:
+        if not _table_exists(conn, "engine_runs"):
+            return None
+        row = conn.execute(
+            """
+            SELECT workflow, run_id, mode, status, started_at, started_at_epoch,
+                   completed_at, completed_at_epoch, selected_count, completed_count,
+                   error, metadata_json
+            FROM engine_runs
+            WHERE workflow=? AND run_id=?
+            """,
+            (workflow, run_id),
+        ).fetchone()
+        return _run_row_to_dict(row) if row is not None else None
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        conn.close()
 
 
 def read_engine_runs(

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -16,6 +16,7 @@ from .sqlite import connect_daedalus_db
 from .state import (
     ENGINE_STATE_TABLES,
     engine_state_tables_exist,
+    engine_run_from_connection,
     finish_engine_run_to_connection,
     init_engine_state,
     latest_engine_runs_from_connection,
@@ -275,6 +276,13 @@ class EngineStore:
         finally:
             conn.close()
 
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        conn = self.connect()
+        try:
+            return engine_run_from_connection(conn, workflow=self.workflow, run_id=run_id)
+        finally:
+            conn.close()
+
     def doctor(self, *, stale_running_seconds: int = 600) -> list[dict[str, Any]]:
         checks: list[dict[str, Any]] = []
         try:
@@ -336,7 +344,7 @@ class EngineStore:
 
             stale_runs = conn.execute(
                 """
-                SELECT run_id, mode, started_at
+                SELECT run_id, mode, started_at, started_at_epoch
                 FROM engine_runs
                 WHERE workflow=? AND status='running' AND completed_at IS NULL AND started_at_epoch < ?
                 ORDER BY started_at_epoch ASC
@@ -344,16 +352,28 @@ class EngineStore:
                 """,
                 (self.workflow, now_epoch - stale_running_seconds),
             ).fetchall()
+            stale_run_details = [
+                {
+                    "run_id": row[0],
+                    "mode": row[1],
+                    "started_at": row[2],
+                    "age_seconds": max(int(now_epoch - float(row[3] or now_epoch)), 0),
+                    "suggested_recovery": f"inspect with `hermes daedalus runs show {row[0]}`",
+                }
+                for row in stale_runs
+            ]
             checks.append(
                 {
                     "name": "engine-runs",
                     "status": "warn" if stale_runs else "pass",
                     "detail": (
-                        f"{len(stale_runs)} stale running engine run(s)"
+                        f"{len(stale_runs)} stale running engine run(s); "
+                        f"oldest_age_seconds={stale_run_details[0]['age_seconds'] if stale_run_details else 0}"
                         if stale_runs
                         else "no stale running engine runs"
                     ),
                     "items": [row[0] for row in stale_runs],
+                    "details": stale_run_details,
                 }
             )
 

--- a/daedalus/workflows/change_delivery/server/routes.py
+++ b/daedalus/workflows/change_delivery/server/routes.py
@@ -8,7 +8,9 @@ Path layout (Symphony §13.7 / spec §6.3):
 
     GET  /                  → HTML dashboard
     GET  /api/v1/state      → state_view() JSON
-    GET  /api/v1/<id>       → issue_view(id) JSON or 404
+    GET  /api/v1/runs      → runs_view() JSON
+    GET  /api/v1/runs/<id> → run_view(id) JSON or 404
+    GET  /api/v1/<id>      → issue_view(id) JSON or 404
     POST /api/v1/refresh    → spawn a tick subprocess (debounced)
     *    other              → 404 JSON
 
@@ -29,7 +31,7 @@ from typing import Any
 from workflows.change_delivery.paths import runtime_paths
 from workflows.change_delivery.server.html import render_dashboard
 from workflows.change_delivery.server.refresh import RefreshController
-from workflows.change_delivery.server.views import issue_view, state_view
+from workflows.change_delivery.server.views import issue_view, run_view, runs_view, state_view
 
 
 @dataclass
@@ -85,6 +87,20 @@ def _make_handler_class(
                 return
             if path == "/api/v1/state":
                 self._respond_json(200, state_view(db_path, events_log_path, workflow_root=workflow_root))
+                return
+            if path == "/api/v1/runs":
+                self._respond_json(200, runs_view(workflow_root))
+                return
+            if path.startswith("/api/v1/runs/"):
+                run_id = urllib.parse.unquote(path[len("/api/v1/runs/"):])
+                view = run_view(workflow_root, events_log_path, run_id)
+                if view is None:
+                    self._respond_json(
+                        404,
+                        {"error": {"code": "run_not_found", "message": f"unknown run: {run_id}"}},
+                    )
+                    return
+                self._respond_json(200, view)
                 return
             if path.startswith("/api/v1/"):
                 ident = urllib.parse.unquote(path[len("/api/v1/"):])

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from engine.state import read_engine_runs, read_engine_scheduler_state
+from engine.state import read_engine_run, read_engine_runs, read_engine_scheduler_state
 from workflows.contract import WorkflowContractError, load_workflow_contract
 from workflows.shared.paths import runtime_paths
 
@@ -220,6 +220,103 @@ def _engine_runs(workflow_root: Path | None, workflow: str, *, limit: int = 5) -
         workflow=workflow,
         limit=limit,
     )
+
+
+def _event_run_id(event: dict[str, Any]) -> str | None:
+    value = event.get("run_id") or event.get("runId")
+    return str(value) if value not in (None, "") else None
+
+
+def _workflow_audit_log_path(workflow_root: Path, events_log_path: Path) -> Path | None:
+    if _workflow_name(workflow_root) == "issue-runner":
+        return _resolve_issue_runner_storage_path(workflow_root, "audit-log", "memory/workflow-audit.jsonl")
+    return events_log_path.parent / "workflow-audit.jsonl"
+
+
+def _run_timeline(workflow_root: Path, events_log_path: Path, run_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+    paths: list[Path] = [events_log_path]
+    audit_path = _workflow_audit_log_path(workflow_root, events_log_path)
+    if audit_path is not None and audit_path not in paths:
+        paths.append(audit_path)
+    events: list[dict[str, Any]] = []
+    for path in paths:
+        for event in _read_events_tail(path, max(limit * 5, limit)):
+            if _event_run_id(event) == run_id:
+                events.append({**event, "source_path": str(path)})
+    events.sort(key=lambda item: str(item.get("at") or item.get("time") or ""))
+    return events[-limit:]
+
+
+def runs_view(workflow_root: Path, *, limit: int = 20, stale_seconds: int = 600) -> dict[str, Any]:
+    workflow_root = Path(workflow_root)
+    workflow = _workflow_name(workflow_root) or "change-delivery"
+    now_epoch = time.time()
+    runs = read_engine_runs(
+        runtime_paths(workflow_root)["db_path"],
+        workflow=workflow,
+        limit=limit,
+    )
+    enriched = []
+    for run in runs:
+        started_at_epoch = float(run.get("started_at_epoch") or now_epoch)
+        age_seconds = max(int(now_epoch - started_at_epoch), 0)
+        enriched.append(
+            {
+                **run,
+                "age_seconds": age_seconds,
+                "stale": run.get("status") == "running" and age_seconds > stale_seconds,
+            }
+        )
+    return {
+        "generated_at": _now_iso(),
+        "workflow": workflow,
+        "counts": {
+            "total": len(enriched),
+            "running": len([run for run in enriched if run.get("status") == "running"]),
+            "failed": len([run for run in enriched if run.get("status") == "failed"]),
+            "stale": len([run for run in enriched if run.get("stale")]),
+        },
+        "runs": enriched,
+    }
+
+
+def run_view(workflow_root: Path, events_log_path: Path, run_id: str) -> dict[str, Any] | None:
+    workflow_root = Path(workflow_root)
+    workflow = _workflow_name(workflow_root) or "change-delivery"
+    run = read_engine_run(
+        runtime_paths(workflow_root)["db_path"],
+        workflow=workflow,
+        run_id=run_id,
+    )
+    if run is None:
+        return None
+    scheduler = _engine_scheduler(workflow_root, workflow)
+    running = [
+        row
+        for row in (scheduler.get("running") or [])
+        if isinstance(row, dict) and _event_run_id(row) == run_id
+    ]
+    retrying = [
+        row
+        for row in (scheduler.get("retry_queue") or scheduler.get("retryQueue") or [])
+        if isinstance(row, dict) and _event_run_id(row) == run_id
+    ]
+    codex_threads = [
+        row
+        for row in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).values()
+        if isinstance(row, dict) and _event_run_id(row) == run_id
+    ]
+    return {
+        "generated_at": _now_iso(),
+        "workflow": workflow,
+        "run": run,
+        "related": {
+            "running": running,
+            "retrying": retrying,
+            "codex_threads": codex_threads,
+        },
+        "timeline": _run_timeline(workflow_root, events_log_path, run_id),
+    }
 
 
 def _epoch_to_iso(value: Any) -> str | None:

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -1352,6 +1352,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
                 "status": "completed",
                 "cancel_requested": False,
                 "cancel_reason": None,
+                "run_id": getattr(ns, "CURRENT_ENGINE_RUN_ID", None),
                 "updated_at": at,
             }
         totals = dict(scheduler.get("codex_totals") or {})
@@ -1400,6 +1401,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             "status": "running",
             "last_event": metrics.get("last_event"),
             "last_message": metrics.get("last_message"),
+            "run_id": getattr(ns, "CURRENT_ENGINE_RUN_ID", None) or prior.get("run_id"),
             "updated_at": ns._now_iso(),
         }
         scheduler.update(
@@ -2237,9 +2239,15 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         return {**result, "after": after}
 
     def tick_raw():
+        def audit_with_run_id(action, summary, **extra):
+            run_id = getattr(ns, "CURRENT_ENGINE_RUN_ID", None)
+            if run_id and not extra.get("run_id"):
+                extra["run_id"] = run_id
+            return ns.audit(action, summary, **extra)
+
         return ns._load_adapter_actions_module().run_tick_raw(
             reconcile_fn=ns.reconcile,
-            audit_fn=ns.audit,
+            audit_fn=audit_with_run_id,
             dispatch_inter_review_agent_review_fn=ns.dispatch_inter_review_agent_review,
             dispatch_implementation_turn_fn=ns.dispatch_implementation_turn,
             publish_ready_pr_fn=ns.publish_ready_pr,
@@ -2322,6 +2330,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def tick():
         engine_run = ns.ENGINE_STORE.start_run(mode="tick")
+        previous_run_id = getattr(ns, "CURRENT_ENGINE_RUN_ID", None)
+        ns.CURRENT_ENGINE_RUN_ID = engine_run["run_id"]
         try:
             result = ns.tick_raw()
             action = result.get("action") if isinstance(result, dict) else {}
@@ -2350,6 +2360,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             except Exception:
                 pass
             raise
+        finally:
+            ns.CURRENT_ENGINE_RUN_ID = previous_run_id
 
     def dispatch_implementation_turn():
         return ns.dispatch_implementation_turn_raw()

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -606,6 +606,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         issue: dict[str, Any],
         session_name: str,
         metrics: dict[str, Any],
+        run_id: str | None = None,
     ) -> None:
         issue_id = str(issue.get("id") or "").strip()
         thread_id = str(metrics.get("thread_id") or "").strip()
@@ -617,6 +618,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "session_name": session_name,
             "thread_id": thread_id,
             "turn_id": metrics.get("turn_id"),
+            "run_id": run_id,
             "updated_at": _now_iso(),
         }
 
@@ -651,6 +653,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         error: str,
         current_attempt: int | None,
         delay_type: str = "failure",
+        run_id: str | None = None,
     ) -> dict[str, Any]:
         max_backoff_ms = int((self.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
         work_item = work_item_from_issue(issue, source=str((self.config.get("tracker") or {}).get("kind") or "tracker"))
@@ -663,12 +666,16 @@ class IssueRunnerWorkspace(WorkflowDriver):
             max_backoff_ms=max_backoff_ms,
             now_epoch=_now_epoch(),
         )
+        if run_id:
+            entry["run_id"] = run_id
+            retry["run_id"] = run_id
         self.retry_entries[work_item.id] = entry
         self._emit_event(
             "issue_runner.retry.scheduled",
             {
                 **retry,
                 "error": error,
+                "run_id": run_id,
             },
         )
         return retry
@@ -778,7 +785,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
             return int(last_run.get("attempt") or 0) + 1
         return 1
 
-    def _mark_running(self, selections: list[tuple[dict[str, Any], dict[str, Any] | None]]) -> None:
+    def _mark_running(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None = None,
+    ) -> None:
         now_epoch = _now_epoch()
         tracker_kind = str((self.config.get("tracker") or {}).get("kind") or "tracker")
         self.running_entries = mark_running_work(
@@ -793,6 +805,11 @@ class IssueRunnerWorkspace(WorkflowDriver):
             ],
             now_epoch=now_epoch,
         )
+        if run_id:
+            for issue, _retry_entry in selections:
+                issue_id = str(issue.get("id") or "").strip()
+                if issue_id in self.running_entries:
+                    self.running_entries[issue_id]["run_id"] = run_id
         self.running_issue_id = next(iter(self.running_entries), None)
         self._persist_scheduler_state()
 
@@ -818,10 +835,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
         reason: str,
         workspace: Path | None = None,
         output_path: Path | None = None,
+        run_id: str | None = None,
     ) -> dict[str, Any]:
         return {
             "ok": False,
             "canceled": True,
+            "runId": run_id,
             "suppressRetry": reason == "terminal-state",
             "issue": issue,
             "attempt": attempt,
@@ -841,6 +860,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         issue: dict[str, Any],
         retry_entry: dict[str, Any] | None,
         cancel_event: threading.Event | None = None,
+        run_id: str | None = None,
     ) -> dict[str, Any]:
         hook_results: list[dict[str, Any]] = []
         runtime: Runtime | None = None
@@ -859,6 +879,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     issue=issue,
                     attempt=attempt,
                     reason="requested-before-start",
+                    run_id=run_id,
                 )
             issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
             issue_workspace.mkdir(parents=True, exist_ok=True)
@@ -884,6 +905,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     reason="requested-before-run",
                     workspace=issue_workspace,
                     output_path=output_path,
+                    run_id=run_id,
                 )
             if created_workspace:
                 hook_results.append(self._run_hook("after_create", issue_workspace, env))
@@ -942,6 +964,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             hook_results.append(self._run_hook("after_run", issue_workspace, env))
             return {
                 "ok": True,
+                "runId": run_id,
                 "issue": issue,
                 "attempt": attempt,
                 "workspace": str(issue_workspace),
@@ -957,6 +980,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 hook_results.append(self._run_hook("after_run", issue_workspace, env, ignore_failure=True))
             return {
                 "ok": False,
+                "runId": run_id,
                 "issue": issue,
                 "attempt": attempt,
                 "workspace": str(issue_workspace) if issue_workspace is not None else None,
@@ -977,6 +1001,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         for result in results:
             issue = result.get("issue") or {}
             issue_id = str(issue.get("id") or "")
+            run_id = result.get("run_id") or result.get("runId")
             metrics = result.get("metrics") or {}
             if metrics:
                 recorded_metrics = self._record_metrics(
@@ -997,6 +1022,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         issue=issue,
                         session_name=issue_session_name(issue),
                         metrics=recorded_metrics,
+                        run_id=run_id,
                     )
                 result["metrics"] = recorded_metrics
 
@@ -1010,6 +1036,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         error="continuation",
                         current_attempt=result.get("attempt"),
                         delay_type="continuation",
+                        run_id=run_id,
                     )
                     result["retry"] = retry
                 self._emit_event(
@@ -1019,6 +1046,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         "attempt": result.get("attempt"),
                         "workspace": result.get("workspace"),
                         "output_path": result.get("outputPath"),
+                        "run_id": run_id,
                         "continuation_retry_attempt": (result.get("retry") or {}).get("retry_attempt"),
                         "continuation_retry_delay_ms": (result.get("retry") or {}).get("delay_ms"),
                     },
@@ -1033,6 +1061,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                             "attempt": result.get("attempt"),
                             "workspace": result.get("workspace"),
                             "error": result.get("error"),
+                            "run_id": run_id,
                             "retry_suppressed": True,
                         },
                     )
@@ -1041,6 +1070,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         issue=issue,
                         error=str(result.get("error") or "issue execution failed"),
                         current_attempt=result.get("attempt"),
+                        run_id=run_id,
                     )
                     result["retry"] = retry
                     self._emit_event(
@@ -1050,6 +1080,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                             "attempt": result.get("attempt"),
                             "workspace": result.get("workspace"),
                             "error": result.get("error"),
+                            "run_id": run_id,
                             "retry_attempt": retry.get("retry_attempt"),
                             "retry_delay_ms": retry.get("delay_ms"),
                         },
@@ -1120,6 +1151,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 "identifier": entry.get("identifier"),
                 "reason": reason,
                 "worker_id": entry.get("worker_id"),
+                "run_id": entry.get("run_id") or entry.get("runId"),
             },
         )
         self._persist_scheduler_state()
@@ -1161,6 +1193,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     },
                     attempt=int(entry.get("attempt") or 0),
                     reason=str(entry.get("cancel_reason") or "canceled"),
+                    run_id=entry.get("run_id") or entry.get("runId"),
                 )
             else:
                 try:
@@ -1182,6 +1215,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         "metrics": {},
                         "runtime": None,
                         "runtimeKind": None,
+                        "runId": entry.get("run_id") or entry.get("runId"),
                     }
             if entry.get("cancel_requested"):
                 result["cancelRequested"] = True
@@ -1203,6 +1237,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     "issue_id": issue_id,
                     "identifier": (result.get("issue") or {}).get("identifier") or entry.get("identifier"),
                     "worker_id": entry.get("worker_id"),
+                    "run_id": entry.get("run_id") or entry.get("runId") or result.get("runId"),
                     "ok": result.get("ok"),
                     "canceled": result.get("canceled"),
                     "error": result.get("error"),
@@ -1215,11 +1250,13 @@ class IssueRunnerWorkspace(WorkflowDriver):
     def _dispatch_supervised_workers(
         self,
         selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
         if not selections:
             return []
         executor = self._ensure_supervisor_executor()
-        self._mark_running(selections)
+        self._mark_running(selections, run_id=run_id)
         dispatched: list[dict[str, Any]] = []
         for issue, retry_entry in selections:
             issue_id = str(issue.get("id") or "").strip()
@@ -1232,6 +1269,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 issue=issue,
                 retry_entry=retry_entry,
                 cancel_event=cancel_event,
+                run_id=run_id,
             )
             self._supervisor_futures[issue_id] = future
             entry = self.running_entries.get(issue_id) or {}
@@ -1247,6 +1285,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     "worker_id": entry.get("worker_id"),
                     "attempt": entry.get("attempt"),
                     "state": issue.get("state"),
+                    "run_id": run_id,
                 },
             )
         self._persist_scheduler_state()
@@ -1289,6 +1328,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     {
                         "error": status["error"],
                         "reason": "tracker-load-failed",
+                        "run_id": engine_run["run_id"],
                     },
                 )
                 return status
@@ -1312,11 +1352,14 @@ class IssueRunnerWorkspace(WorkflowDriver):
             selections = refreshed_selections
             status["selectedIssues"] = [issue for issue, _retry_entry in selections]
             status["selectedIssue"] = selections[0][0] if selections else None
-            dispatched = self._dispatch_supervised_workers(selections)
+            dispatched = self._dispatch_supervised_workers(selections, run_id=engine_run["run_id"])
             status["dispatchedWorkers"] = dispatched
             if not completed and not dispatched:
                 status["message"] = "no dispatchable issues"
-                self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
+                self._emit_event(
+                    "issue_runner.tick.noop",
+                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
+                )
 
             if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
                 status["ok"] = False
@@ -1410,6 +1453,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     {
                         "error": status["error"],
                         "reason": "tracker-load-failed",
+                        "run_id": engine_run["run_id"],
                     },
                 )
                 return status
@@ -1437,19 +1481,33 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 )
                 self._write_status(status, health="healthy")
                 self._persist_scheduler_state()
-                self._emit_event("issue_runner.tick.noop", {"reason": "no-dispatchable-issues"})
+                self._emit_event(
+                    "issue_runner.tick.noop",
+                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
+                )
                 return status
 
-            self._mark_running(selections)
+            self._mark_running(selections, run_id=engine_run["run_id"])
             results: list[dict[str, Any]] = []
             try:
                 if len(selections) == 1:
                     issue, retry_entry = selections[0]
-                    results = [self._execute_issue(issue=issue, retry_entry=retry_entry)]
+                    results = [
+                        self._execute_issue(
+                            issue=issue,
+                            retry_entry=retry_entry,
+                            run_id=engine_run["run_id"],
+                        )
+                    ]
                 else:
                     with concurrent.futures.ThreadPoolExecutor(max_workers=len(selections)) as executor:
                         future_map = {
-                            executor.submit(self._execute_issue, issue=issue, retry_entry=retry_entry): (issue, retry_entry)
+                            executor.submit(
+                                self._execute_issue,
+                                issue=issue,
+                                retry_entry=retry_entry,
+                                run_id=engine_run["run_id"],
+                            ): (issue, retry_entry)
                             for issue, retry_entry in selections
                         }
                         for future in concurrent.futures.as_completed(future_map):

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -191,6 +191,7 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
                 "attempt": 2,
                 "started_at_epoch": 100.0,
                 "heartbeat_at_epoch": 110.0,
+                "run_id": "run-1",
             }
         },
         retry_entries={
@@ -200,6 +201,7 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
                 "attempt": 1,
                 "due_at_epoch": 130.0,
                 "error": "temporary failure",
+                "run_id": "run-1",
             }
         },
         codex_threads={
@@ -210,6 +212,7 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
                 "runtime_kind": "codex-app-server",
                 "thread_id": "thread-1",
                 "turn_id": "turn-1",
+                "run_id": "run-1",
                 "updated_at": "2026-04-30T00:00:00Z",
             }
         },
@@ -232,10 +235,13 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
     )
 
     assert loaded["running"][0]["issue_id"] == "ISSUE-1"
+    assert loaded["running"][0]["run_id"] == "run-1"
     assert loaded["running"][0]["running_for_ms"] == 25000
     assert loaded["retry_queue"][0]["issue_id"] == "ISSUE-2"
+    assert loaded["retry_queue"][0]["run_id"] == "run-1"
     assert loaded["retry_queue"][0]["due_in_ms"] == 5000
     assert loaded["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert loaded["codex_threads"]["ISSUE-1"]["run_id"] == "run-1"
     assert loaded["codex_totals"]["total_tokens"] == 7
     assert readonly == loaded
 

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -14,6 +14,7 @@ import json
 import sqlite3
 import threading
 import time
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from unittest import mock
@@ -547,6 +548,43 @@ def test_server_known_issue_returns_view(tmp_path: Path) -> None:
             assert resp.status == 200
             payload = json.loads(resp.read().decode("utf-8"))
         assert payload["issue_identifier"] == "#42"
+    finally:
+        handle.shutdown()
+
+
+def test_server_runs_endpoints_return_run_history_and_timeline(tmp_path: Path) -> None:
+    from engine.store import EngineStore
+    from workflows.shared.paths import runtime_paths
+
+    store = EngineStore(
+        db_path=runtime_paths(tmp_path)["db_path"],
+        workflow="change-delivery",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    engine_run = store.start_run(mode="active-iteration")
+    completed = store.complete_run(engine_run["run_id"], selected_count=1, completed_count=1)
+    _make_events_log(
+        tmp_path / "events.jsonl",
+        [{"at": "2026-04-30T12:00:22Z", "event_type": "test_event", "run_id": completed["run_id"]}],
+    )
+
+    handle = _start_test_server(tmp_path)
+    try:
+        _make_events_log(
+            tmp_path / "events.jsonl",
+            [{"at": "2026-04-30T12:00:22Z", "event_type": "test_event", "run_id": completed["run_id"]}],
+        )
+        with urllib.request.urlopen(f"http://127.0.0.1:{handle.port}/api/v1/runs", timeout=5) as resp:
+            runs_payload = json.loads(resp.read().decode("utf-8"))
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{handle.port}/api/v1/runs/{urllib.parse.quote(completed['run_id'], safe='')}",
+            timeout=5,
+        ) as resp:
+            run_payload = json.loads(resp.read().decode("utf-8"))
+        assert runs_payload["runs"][0]["run_id"] == completed["run_id"]
+        assert run_payload["run"]["run_id"] == completed["run_id"]
+        assert run_payload["timeline"][0]["event_type"] == "test_event"
     finally:
         handle.shutdown()
 

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -97,6 +97,45 @@ def test_run_cli_command_dispatches_watch(tmp_path, capsys):
     assert "Daedalus active lanes" in out or "active lanes" in out.lower()
 
 
+def test_execute_raw_args_runs_command_lists_engine_runs(tmp_path):
+    from engine.store import EngineStore
+    from workflows.contract import render_workflow_markdown
+    from workflows.shared.paths import runtime_paths
+
+    tools = _tools()
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "issue-runner",
+                "schema-version": 1,
+                "instance": {"name": "attmous-daedalus-issue-runner", "engine-owner": "hermes"},
+                "repository": {"local-path": str(tmp_path / "repo"), "github-slug": "attmous/daedalus"},
+                "tracker": {"kind": "local-json", "path": "config/issues.json"},
+                "workspace": {"root": "workspace/issues"},
+                "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "default"},
+            },
+            prompt_template="Issue: {{ issue.identifier }}",
+        ),
+        encoding="utf-8",
+    )
+    store = EngineStore(
+        db_path=runtime_paths(root)["db_path"],
+        workflow="issue-runner",
+        now_iso=lambda: "2026-04-30T12:00:21Z",
+        now_epoch=lambda: 1714478421.0,
+    )
+    run = store.start_run(mode="tick")
+    store.complete_run(run["run_id"], selected_count=1, completed_count=1)
+
+    output = tools.execute_raw_args(f"runs --workflow-root {root} --json")
+    payload = json.loads(output)
+
+    assert payload["workflow"] == "issue-runner"
+    assert payload["runs"][0]["run_id"] == run["run_id"]
+
+
 def test_run_cli_command_dispatches_scaffold_workflow(tmp_path, capsys):
     tools = _tools()
     root = tmp_path / "attmous-daedalus-issue-runner"

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -241,8 +241,19 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     assert result["engineRun"]["mode"] == "tick"
     assert result["engineRun"]["status"] == "completed"
     assert workspace.engine_store.latest_runs(limit=1)[0]["run_id"] == result["engineRun"]["run_id"]
+    audit_events = [
+        json.loads(line)
+        for line in (workflow_root / "memory" / "workflow-audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    correlated = [event for event in audit_events if event.get("run_id") == result["engineRun"]["run_id"]]
+    assert {event["event"] for event in correlated} >= {
+        "issue_runner.retry.scheduled",
+        "issue_runner.tick.completed",
+    }
     assert result["selectedIssue"]["id"] == "ISSUE-1"
     assert result["results"][0]["retry"]["delay_type"] == "continuation"
+    assert result["results"][0]["retry"]["run_id"] == result["engineRun"]["run_id"]
     assert result["results"][0]["retry"]["delay_ms"] == 1000
     output_path = Path(result["outputPath"])
     assert output_path.exists()


### PR DESCRIPTION
## Summary

Builds on the engine run ledger by correlating workflow activity back to `run_id` and adding operator-facing run timeline surfaces.

## Changes

- Persist `run_id` on shared scheduler rows for running work, retry queue entries, and runtime sessions.
- Preserve `run_id` through scheduler snapshot/restore and recovered-running retry conversion.
- Add `run_id` to issue-runner dispatch, retry, completion, cancellation, failure, and noop events.
- Add change-delivery tick audit correlation and Codex runtime-session `run_id` persistence.
- Add `hermes daedalus runs` for list/failed/stale/show views.
- Add HTTP `/api/v1/runs` and `/api/v1/runs/<run_id>` endpoints with timeline filtering.
- Improve stale engine-run doctor details with age and suggested recovery.

## Validation

- `git diff --check`
- `pytest -q` -> `843 passed, 8 skipped`