### PR TITLE
[codex] Automate engine event retention

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -24,6 +24,7 @@ from engine.state import (
     read_engine_runs,
     read_engine_scheduler_state,
 )
+from engine.retention import normalize_event_retention
 from engine.store import EngineStore
 from workflows.contract import (
     WorkflowContractError,
@@ -695,33 +696,33 @@ def build_events_report(
         "event_type": event_type,
         "severity": severity,
     }
+    retention_cfg = normalize_event_retention(_workflow_event_retention(workflow_root))
+    if max_age_days is not None:
+        retention_cfg["configured"] = True
+        retention_cfg["max_age_days"] = max_age_days
+        retention_cfg["max_age_seconds"] = max_age_days * 86400
+    if max_rows is not None:
+        retention_cfg["configured"] = True
+        retention_cfg["max_rows"] = max_rows
+    if action == "stats":
+        return {
+            "mode": "stats",
+            "workflow": workflow_name,
+            "stats": store.event_stats(retention_cfg),
+        }
     if action == "prune":
-        retention_cfg = _workflow_event_retention(workflow_root)
-        resolved_max_age_days = max_age_days
-        if resolved_max_age_days is None and retention_cfg.get("max-age-days") is not None:
-            resolved_max_age_days = float(retention_cfg["max-age-days"])
-        if resolved_max_age_days is None and retention_cfg.get("max_age_days") is not None:
-            resolved_max_age_days = float(retention_cfg["max_age_days"])
-        resolved_max_rows = max_rows
-        if resolved_max_rows is None and retention_cfg.get("max-rows") is not None:
-            resolved_max_rows = int(retention_cfg["max-rows"])
-        if resolved_max_rows is None and retention_cfg.get("max_rows") is not None:
-            resolved_max_rows = int(retention_cfg["max_rows"])
-        if resolved_max_age_days is None and resolved_max_rows is None:
+        if not retention_cfg.get("configured"):
             raise DaedalusCommandError(
                 "events prune requires --max-age-days, --max-rows, or retention.events in WORKFLOW.md"
             )
         result = store.prune_events(
-            max_age_seconds=(resolved_max_age_days * 86400) if resolved_max_age_days is not None else None,
-            max_rows=resolved_max_rows,
+            max_age_seconds=retention_cfg.get("max_age_seconds"),
+            max_rows=retention_cfg.get("max_rows"),
         )
         return {
             "mode": "prune",
             "workflow": workflow_name,
-            "retention": {
-                "max_age_days": resolved_max_age_days,
-                "max_rows": resolved_max_rows,
-            },
+            "retention": retention_cfg,
             **result,
         }
     events = read_engine_events(
@@ -2077,6 +2078,39 @@ def build_doctor_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
         )
     )
 
+    event_retention = _workflow_event_retention(workflow_root)
+    event_stats = EngineStore(
+        db_path=runtime_paths(workflow_root)["db_path"],
+        workflow="change-delivery",
+    ).event_stats(event_retention)
+    retention = event_stats.get("retention") or {}
+    retention_reasons = []
+    if not retention.get("configured") and event_stats.get("total_events"):
+        retention_reasons.append("not-configured")
+    if retention.get("excess_rows"):
+        retention_reasons.append("row-limit-exceeded")
+    if retention.get("age_overdue"):
+        retention_reasons.append("age-limit-exceeded")
+    checks.append(
+        _make_check(
+            code="engine_event_retention",
+            status="warn" if retention_reasons else "pass",
+            severity="warning" if retention_reasons else "info",
+            summary=(
+                "Engine event retention needs attention"
+                if retention_reasons
+                else "No engine event retention issue detected"
+            ),
+            details={
+                "reasons": retention_reasons,
+                "total_events": event_stats.get("total_events"),
+                "oldest_event_at": event_stats.get("oldest_event_at"),
+                "oldest_age_seconds": event_stats.get("oldest_age_seconds"),
+                "retention": retention,
+            },
+        )
+    )
+
     active_lane_id = active_lane.get("lane_id")
     stuck_dispatched_actions = daedalus.query_stuck_dispatched_actions(
         workflow_root=workflow_root,
@@ -2917,7 +2951,7 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
 
     events_cmd = sub.add_parser("events", help="Inspect and prune the durable engine event ledger.")
     events_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
-    events_cmd.add_argument("events_action", nargs="?", default="list", choices=["list", "prune"])
+    events_cmd.add_argument("events_action", nargs="?", default="list", choices=["list", "stats", "prune"])
     events_cmd.add_argument("--run-id")
     events_cmd.add_argument("--work-id")
     events_cmd.add_argument("--type", dest="event_type")
@@ -3749,6 +3783,26 @@ def render_result(
             )
         return "\n".join(lines)
     if command == "events":
+        if result.get("mode") == "stats":
+            stats = result.get("stats") or {}
+            retention = stats.get("retention") or {}
+            lines = [
+                f"workflow={result.get('workflow')} total_events={stats.get('total_events')}",
+                f"oldest_event_at={stats.get('oldest_event_at')} oldest_age_seconds={stats.get('oldest_age_seconds')}",
+                f"newest_event_at={stats.get('newest_event_at')}",
+                (
+                    f"retention_configured={retention.get('configured')} "
+                    f"overdue={retention.get('overdue')} "
+                    f"max_age_seconds={retention.get('max_age_seconds')} "
+                    f"max_rows={retention.get('max_rows')} "
+                    f"excess_rows={retention.get('excess_rows')}"
+                ),
+            ]
+            if stats.get("by_type"):
+                lines.append(f"by_type={stats.get('by_type')}")
+            if stats.get("by_severity"):
+                lines.append(f"by_severity={stats.get('by_severity')}")
+            return "\n".join(lines)
         if result.get("mode") == "prune":
             retention = result.get("retention") or {}
             return (

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -19,6 +19,7 @@ from .leases import (
     read_engine_lease,
     release_engine_lease,
 )
+from .retention import normalize_event_retention
 from .scheduler import (
     RestoredSchedulerState,
     build_scheduler_payload,
@@ -31,6 +32,7 @@ from .scheduler import (
 from .sqlite import connect_daedalus_db
 from .state import (
     append_engine_event_to_connection,
+    engine_event_stats_from_connection,
     engine_events_from_connection,
     engine_events_for_run_from_connection,
     engine_run_from_connection,
@@ -40,6 +42,7 @@ from .state import (
     latest_engine_runs_from_connection,
     load_engine_scheduler_state,
     prune_engine_events_to_connection,
+    read_engine_event_stats,
     read_engine_events,
     read_engine_events_for_run,
     read_engine_run,
@@ -75,6 +78,7 @@ __all__ = [
     "clear_work_entries",
     "codex_threads_snapshot",
     "connect_daedalus_db",
+    "engine_event_stats_from_connection",
     "engine_events_from_connection",
     "engine_events_for_run_from_connection",
     "engine_run_from_connection",
@@ -87,7 +91,9 @@ __all__ = [
     "load_optional_json",
     "mark_running_work",
     "make_audit_fn",
+    "normalize_event_retention",
     "prune_engine_events_to_connection",
+    "read_engine_event_stats",
     "read_engine_lease",
     "read_engine_events",
     "read_engine_events_for_run",

--- a/daedalus/engine/retention.py
+++ b/daedalus/engine/retention.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SECONDS_PER_DAY = 86400
+
+
+def _number(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _integer(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_event_retention(value: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize WORKFLOW.md event-retention config.
+
+    Accepts either the full ``retention:`` block or its nested ``events:`` block.
+    """
+
+    raw = value if isinstance(value, dict) else {}
+    events = raw.get("events") if isinstance(raw.get("events"), dict) else raw
+    max_age_days = _number(events.get("max-age-days") if isinstance(events, dict) else None)
+    if max_age_days is None and isinstance(events, dict):
+        max_age_days = _number(events.get("max_age_days"))
+    max_age_seconds = _number(events.get("max-age-seconds") if isinstance(events, dict) else None)
+    if max_age_seconds is None and isinstance(events, dict):
+        max_age_seconds = _number(events.get("max_age_seconds"))
+    if max_age_seconds is None and max_age_days is not None:
+        max_age_seconds = max_age_days * SECONDS_PER_DAY
+    max_rows = _integer(events.get("max-rows") if isinstance(events, dict) else None)
+    if max_rows is None and isinstance(events, dict):
+        max_rows = _integer(events.get("max_rows"))
+    configured = max_age_seconds is not None or max_rows is not None
+    return {
+        "configured": configured,
+        "max_age_days": max_age_days,
+        "max_age_seconds": max_age_seconds,
+        "max_rows": max_rows,
+    }

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -1138,6 +1138,148 @@ def read_engine_events(
         conn.close()
 
 
+def engine_event_stats_from_connection(
+    conn: sqlite3.Connection,
+    *,
+    workflow: str,
+    now_epoch: float,
+    retention: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    init_engine_state(conn)
+    retention_cfg = dict(retention or {})
+    row = conn.execute(
+        """
+        SELECT COUNT(*), MIN(created_at_epoch), MAX(created_at_epoch)
+        FROM engine_events
+        WHERE workflow=?
+        """,
+        (workflow,),
+    ).fetchone()
+    total = int((row or [0])[0] or 0)
+    oldest_epoch = None if row is None or row[1] is None else float(row[1])
+    newest_epoch = None if row is None or row[2] is None else float(row[2])
+    oldest_at = None
+    newest_at = None
+    if oldest_epoch is not None:
+        oldest_at = conn.execute(
+            """
+            SELECT created_at
+            FROM engine_events
+            WHERE workflow=? AND created_at_epoch=?
+            ORDER BY event_id ASC
+            LIMIT 1
+            """,
+            (workflow, oldest_epoch),
+        ).fetchone()[0]
+    if newest_epoch is not None:
+        newest_at = conn.execute(
+            """
+            SELECT created_at
+            FROM engine_events
+            WHERE workflow=? AND created_at_epoch=?
+            ORDER BY event_id DESC
+            LIMIT 1
+            """,
+            (workflow, newest_epoch),
+        ).fetchone()[0]
+    by_type = {
+        str(event_type): int(count or 0)
+        for event_type, count in conn.execute(
+            """
+            SELECT event_type, COUNT(*)
+            FROM engine_events
+            WHERE workflow=?
+            GROUP BY event_type
+            ORDER BY COUNT(*) DESC, event_type ASC
+            """,
+            (workflow,),
+        ).fetchall()
+    }
+    by_severity = {
+        str(severity): int(count or 0)
+        for severity, count in conn.execute(
+            """
+            SELECT severity, COUNT(*)
+            FROM engine_events
+            WHERE workflow=?
+            GROUP BY severity
+            ORDER BY COUNT(*) DESC, severity ASC
+            """,
+            (workflow,),
+        ).fetchall()
+    }
+    oldest_age_seconds = None
+    if oldest_epoch is not None:
+        oldest_age_seconds = max(float(now_epoch) - oldest_epoch, 0)
+    max_age_seconds = retention_cfg.get("max_age_seconds")
+    max_rows = retention_cfg.get("max_rows")
+    excess_rows = max(total - int(max_rows), 0) if max_rows is not None else 0
+    age_overdue = bool(
+        max_age_seconds is not None
+        and oldest_age_seconds is not None
+        and oldest_age_seconds > float(max_age_seconds)
+    )
+    overdue = bool(excess_rows > 0 or age_overdue)
+    return {
+        "workflow": workflow,
+        "total_events": total,
+        "oldest_event_at": oldest_at,
+        "oldest_event_epoch": oldest_epoch,
+        "oldest_age_seconds": oldest_age_seconds,
+        "newest_event_at": newest_at,
+        "newest_event_epoch": newest_epoch,
+        "by_type": by_type,
+        "by_severity": by_severity,
+        "retention": {
+            **retention_cfg,
+            "excess_rows": excess_rows,
+            "age_overdue": age_overdue,
+            "overdue": overdue,
+        },
+    }
+
+
+def read_engine_event_stats(
+    db_path: Path,
+    *,
+    workflow: str,
+    now_epoch: float,
+    retention: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    empty_retention = dict(retention or {})
+    empty = {
+        "workflow": workflow,
+        "total_events": 0,
+        "oldest_event_at": None,
+        "oldest_event_epoch": None,
+        "oldest_age_seconds": None,
+        "newest_event_at": None,
+        "newest_event_epoch": None,
+        "by_type": {},
+        "by_severity": {},
+        "retention": {**empty_retention, "excess_rows": 0, "age_overdue": False, "overdue": False},
+    }
+    if not db_path.exists():
+        return empty
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.OperationalError:
+        return empty
+    try:
+        if not _table_exists(conn, "engine_events"):
+            return empty
+        return engine_event_stats_from_connection(
+            conn,
+            workflow=workflow,
+            now_epoch=now_epoch,
+            retention=retention,
+        )
+    except sqlite3.OperationalError:
+        return empty
+    finally:
+        conn.close()
+
+
 def prune_engine_events_to_connection(
     conn: sqlite3.Connection,
     *,

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -12,10 +12,12 @@ from .leases import (
     read_engine_lease,
     release_engine_lease,
 )
+from .retention import normalize_event_retention
 from .sqlite import connect_daedalus_db
 from .state import (
     ENGINE_STATE_TABLES,
     append_engine_event_to_connection,
+    engine_event_stats_from_connection,
     engine_events_from_connection,
     engine_events_for_run_from_connection,
     engine_run_from_connection,
@@ -384,7 +386,44 @@ class EngineStore:
                 max_rows=max_rows,
             )
 
-    def doctor(self, *, stale_running_seconds: int = 600) -> list[dict[str, Any]]:
+    def apply_event_retention(self, event_retention: dict[str, Any] | None) -> dict[str, Any]:
+        retention = normalize_event_retention(event_retention)
+        if not retention.get("configured"):
+            return {
+                "workflow": self.workflow,
+                "applied": False,
+                "reason": "not-configured",
+                "retention": retention,
+            }
+        result = self.prune_events(
+            max_age_seconds=retention.get("max_age_seconds"),
+            max_rows=retention.get("max_rows"),
+        )
+        return {
+            **result,
+            "applied": True,
+            "retention": retention,
+        }
+
+    def event_stats(self, event_retention: dict[str, Any] | None = None) -> dict[str, Any]:
+        retention = normalize_event_retention(event_retention)
+        conn = self.connect()
+        try:
+            return engine_event_stats_from_connection(
+                conn,
+                workflow=self.workflow,
+                now_epoch=self._now_epoch(),
+                retention=retention,
+            )
+        finally:
+            conn.close()
+
+    def doctor(
+        self,
+        *,
+        stale_running_seconds: int = 600,
+        event_retention: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
         checks: list[dict[str, Any]] = []
         try:
             conn = self.connect()
@@ -503,6 +542,42 @@ class EngineStore:
                         else f"{int(event_count or 0)} event(s); no orphaned run references"
                     ),
                     "items": [row[0] for row in orphaned_events],
+                }
+            )
+            event_retention_cfg = normalize_event_retention(event_retention)
+            event_stats = engine_event_stats_from_connection(
+                conn,
+                workflow=self.workflow,
+                now_epoch=now_epoch,
+                retention=event_retention_cfg,
+            )
+            retention = event_stats.get("retention") or {}
+            retention_reasons: list[str] = []
+            if not retention.get("configured") and event_stats.get("total_events"):
+                retention_reasons.append("not configured")
+            if retention.get("excess_rows"):
+                retention_reasons.append(f"excess_rows={retention.get('excess_rows')}")
+            if retention.get("age_overdue"):
+                retention_reasons.append(
+                    f"oldest_age_seconds={int(event_stats.get('oldest_age_seconds') or 0)}"
+                )
+            if retention_reasons:
+                retention_detail = "; ".join(retention_reasons)
+            elif retention.get("configured"):
+                retention_detail = "configured and within retention limits"
+            else:
+                retention_detail = "not configured; no durable events"
+            checks.append(
+                {
+                    "name": "engine-event-retention",
+                    "status": "warn" if retention_reasons else "pass",
+                    "detail": retention_detail
+                    + (
+                        f"; total_events={event_stats.get('total_events')}"
+                        f"; max_age_seconds={retention.get('max_age_seconds')}"
+                        f"; max_rows={retention.get('max_rows')}"
+                    ),
+                    "details": event_stats,
                 }
             )
 

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -15,6 +15,7 @@ from engine.leases import acquire_engine_lease, init_engine_leases, release_engi
 from engine.store import EngineStore
 from engine.state import init_engine_state
 from engine.sqlite import connect_daedalus_db
+from workflows.contract import WorkflowContractError, load_workflow_contract
 from workflows.shared.paths import (
     plugin_entrypoint_path,
     project_key_for_workflow_root,
@@ -716,6 +717,31 @@ def release_lease(
 
 def _runtime_paths(workflow_root: Path) -> dict[str, Path]:
     return runtime_paths(workflow_root)
+
+
+def _workflow_event_retention(workflow_root: Path) -> dict[str, Any]:
+    try:
+        contract = load_workflow_contract(Path(workflow_root))
+    except (FileNotFoundError, WorkflowContractError, OSError, UnicodeDecodeError):
+        return {}
+    retention = contract.config.get("retention") or {}
+    return retention if isinstance(retention, dict) else {}
+
+
+def _apply_workflow_event_retention(*, workflow_root: Path, workflow: str) -> dict[str, Any]:
+    try:
+        return EngineStore(
+            db_path=runtime_paths(Path(workflow_root))["db_path"],
+            workflow=workflow,
+            now_iso=_now_iso,
+            now_epoch=time.time,
+        ).apply_event_retention(_workflow_event_retention(workflow_root))
+    except Exception as exc:
+        return {
+            "workflow": workflow,
+            "applied": False,
+            "reason": f"{type(exc).__name__}: {exc}",
+        }
 
 
 def _project_key_for(workflow_root: Path) -> str:
@@ -3684,6 +3710,7 @@ def run_shadow_loop(
             }
     iterations = 0
     last_result = None
+    last_retention = _apply_workflow_event_retention(workflow_root=workflow_root, workflow="change-delivery")
     try:
         while True:
             legacy_status = legacy_status_provider() if legacy_status_provider else None
@@ -3692,6 +3719,10 @@ def run_shadow_loop(
                 instance_id=instance_id,
                 legacy_status=legacy_status,
                 now_iso=_now_iso(),
+            )
+            last_retention = _apply_workflow_event_retention(
+                workflow_root=workflow_root,
+                workflow="change-delivery",
             )
             iterations += 1
             if max_iterations is not None and iterations >= max_iterations:
@@ -3703,12 +3734,14 @@ def run_shadow_loop(
             "instance_id": instance_id,
             "iterations": iterations,
             "last_result": last_result,
+            "event_retention": last_retention,
         }
     return {
         "loop_status": "completed",
         "instance_id": instance_id,
         "iterations": iterations,
         "last_result": last_result,
+        "event_retention": last_retention,
     }
 
 
@@ -4049,6 +4082,7 @@ def run_active_loop(
         owned_action_runners = _default_active_action_runners(workflow_root=workflow_root)
         action_runners = owned_action_runners
     loop_status = "completed"
+    last_retention = _apply_workflow_event_retention(workflow_root=workflow_root, workflow="change-delivery")
     try:
         while True:
             completed, supervised_iteration = _reconcile_active_loop_iteration(supervised_iteration)
@@ -4127,6 +4161,10 @@ def run_active_loop(
                     "running_iteration": _active_loop_running_snapshot(supervised_iteration),
                 }
             iterations += 1
+            last_retention = _apply_workflow_event_retention(
+                workflow_root=workflow_root,
+                workflow="change-delivery",
+            )
             if max_iterations is not None and iterations >= max_iterations:
                 break
             sleep_fn(interval_seconds)
@@ -4154,6 +4192,7 @@ def run_active_loop(
         "iterations": iterations,
         "last_result": last_result,
         "running_iteration": _active_loop_running_snapshot(supervised_iteration),
+        "event_retention": last_retention,
     }
 
 

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -2096,7 +2096,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         after = before
         if before["health"] != "healthy" or fix_watchers:
             after = ns.reconcile(fix_watchers=fix_watchers)
-        engine_checks = ns.ENGINE_STORE.doctor()
+        engine_checks = ns.ENGINE_STORE.doctor(event_retention=(ns.WORKFLOW_YAML or {}).get("retention") or {})
         ns.audit(
             "doctor",
             f"Doctor checked workflow: {before['health']} -> {after['health']}",
@@ -2110,6 +2110,16 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             "engineChecks": engine_checks,
             "fixed": before["health"] != after["health"] or bool(after.get("actionsTaken", {}).get("jobs")),
         }
+
+    def apply_event_retention():
+        try:
+            return ns.ENGINE_STORE.apply_event_retention((ns.WORKFLOW_YAML or {}).get("retention") or {})
+        except Exception as exc:
+            return {
+                "workflow": "change-delivery",
+                "applied": False,
+                "reason": f"{type(exc).__name__}: {exc}",
+            }
 
     # -----------------------------------------------------------------
     # Cron operator commands: pause / resume / wake.
@@ -2382,6 +2392,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
                 pass
             raise
         finally:
+            ns.apply_event_retention()
             ns.CURRENT_ENGINE_RUN_ID = previous_run_id
 
     def dispatch_implementation_turn():

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -421,7 +421,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         except Exception as exc:
             checks.append({"name": "agent-runtime", "status": "fail", "detail": str(exc)})
 
-        checks.extend(self.engine_store.doctor())
+        checks.extend(self.engine_store.doctor(event_retention=self.config.get("retention") or {}))
         ok = all(check["status"] == "pass" for check in checks)
         return {
             "ok": ok,
@@ -480,6 +480,16 @@ class IssueRunnerWorkspace(WorkflowDriver):
         except Exception as exc:
             checks.append({"name": "github-repo", "status": "fail", "detail": str(exc)})
         return checks
+
+    def _apply_event_retention(self) -> dict[str, Any]:
+        try:
+            return self.engine_store.apply_event_retention(self.config.get("retention") or {})
+        except Exception as exc:
+            return {
+                "workflow": "issue-runner",
+                "applied": False,
+                "reason": f"{type(exc).__name__}: {exc}",
+            }
 
     def _runtime_diagnostics(self) -> dict[str, dict[str, Any]]:
         diagnostics: dict[str, dict[str, Any]] = {}
@@ -1528,6 +1538,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
         except Exception as exc:
             self._fail_engine_run_after_exception(engine_run, exc)
             raise
+        finally:
+            self._apply_event_retention()
 
     def _cleanup_terminal_workspaces(self, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
         tracker_cfg = self.config.get("tracker") or {}
@@ -1788,11 +1800,13 @@ class IssueRunnerWorkspace(WorkflowDriver):
     ) -> dict[str, Any]:
         iterations = 0
         last_result = None
+        last_retention = self._apply_event_retention()
         loop_status = "completed"
         try:
             while True:
                 self.reload_contract()
                 last_result = self.supervise_once()
+                last_retention = self._apply_event_retention()
                 iterations += 1
                 if max_iterations is not None and iterations >= max_iterations:
                     break
@@ -1806,6 +1820,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "loop_status": loop_status,
             "iterations": iterations,
             "last_result": last_result,
+            "event_retention": last_retention,
         }
 
     def reload_contract(self) -> None:

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -100,8 +100,14 @@ retention:
 Apply it manually or from automation:
 
 ```bash
+hermes daedalus events stats --workflow-root ~/.hermes/workflows/<profile>
 hermes daedalus events prune --workflow-root ~/.hermes/workflows/<profile>
 ```
+
+The long-running service applies configured SQLite event retention automatically
+at startup and after each supervised loop/tick. Manual `events prune` is for
+one-off cleanup, emergency compaction, or testing a new retention policy before
+running the service.
 
 For JSONL tails, archive files normally if they grow too large. The next event
 write creates a fresh `daedalus-events.jsonl`.
@@ -135,6 +141,7 @@ All events share a common envelope:
 Use the engine ledger first:
 
 ```bash
+hermes daedalus events stats --workflow-root ~/.hermes/workflows/<profile>
 hermes daedalus events --workflow-root ~/.hermes/workflows/<profile> --limit 50
 hermes daedalus events --workflow-root ~/.hermes/workflows/<profile> --run-id <run_id>
 hermes daedalus events --workflow-root ~/.hermes/workflows/<profile> --work-id ISSUE-123

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -14,6 +14,7 @@ It is specifically written for the opinionated `change-delivery` workflow.
 | **Check status** | `/daedalus status` |
 | **Full health check** | `/daedalus doctor` |
 | **Live dashboard** | `/daedalus watch` |
+| **Event retention posture** | `/daedalus events stats` |
 | **Service health** | `systemctl --user status daedalus-active@<profile>.service` |
 | **Recent logs** | `journalctl --user -u daedalus-active@<profile>.service -n 200` |
 | **Lane actions (SQL)** | `select action_id, action_type, status, retry_count from lane_actions where lane_id='lane:220' order by requested_at desc;` |
@@ -54,6 +55,7 @@ It is specifically written for the opinionated `change-delivery` workflow.
 /daedalus status              # Runtime row, lane count, paths, freshness
 /daedalus doctor              # Full health check across all subsystems
 /daedalus watch               # Live TUI: lanes + alerts + events
+/daedalus events stats        # Event counts plus retention limit posture
 /daedalus shadow-report       # Diff shadow plan vs active reality
 /daedalus active-gate-status  # What's blocking promotion to active
 /daedalus service-status      # systemd health snapshot

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -19,6 +19,8 @@ workflow exposes the richer `change-delivery` command surface.
 | `/daedalus status` | Runtime row + lane count + paths (DB, event log) |
 | `/daedalus doctor` | Full health check across all subsystems |
 | `/daedalus events` | Query the durable engine event ledger |
+| `/daedalus events stats` | Count durable events by type/severity and show retention posture |
+| `/daedalus events prune` | Apply explicit or `WORKFLOW.md` event retention immediately |
 | `/daedalus runs` | Inspect durable engine run history |
 | `/daedalus shadow-report` | `change-delivery` shadow-mode action proposal vs active/runtime state |
 | `/daedalus active-gate-status` | Active-execution gate state and blockers |

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -390,9 +390,26 @@ def test_engine_store_filters_and_prunes_events(tmp_path):
     assert [event["work_id"] for event in store.events(work_id="ISSUE-1", order="asc")] == ["ISSUE-1", "ISSUE-1"]
     assert store.events(severity="warn")[0]["work_id"] == "ISSUE-2"
 
-    pruned = store.prune_events(max_rows=1)
+    stats = store.event_stats({"events": {"max-age-seconds": 1, "max-rows": 2}})
+    checks = {
+        check["name"]: check
+        for check in store.doctor(event_retention={"events": {"max-age-seconds": 1, "max-rows": 2}})
+    }
+    not_configured = store.apply_event_retention({})
+    pruned = store.apply_event_retention({"events": {"max-rows": 1}})
     remaining = store.events()
 
+    assert stats["total_events"] == 3
+    assert stats["oldest_age_seconds"] == 2.0
+    assert stats["by_type"] == {"b": 2, "a": 1}
+    assert stats["by_severity"] == {"info": 2, "warn": 1}
+    assert stats["retention"]["excess_rows"] == 1
+    assert stats["retention"]["age_overdue"] is True
+    assert checks["engine-event-retention"]["status"] == "warn"
+    assert "excess_rows=1" in checks["engine-event-retention"]["detail"]
+    assert not_configured["applied"] is False
+    assert not_configured["reason"] == "not-configured"
+    assert pruned["applied"] is True
     assert pruned["deleted"] == 2
     assert pruned["remaining"] == 1
     assert remaining[0]["event_type"] == "b"

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -427,6 +427,40 @@ def test_run_active_loop_reconciles_fast_supervised_iteration_before_bounded_exi
     assert action_status == "completed"
 
 
+def test_runtime_event_retention_uses_repo_owned_workflow_contract(runtime_module, tmp_path):
+    from engine.store import EngineStore
+    from workflows.contract import render_workflow_markdown
+
+    workflow_root = tmp_path / "workflow"
+    workflow_root.mkdir()
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "change-delivery",
+                "retention": {"events": {"max-rows": 1}},
+            },
+            prompt_template="Deliver the active change.",
+        ),
+        encoding="utf-8",
+    )
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    store = EngineStore(
+        db_path=runtime_module._runtime_paths(workflow_root)["db_path"],
+        workflow="change-delivery",
+    )
+    store.append_event(event_type="old", payload={"lane_id": "lane:1"})
+    store.append_event(event_type="new", payload={"lane_id": "lane:2"})
+
+    result = runtime_module._apply_workflow_event_retention(
+        workflow_root=workflow_root,
+        workflow="change-delivery",
+    )
+
+    assert result["applied"] is True
+    assert result["deleted"] == 1
+    assert len(store.events()) == 1
+
+
 def test_run_active_loop_heartbeats_while_supervised_iteration_is_running(runtime_module, tmp_path, monkeypatch):
     workflow_root = tmp_path / "workflow"
     paths = runtime_module._runtime_paths(workflow_root)

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -183,12 +183,18 @@ def test_execute_raw_args_events_lists_and_prunes_engine_events(tmp_path):
 
     output = tools.execute_raw_args(f"events --workflow-root {root} --work-id ISSUE-2 --json")
     payload = json.loads(output)
+    stats_output = tools.execute_raw_args(f"events --workflow-root {root} stats --json")
+    stats_payload = json.loads(stats_output)
     prune_output = tools.execute_raw_args(f"events --workflow-root {root} prune --json")
     prune_payload = json.loads(prune_output)
 
     assert payload["workflow"] == "issue-runner"
     assert payload["events"][0]["event_type"] == "b"
     assert payload["events"][0]["work_id"] == "ISSUE-2"
+    assert stats_payload["mode"] == "stats"
+    assert stats_payload["stats"]["total_events"] == 2
+    assert stats_payload["stats"]["retention"]["max_rows"] == 1
+    assert stats_payload["stats"]["retention"]["excess_rows"] == 1
     assert prune_payload["deleted"] == 1
     assert prune_payload["remaining"] == 1
 

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -881,6 +881,35 @@ def test_issue_runner_run_loop_reconciles_completed_worker_before_interrupt_exit
     assert workspace.build_status()["scheduler"]["running"] == []
 
 
+def test_issue_runner_run_loop_applies_event_retention(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    cfg["retention"] = {"events": {"max-rows": 1}}
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[],
+    )
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=lambda *args, **kwargs: None,
+        run_json=lambda *args, **kwargs: {},
+    )
+    workspace.engine_store.append_event(event_type="old", payload={"issue_id": "ISSUE-1"})
+    workspace.engine_store.append_event(event_type="new", payload={"issue_id": "ISSUE-2"})
+
+    result = workspace.run_loop(interval_seconds=1, max_iterations=1, sleep_fn=lambda _seconds: None)
+    stats = workspace.engine_store.event_stats(cfg["retention"])
+
+    assert result["event_retention"]["applied"] is True
+    assert stats["total_events"] <= 1
+    assert stats["retention"]["overdue"] is False
+
+
 def test_issue_runner_supervised_terminal_issue_requests_cancel_and_defers_cleanup(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 


### PR DESCRIPTION
## Summary
- add normalized WORKFLOW.md event-retention handling plus engine event stats
- apply configured retention from issue-runner and change-delivery service loops/ticks
- expose /daedalus events stats and retention checks in doctor surfaces
- document stats/prune behavior and add focused regression coverage

## Tests
- pytest tests/test_engine_primitives.py tests/test_tools_run_cli_command_dispatch.py tests/test_workflows_issue_runner_workspace.py tests/test_runtime_tools_alerts.py -q
- git diff --check
- python -m compileall daedalus/engine daedalus/daedalus_cli.py daedalus/runtime.py daedalus/workflows/issue_runner/workspace.py daedalus/workflows/change_delivery/workspace.py
- pytest -q