### PR TITLE
[codex] Harden workflow contract validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ hermes plugins install attmous/daedalus --enable
 cd /path/to/your/repo
 hermes daedalus bootstrap
 $EDITOR WORKFLOW.md
+hermes daedalus validate
 hermes daedalus service-up
 hermes
 ```
@@ -77,6 +78,7 @@ Inside Hermes Agent:
 # Daedalus engine and service commands
 /daedalus status                            # show runtime state, workflow root, and important paths
 /daedalus doctor                            # run health checks across config, service, state, and integrations
+/daedalus validate                          # validate WORKFLOW.md, schema, service mode, and preflight
 /daedalus watch                             # render a live operator view
 /daedalus events --limit 20                 # inspect the durable engine event ledger
 /daedalus service-status                    # show the systemd user service state

--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -38,6 +38,7 @@ from workflows.contract import (
     workflow_markdown_path,
     write_workflow_contract_pointer,
 )
+from workflows.validation import validate_workflow_contract
 from workflows.shared.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -423,13 +424,21 @@ def install_supervised_service(
     interval_seconds: int,
     service_name: str | None = None,
     service_mode: str = "shadow",
+    validate_contract: bool = True,
 ) -> dict[str, Any]:
     plugin_runtime_path = _expected_plugin_runtime_path(workflow_root)
     if not plugin_runtime_path.exists():
         raise DaedalusCommandError(
             f"Daedalus plugin runtime not found at {plugin_runtime_path}; install the plugin into ~/.hermes/plugins/daedalus before installing the service"
         )
-    workflow_name = _assert_service_mode_supported(workflow_root=workflow_root, service_mode=service_mode)
+    if validate_contract:
+        preflight_result = _validate_workflow_contract_preflight_for_service(
+            workflow_root=workflow_root,
+            service_mode=service_mode,
+        )
+        workflow_name = str(preflight_result.get("workflow") or "")
+    else:
+        workflow_name = _assert_service_mode_supported(workflow_root=workflow_root, service_mode=service_mode)
     workspace = workflow_root.name
     resolved_service_name = _resolve_service_name(
         service_name=service_name, service_mode=service_mode, workspace=workspace
@@ -460,51 +469,51 @@ def install_supervised_service(
 
 
 def _validate_workflow_contract_preflight(workflow_root: Path) -> dict[str, Any]:
-    import jsonschema
-    from workflows import load_workflow
+    return _validate_workflow_contract_preflight_for_service(
+        workflow_root=workflow_root,
+        service_mode=None,
+    )
 
-    contract = load_workflow_contract(workflow_root)
-    config = contract.config
-    workflow_name = config.get("workflow")
-    if not workflow_name:
-        raise DaedalusCommandError(
-            f"{contract.source_path} is missing top-level `workflow:` field"
-        )
-    module = load_workflow(str(workflow_name))
-    schema = yaml.safe_load(module.CONFIG_SCHEMA_PATH.read_text(encoding="utf-8"))
-    jsonschema.validate(config, schema)
-    schema_version = int(config.get("schema-version", 1))
-    if schema_version not in module.SUPPORTED_SCHEMA_VERSIONS:
-        raise DaedalusCommandError(
-            f"workflow {workflow_name!r} does not support schema-version={schema_version}; "
-            f"supported: {list(module.SUPPORTED_SCHEMA_VERSIONS)}"
-        )
-    preflight_fn = getattr(module, "run_preflight", None)
-    if callable(preflight_fn):
-        result = preflight_fn(config)
-        if not getattr(result, "ok", True):
-            raise DaedalusCommandError(
-                f"workflow preflight failed for {workflow_name!r}: "
-                f"code={getattr(result, 'error_code', None)} "
-                f"detail={getattr(result, 'error_detail', None)}"
-            )
-        return {
-            "ok": True,
-            "workflow": workflow_name,
-            "schema_version": schema_version,
-            "preflight": {
-                "ok": True,
-                "error_code": getattr(result, "error_code", None),
-                "error_detail": getattr(result, "error_detail", None),
-            },
-            "source_path": str(contract.source_path),
-        }
+
+def build_validate_report(*, workflow_root: Path, service_mode: str | None = None) -> dict[str, Any]:
+    return validate_workflow_contract(workflow_root, service_mode=service_mode)
+
+
+def _validation_failure_summary(report: dict[str, Any]) -> str:
+    failures = report.get("failures") or []
+    if not failures:
+        return "workflow contract validation failed"
+    lines = ["workflow contract validation failed:"]
+    for check in failures[:8]:
+        lines.append(f"- {check.get('name')}: {check.get('detail')}")
+        for item in (check.get("items") or [])[:5]:
+            path = item.get("path") or "<root>"
+            message = item.get("message") or item
+            lines.append(f"  {path}: {message}")
+    if len(failures) > 8:
+        lines.append(f"- ... {len(failures) - 8} more failing checks")
+    return "\n".join(lines)
+
+
+def _assert_workflow_validation_ok(report: dict[str, Any]) -> None:
+    if not report.get("ok"):
+        raise DaedalusCommandError(_validation_failure_summary(report))
+
+
+def _validate_workflow_contract_preflight_for_service(
+    *,
+    workflow_root: Path,
+    service_mode: str | None,
+) -> dict[str, Any]:
+    report = build_validate_report(workflow_root=workflow_root, service_mode=service_mode)
+    _assert_workflow_validation_ok(report)
     return {
         "ok": True,
-        "workflow": workflow_name,
-        "schema_version": schema_version,
-        "preflight": {"ok": True, "error_code": None, "error_detail": None},
-        "source_path": str(contract.source_path),
+        "workflow": report.get("workflow"),
+        "schema_version": report.get("schema_version"),
+        "source_path": report.get("source_path"),
+        "checks": report.get("checks") or [],
+        "warnings": report.get("warnings") or [],
     }
 
 
@@ -796,7 +805,10 @@ def service_up(
     service_name: str | None = None,
     service_mode: str = "active",
 ) -> dict[str, Any]:
-    preflight_result = _validate_workflow_contract_preflight(workflow_root)
+    preflight_result = _validate_workflow_contract_preflight_for_service(
+        workflow_root=workflow_root,
+        service_mode=service_mode,
+    )
     workflow_name = preflight_result.get("workflow")
     if workflow_name == "change-delivery":
         daedalus = _load_daedalus_module(workflow_root)
@@ -816,6 +828,7 @@ def service_up(
         interval_seconds=interval_seconds,
         service_name=service_name,
         service_mode=service_mode,
+        validate_contract=False,
     )
     if not install_result.get("installed"):
         daemon_reload = install_result.get("daemon_reload") or {}
@@ -2934,6 +2947,18 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     )
     doctor_cmd.set_defaults(func=run_cli_command)
 
+    validate_cmd = sub.add_parser("validate", help="Validate the repo-owned WORKFLOW.md contract and workflow preflight rules.")
+    validate_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    validate_cmd.add_argument("--service-mode", choices=sorted(SERVICE_PROFILES))
+    validate_cmd.add_argument("--json", action="store_true")
+    validate_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    validate_cmd.set_defaults(func=run_cli_command)
+
     runs_cmd = sub.add_parser("runs", help="Inspect durable engine run history and run timelines.")
     runs_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
     runs_cmd.add_argument("runs_action", nargs="?", default="list", choices=["list", "failed", "stale", "show"])
@@ -3396,7 +3421,7 @@ def _resolve_format(format_arg: str | None, json_flag: bool | None) -> str:
 def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     workflow_root = Path(args.workflow_root).resolve() if hasattr(args, "workflow_root") else None
     daedalus = _load_daedalus_module(workflow_root) if workflow_root is not None else None
-    eventless_commands = {"codex-app-server", "runs", "events"}
+    eventless_commands = {"codex-app-server", "runs", "events", "validate"}
     if (
         workflow_root is not None
         and daedalus is not None
@@ -3443,6 +3468,11 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
         return build_doctor_report(
             workflow_root=workflow_root,
             recent_actions_limit=args.recent_actions_limit,
+        )
+    if args.daedalus_command == "validate":
+        return build_validate_report(
+            workflow_root=workflow_root,
+            service_mode=getattr(args, "service_mode", None),
         )
     if args.daedalus_command == "runs":
         return build_runs_report(
@@ -3735,6 +3765,26 @@ def render_result(
             spec.loader.exec_module(mod)
             _fmt = mod.format_doctor
         return _fmt(result)
+    if command == "validate":
+        checks = result.get("checks") or []
+        failures = result.get("failures") or []
+        warnings = result.get("warnings") or []
+        lines = [
+            f"workflow contract valid={result.get('ok')} workflow={result.get('workflow')}",
+            f"source={result.get('source_path')}",
+            f"checks={len(checks)} failures={len(failures)} warnings={len(warnings)}",
+        ]
+        for check in checks:
+            prefix = {"pass": "PASS", "warn": "WARN", "fail": "FAIL", "skip": "SKIP"}.get(
+                str(check.get("status")),
+                str(check.get("status")).upper(),
+            )
+            lines.append(f"- {prefix} {check.get('name')}: {check.get('detail')}")
+            for item in (check.get("items") or [])[:5]:
+                path = item.get("path") if isinstance(item, dict) else None
+                message = item.get("message") if isinstance(item, dict) else str(item)
+                lines.append(f"  {path or '<root>'}: {message}")
+        return "\n".join(lines)
     if command == "runs":
         if result.get("mode") == "show":
             run = result.get("run") or {}

--- a/daedalus/workflows/__init__.py
+++ b/daedalus/workflows/__init__.py
@@ -13,6 +13,7 @@ must expose these five attributes in its package ``__init__.py``:
 from __future__ import annotations
 
 import importlib
+import inspect
 from pathlib import Path
 from types import ModuleType
 
@@ -115,7 +116,10 @@ def run_cli(
         and invoked_command in gated_commands
     )
     if should_gate:
-        result = preflight_fn(cfg)
+        if "workflow_root" in inspect.signature(preflight_fn).parameters:
+            result = preflight_fn(cfg, workflow_root=workflow_root)
+        else:
+            result = preflight_fn(cfg)
         if not getattr(result, "ok", True):
             _emit_dispatch_skipped_event(
                 workflow_root=workflow_root,

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -21,15 +21,15 @@ class PreflightResult:
     error_detail: str | None = None
 
 
-def run_preflight(config: dict[str, Any]) -> PreflightResult:
+def run_preflight(config: dict[str, Any], *, workflow_root: Path | None = None) -> PreflightResult:
     try:
-        _validate_config(config)
+        _validate_config(config, workflow_root=workflow_root or Path("."))
     except RuntimeError as exc:
         return PreflightResult(ok=False, error_code="invalid-config", error_detail=str(exc))
     return PreflightResult(ok=True)
 
 
-def _validate_config(config: dict[str, Any]) -> None:
+def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
     daedalus_cfg = config.get("daedalus") or {}
     runtimes = config.get("runtimes") or (daedalus_cfg.get("runtimes") if isinstance(daedalus_cfg, dict) else {}) or {}
     agent = config.get("agent") or {}
@@ -53,7 +53,6 @@ def _validate_config(config: dict[str, Any]) -> None:
     elif not (agent.get("command") or codex_cfg.get("command")):
         raise RuntimeError("issue-runner requires agent.runtime, agent.command, or codex.command")
 
-    workflow_root = Path(".")
     tracker_cfg = config.get("tracker") or {}
     repository_cfg = config.get("repository") or {}
     repo_raw = str(
@@ -86,7 +85,9 @@ def _validate_config(config: dict[str, Any]) -> None:
                 repo_path=repo_path,
             )
         if str(tracker_cfg.get("kind") or "").strip() == "local-json":
-            resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg)
+            path = resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg)
+            if not path.exists():
+                raise TrackerConfigError(f"tracker.path does not exist: {path}")
         client = build_tracker_client(
             workflow_root=workflow_root,
             tracker_cfg=tracker_client_cfg,

--- a/daedalus/workflows/validation.py
+++ b/daedalus/workflows/validation.py
@@ -1,0 +1,256 @@
+"""Workflow contract validation used by operator commands and service setup."""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from . import load_workflow
+from .contract import WorkflowContract, WorkflowContractError, load_workflow_contract
+
+
+SERVICE_MODES = frozenset({"active", "shadow"})
+
+
+def _check(name: str, status: str, detail: str, **extra: Any) -> dict[str, Any]:
+    payload = {"name": name, "status": status, "detail": detail}
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    return payload
+
+
+def _json_path(parts: Any) -> str:
+    values = [str(part) for part in parts]
+    return ".".join(values) if values else "<root>"
+
+
+def _schema_error_item(error: jsonschema.ValidationError) -> dict[str, Any]:
+    return {
+        "path": _json_path(error.absolute_path),
+        "message": error.message,
+        "validator": str(error.validator),
+    }
+
+
+def _schema_errors(*, config: dict[str, Any], schema: dict[str, Any]) -> list[dict[str, Any]]:
+    validator = jsonschema.Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(config), key=lambda item: list(item.absolute_path))
+    return [_schema_error_item(error) for error in errors]
+
+
+def _call_preflight(preflight_fn: Any, *, config: dict[str, Any], workflow_root: Path) -> Any:
+    signature = inspect.signature(preflight_fn)
+    if "workflow_root" in signature.parameters:
+        return preflight_fn(config, workflow_root=workflow_root)
+    return preflight_fn(config)
+
+
+def _repository_path_check(*, workflow_root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    repository = config.get("repository") or {}
+    if not isinstance(repository, dict):
+        return _check("repository-path", "fail", "repository must be a mapping")
+    raw = str(repository.get("local-path") or repository.get("local_path") or "").strip()
+    if not raw:
+        return _check("repository-path", "fail", "repository.local-path is required")
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = (workflow_root / path).resolve()
+    if not path.exists():
+        return _check("repository-path", "fail", f"repository.local-path does not exist: {path}")
+    if not path.is_dir():
+        return _check("repository-path", "fail", f"repository.local-path is not a directory: {path}")
+    return _check("repository-path", "pass", str(path))
+
+
+def _instance_name_check(*, workflow_root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    instance = config.get("instance") or {}
+    if not isinstance(instance, dict):
+        return _check("instance-name", "fail", "instance must be a mapping")
+    name = str(instance.get("name") or "").strip()
+    if not name:
+        return _check("instance-name", "fail", "instance.name is required")
+    if name != workflow_root.name:
+        return _check(
+            "instance-name",
+            "fail",
+            f"instance.name={name!r} must match workflow root directory {workflow_root.name!r}",
+        )
+    return _check("instance-name", "pass", name)
+
+
+def _service_mode_check(*, workflow_name: str | None, service_mode: str | None) -> dict[str, Any] | None:
+    if not service_mode:
+        return None
+    if service_mode not in SERVICE_MODES:
+        return _check(
+            "service-mode",
+            "fail",
+            f"unknown service mode {service_mode!r}; expected one of {sorted(SERVICE_MODES)}",
+        )
+    if workflow_name == "issue-runner" and service_mode != "active":
+        return _check(
+            "service-mode",
+            "fail",
+            "issue-runner supports only active supervised mode; use --service-mode active",
+        )
+    return _check("service-mode", "pass", f"{workflow_name}:{service_mode}")
+
+
+def _contract_kind_check(contract: WorkflowContract) -> dict[str, Any]:
+    if contract.source_path.suffix.lower() == ".md":
+        return _check("contract-format", "pass", "repo-owned Markdown workflow contract")
+    return _check(
+        "contract-format",
+        "warn",
+        "legacy YAML workflow contract loaded; prefer repo-owned WORKFLOW.md",
+    )
+
+
+def validate_workflow_contract(
+    workflow_root: Path,
+    *,
+    service_mode: str | None = None,
+    run_preflight: bool = True,
+) -> dict[str, Any]:
+    root = Path(workflow_root).expanduser().resolve()
+    checks: list[dict[str, Any]] = []
+    contract: WorkflowContract | None = None
+    workflow_name: str | None = None
+    schema_version: int | None = None
+    source_path: str | None = None
+
+    try:
+        contract = load_workflow_contract(root)
+        source_path = str(contract.source_path)
+        checks.append(_check("contract-file", "pass", str(contract.source_path)))
+        checks.append(_contract_kind_check(contract))
+    except FileNotFoundError as exc:
+        checks.append(_check("contract-file", "fail", str(exc)))
+    except (WorkflowContractError, OSError, UnicodeDecodeError) as exc:
+        checks.append(_check("contract-file", "fail", str(exc)))
+
+    if contract is None:
+        return _validation_report(
+            workflow_root=root,
+            source_path=source_path,
+            workflow_name=workflow_name,
+            schema_version=schema_version,
+            checks=checks,
+        )
+
+    config = contract.config
+    workflow_name = str(config.get("workflow") or "").strip() or None
+    if not workflow_name:
+        checks.append(_check("workflow-field", "fail", "top-level workflow field is required"))
+        return _validation_report(
+            workflow_root=root,
+            source_path=source_path,
+            workflow_name=workflow_name,
+            schema_version=schema_version,
+            checks=checks,
+        )
+    checks.append(_check("workflow-field", "pass", workflow_name))
+
+    module = None
+    try:
+        module = load_workflow(workflow_name)
+        checks.append(_check("workflow-package", "pass", f"workflows.{workflow_name.replace('-', '_')}"))
+    except Exception as exc:
+        checks.append(_check("workflow-package", "fail", str(exc)))
+
+    if module is not None:
+        try:
+            schema = yaml.safe_load(module.CONFIG_SCHEMA_PATH.read_text(encoding="utf-8"))
+            if not isinstance(schema, dict):
+                raise WorkflowContractError(f"{module.CONFIG_SCHEMA_PATH} must decode to a mapping")
+            errors = _schema_errors(config=config, schema=schema)
+            if errors:
+                checks.append(
+                    _check(
+                        "schema",
+                        "fail",
+                        f"{len(errors)} schema violation(s)",
+                        items=errors,
+                    )
+                )
+            else:
+                checks.append(_check("schema", "pass", str(module.CONFIG_SCHEMA_PATH)))
+        except Exception as exc:
+            checks.append(_check("schema", "fail", str(exc)))
+
+        try:
+            schema_version = int(config.get("schema-version", 1))
+            supported = tuple(int(item) for item in module.SUPPORTED_SCHEMA_VERSIONS)
+            if schema_version not in supported:
+                checks.append(
+                    _check(
+                        "schema-version",
+                        "fail",
+                        f"schema-version={schema_version} not supported; supported={list(supported)}",
+                    )
+                )
+            else:
+                checks.append(_check("schema-version", "pass", str(schema_version)))
+        except Exception as exc:
+            checks.append(_check("schema-version", "fail", str(exc)))
+
+    service_check = _service_mode_check(workflow_name=workflow_name, service_mode=service_mode)
+    if service_check is not None:
+        checks.append(service_check)
+
+    checks.append(_instance_name_check(workflow_root=root, config=config))
+    checks.append(_repository_path_check(workflow_root=root, config=config))
+
+    if module is not None and run_preflight:
+        preflight_fn = getattr(module, "run_preflight", None)
+        if callable(preflight_fn):
+            try:
+                result = _call_preflight(preflight_fn, config=config, workflow_root=root)
+                ok = bool(getattr(result, "ok", True))
+                code = getattr(result, "error_code", None)
+                detail = getattr(result, "error_detail", None)
+                checks.append(
+                    _check(
+                        "workflow-preflight",
+                        "pass" if ok else "fail",
+                        "ok" if ok else f"code={code} detail={detail}",
+                        error_code=code,
+                        error_detail=detail,
+                    )
+                )
+            except Exception as exc:
+                checks.append(_check("workflow-preflight", "fail", f"{type(exc).__name__}: {exc}"))
+        else:
+            checks.append(_check("workflow-preflight", "skip", "workflow has no preflight hook"))
+
+    return _validation_report(
+        workflow_root=root,
+        source_path=source_path,
+        workflow_name=workflow_name,
+        schema_version=schema_version,
+        checks=checks,
+    )
+
+
+def _validation_report(
+    *,
+    workflow_root: Path,
+    source_path: str | None,
+    workflow_name: str | None,
+    schema_version: int | None,
+    checks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    failures = [check for check in checks if check.get("status") == "fail"]
+    warnings = [check for check in checks if check.get("status") == "warn"]
+    return {
+        "ok": not failures,
+        "workflow_root": str(workflow_root),
+        "source_path": source_path,
+        "workflow": workflow_name,
+        "schema_version": schema_version,
+        "checks": checks,
+        "failures": failures,
+        "warnings": warnings,
+    }

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -13,6 +13,7 @@ It is specifically written for the opinionated `change-delivery` workflow.
 |:---|:---|
 | **Check status** | `/daedalus status` |
 | **Full health check** | `/daedalus doctor` |
+| **Validate config** | `/daedalus validate` |
 | **Live dashboard** | `/daedalus watch` |
 | **Event retention posture** | `/daedalus events stats` |
 | **Service health** | `systemctl --user status daedalus-active@<profile>.service` |
@@ -54,6 +55,7 @@ It is specifically written for the opinionated `change-delivery` workflow.
 ```text
 /daedalus status              # Runtime row, lane count, paths, freshness
 /daedalus doctor              # Full health check across all subsystems
+/daedalus validate            # Validate WORKFLOW.md, schema, and preflight rules
 /daedalus watch               # Live TUI: lanes + alerts + events
 /daedalus events stats        # Event counts plus retention limit posture
 /daedalus shadow-report       # Diff shadow plan vs active reality

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -157,8 +157,14 @@ prompts; `issue-runner` renders it as the issue prompt template.
 ## Bring it up
 
 ```bash
+hermes daedalus validate
 hermes daedalus service-up
 ```
+
+Run `validate` after editing `WORKFLOW.md`. It checks the contract file,
+workflow schema, schema version, instance naming, repository path, service mode,
+and workflow preflight rules. `service-up` runs the same validation again before
+it installs or starts the user service.
 
 `service-up` runs the supported post-edit path in one command:
 

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -18,6 +18,7 @@ workflow exposes the richer `change-delivery` command surface.
 |---|---|
 | `/daedalus status` | Runtime row + lane count + paths (DB, event log) |
 | `/daedalus doctor` | Full health check across all subsystems |
+| `/daedalus validate` | Validate `WORKFLOW.md`, schema, service mode, and workflow preflight |
 | `/daedalus events` | Query the durable engine event ledger |
 | `/daedalus events stats` | Count durable events by type/severity and show retention posture |
 | `/daedalus events prune` | Apply explicit or `WORKFLOW.md` event retention immediately |

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -66,6 +66,26 @@ The YAML front matter is structured operator configuration:
 
 Each workflow validates this section against its own schema before dispatch.
 
+Validate it explicitly after every config edit:
+
+```bash
+hermes daedalus validate
+hermes daedalus validate --service-mode active --format json
+```
+
+The validator checks:
+
+| Check | What it catches |
+|---|---|
+| Contract file | Missing file, parse errors, unsupported format |
+| Workflow package | Unknown workflow names or broken workflow packages |
+| Schema | Missing fields, wrong types, unsupported enum values |
+| Schema version | Contract versions not supported by the installed plugin |
+| Service mode | Invalid modes, such as `shadow` for `issue-runner` |
+| Instance name | `instance.name` not matching the workflow root directory |
+| Repository path | Missing or non-directory `repository.local-path` |
+| Workflow preflight | Tracker/runtime references that cannot dispatch safely |
+
 ## Markdown Body
 
 The Markdown body is policy text. Workflows decide how to use it:
@@ -78,5 +98,11 @@ hot reload to keep the last known good config if a bad edit lands.
 
 ## Examples
 
-- [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md)
-- [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md)
+| Example | Use it when |
+|---|---|
+| [`docs/examples/issue-runner.workflow.md`](../examples/issue-runner.workflow.md) | You want the default generic issue-runner contract. |
+| [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | You want the opinionated issue-to-PR-to-merge contract. |
+
+For production, start from the same examples and fill in tracker credentials,
+real runtime profiles, retention limits, hooks, gates, and observability
+settings before running `hermes daedalus service-up`.

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -1,0 +1,128 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from workflows.contract import render_workflow_markdown
+from workflows.validation import validate_workflow_contract
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
+
+
+def _tools():
+    module_path = REPO_ROOT / "daedalus_cli.py"
+    spec = importlib.util.spec_from_file_location("daedalus_tools_workflow_validation_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_issue_runner_contract(root: Path, repo: Path, *, overrides: dict | None = None) -> None:
+    (root / "config").mkdir(parents=True, exist_ok=True)
+    (root / "config" / "issues.json").write_text(
+        json.dumps({"issues": [{"id": "ISSUE-1", "title": "First", "state": "todo"}]}),
+        encoding="utf-8",
+    )
+    config = {
+        "workflow": "issue-runner",
+        "schema-version": 1,
+        "instance": {"name": root.name, "engine-owner": "hermes"},
+        "repository": {"local-path": str(repo), "slug": "attmous/daedalus"},
+        "tracker": {"kind": "local-json", "path": "config/issues.json"},
+        "workspace": {"root": "workspace/issues"},
+        "agent": {"name": "Issue_Runner_Agent", "model": "gpt-5.4", "runtime": "default"},
+        "daedalus": {"runtimes": {"default": {"kind": "hermes-agent", "command": ["echo", "{prompt_path}"]}}},
+        "storage": {
+            "status": "memory/workflow-status.json",
+            "health": "memory/workflow-health.json",
+            "audit-log": "memory/workflow-audit.jsonl",
+        },
+    }
+    if overrides:
+        config.update(overrides)
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=config, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+
+def test_validate_workflow_contract_accepts_valid_issue_runner(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_issue_runner_contract(root, repo)
+    monkeypatch.chdir(tmp_path)
+
+    report = validate_workflow_contract(root, service_mode="active")
+
+    assert report["ok"] is True
+    assert report["workflow"] == "issue-runner"
+    assert report["source_path"] == str(root / "WORKFLOW.md")
+    assert {check["name"]: check["status"] for check in report["checks"]}["workflow-preflight"] == "pass"
+
+
+def test_validate_command_reports_schema_and_semantic_failures(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_issue_runner_contract(
+        root,
+        repo,
+        overrides={
+            "instance": {"name": "wrong-name", "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path / "missing"), "slug": "attmous/daedalus"},
+            "storage": None,
+        },
+    )
+
+    tools = _tools()
+    output = tools.execute_raw_args(f"validate --workflow-root {root} --json")
+    payload = json.loads(output)
+    checks = {check["name"]: check for check in payload["checks"]}
+
+    assert payload["ok"] is False
+    assert checks["schema"]["status"] == "fail"
+    assert any(item["path"] == "storage" for item in checks["schema"]["items"])
+    assert checks["instance-name"]["status"] == "fail"
+    assert checks["repository-path"]["status"] == "fail"
+
+
+def test_validate_command_text_keeps_actionable_failures(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_issue_runner_contract(root, repo, overrides={"storage": None})
+
+    tools = _tools()
+    output = tools.execute_raw_args(f"validate --workflow-root {root}")
+
+    assert "workflow contract valid=False" in output
+    assert "FAIL schema" in output
+    assert "storage" in output
+
+
+def test_service_up_refuses_invalid_contract_before_install(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_issue_runner_contract(root, repo, overrides={"storage": None})
+
+    tools = _tools()
+    with pytest.raises(tools.DaedalusCommandError) as exc:
+        tools.service_up(
+            workflow_root=root,
+            project_key=root.name,
+            instance_id=None,
+            interval_seconds=30,
+            service_mode="active",
+        )
+
+    assert "workflow contract validation failed" in str(exc.value)
+    assert "schema" in str(exc.value)


### PR DESCRIPTION
## Summary
- add a structured workflow contract validator used by the new daedalus validate command
- validate schema, schema version, service mode, instance naming, repository path, and workflow preflight
- wire service-up and service-install through the same validation gate before installing/starting services
- make issue-runner preflight resolve relative tracker paths from the actual workflow root
- document the validate step in quickstart, install, slash command, and WORKFLOW.md docs

## Tests
- python -m compileall daedalus/workflows daedalus/daedalus_cli.py
- pytest tests/test_workflow_validation.py tests/test_tools_run_cli_command_dispatch.py tests/test_public_onboarding_smoke.py tests/test_workflows_dispatcher.py -q
- pytest tests/test_systemd_template_units.py tests/test_runtime_tools_alerts.py tests/test_workflows_issue_runner_workspace.py tests/test_workflows_issue_runner_cli.py tests/test_workflows_issue_runner_github_preflight.py -q
- git diff --check
- pytest -q