### PR TITLE
[codex] Add shared tracker feedback

### DIFF
--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -31,6 +31,17 @@ class TrackerClient(Protocol):
 
     def list_terminal(self) -> list[dict[str, Any]]: ...
 
+    def post_feedback(
+        self,
+        *,
+        issue_id: str,
+        event: str,
+        body: str,
+        summary: str,
+        state: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
 
 _TRACKER_KINDS: dict[str, type] = {}
 

--- a/daedalus/trackers/feedback.py
+++ b/daedalus/trackers/feedback.py
@@ -1,0 +1,108 @@
+"""Shared tracker feedback helpers.
+
+Workflows emit stage updates through this module; tracker adapters decide how
+those updates become comments, state transitions, labels, or no-ops.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+DEFAULT_INCLUDE = (
+    "issue.selected",
+    "issue.dispatched",
+    "issue.running",
+    "issue.completed",
+    "issue.failed",
+    "issue.canceled",
+    "issue.retry_scheduled",
+)
+
+
+def feedback_config(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("tracker-feedback") or config.get("tracker_feedback") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def feedback_enabled(config: dict[str, Any]) -> bool:
+    cfg = feedback_config(config)
+    return bool(cfg.get("enabled", False))
+
+
+def event_included(config: dict[str, Any], event: str) -> bool:
+    cfg = feedback_config(config)
+    include = cfg.get("include")
+    if include is None:
+        return event in DEFAULT_INCLUDE
+    if not isinstance(include, list):
+        return False
+    return event in {str(item).strip() for item in include if str(item).strip()}
+
+
+def state_for_event(config: dict[str, Any], event: str) -> str | None:
+    cfg = feedback_config(config)
+    state_cfg = cfg.get("state-updates") or cfg.get("state_updates") or {}
+    if not isinstance(state_cfg, dict) or not state_cfg.get("enabled", False):
+        return None
+    event_key = str(event).strip()
+    short_key = event_key.split(".")[-1].replace("_", "-")
+    for key in (
+        f"on-{event_key}",
+        f"on-{event_key.replace('.', '-')}",
+        f"on-{short_key}",
+        event_key,
+    ):
+        value = state_cfg.get(key)
+        if value not in (None, ""):
+            return str(value).strip()
+    return None
+
+
+def format_feedback_body(*, event: str, summary: str, metadata: dict[str, Any] | None = None) -> str:
+    lines = [
+        f"### Daedalus update: {event}",
+        "",
+        summary.strip() or "Daedalus recorded a workflow update.",
+    ]
+    metadata = metadata or {}
+    visible_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if value not in (None, "", [], {})
+    }
+    if visible_metadata:
+        lines.append("")
+        for key, value in sorted(visible_metadata.items()):
+            lines.append(f"- `{key}`: `{value}`")
+    return "\n".join(lines).strip() + "\n"
+
+
+def publish_tracker_feedback(
+    *,
+    tracker_client: Any,
+    workflow_config: dict[str, Any],
+    issue: dict[str, Any],
+    event: str,
+    summary: str,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not feedback_enabled(workflow_config):
+        return {"ok": True, "skipped": True, "reason": "disabled", "event": event}
+    if not event_included(workflow_config, event):
+        return {"ok": True, "skipped": True, "reason": "not-included", "event": event}
+    issue_id = str(issue.get("id") or "").strip()
+    if not issue_id:
+        return {"ok": False, "skipped": True, "reason": "missing-issue-id", "event": event}
+    publisher = getattr(tracker_client, "post_feedback", None)
+    if not callable(publisher):
+        return {"ok": True, "skipped": True, "reason": "tracker-does-not-support-feedback", "event": event}
+    target_state = state_for_event(workflow_config, event)
+    body = format_feedback_body(event=event, summary=summary, metadata=metadata)
+    return publisher(
+        issue_id=issue_id,
+        event=event,
+        body=body,
+        summary=summary,
+        state=target_state,
+        metadata=metadata or {},
+    )

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -412,3 +412,33 @@ class GithubTrackerClient:
             )
         ]
         return sorted(issues, key=issue_priority_sort_key)
+
+    def post_feedback(
+        self,
+        *,
+        issue_id: str,
+        event: str,
+        body: str,
+        summary: str,
+        state: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        issue_number = _coerce_issue_number(issue_id)
+        if issue_number is None:
+            raise TrackerConfigError("issue_id is required when posting GitHub feedback")
+        completed = subprocess.run(
+            self._with_repo(["gh", "issue", "comment", issue_number, "--body", body]),
+            cwd=str(self._repo_path) if self._repo_path else None,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return {
+            "ok": True,
+            "kind": self.kind,
+            "issue_id": issue_number,
+            "event": event,
+            "state": None,
+            "requested_state": state,
+            "url": (completed.stdout or "").strip() or None,
+        }

--- a/daedalus/trackers/local_json.py
+++ b/daedalus/trackers/local_json.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from pathlib import Path
+from typing import Any
 
 from . import (
     DEFAULT_TERMINAL_STATES,
@@ -11,6 +14,30 @@ from . import (
     register,
     resolve_tracker_path,
 )
+
+
+_WRITE_LOCK = threading.Lock()
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _read_issue_payload(path: Path) -> tuple[Any, list[Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        raw_issues = payload.get("issues")
+    else:
+        raw_issues = payload
+    if not isinstance(raw_issues, list):
+        raise TrackerConfigError(f"{path} must contain a top-level list or an object with an 'issues' list")
+    return payload, raw_issues
+
+
+def _write_issue_payload(path: Path, payload: Any) -> None:
+    tmp_path = path.with_name(f"{path.name}.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
 
 
 @register("local-json")
@@ -23,13 +50,7 @@ class LocalJsonTrackerClient:
 
     def list_all(self) -> list[dict[str, object]]:
         path = resolve_tracker_path(workflow_root=self._workflow_root, tracker_cfg=self._tracker_cfg)
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(payload, dict):
-            raw_issues = payload.get("issues")
-        else:
-            raw_issues = payload
-        if not isinstance(raw_issues, list):
-            raise TrackerConfigError(f"{path} must contain a top-level list or an object with an 'issues' list")
+        _payload, raw_issues = _read_issue_payload(path)
         return [normalize_issue(item) for item in raw_issues]
 
     def list_candidates(self) -> list[dict[str, object]]:
@@ -58,3 +79,54 @@ class LocalJsonTrackerClient:
             for issue in self.list_all()
             if str(issue.get("state") or "").strip().lower() in terminal_states
         ]
+
+    def post_feedback(
+        self,
+        *,
+        issue_id: str,
+        event: str,
+        body: str,
+        summary: str,
+        state: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        path = resolve_tracker_path(workflow_root=self._workflow_root, tracker_cfg=self._tracker_cfg)
+        target_id = str(issue_id or "").strip()
+        if not target_id:
+            raise TrackerConfigError("issue_id is required when posting local-json feedback")
+
+        with _WRITE_LOCK:
+            payload, raw_issues = _read_issue_payload(path)
+            for raw_issue in raw_issues:
+                if not isinstance(raw_issue, dict):
+                    continue
+                if str(raw_issue.get("id") or "").strip() != target_id:
+                    continue
+                now_iso = _now_iso()
+                comments = raw_issue.get("comments")
+                if not isinstance(comments, list):
+                    comments = []
+                comment = {
+                    "at": now_iso,
+                    "event": event,
+                    "summary": summary,
+                    "body": body.rstrip(),
+                    "metadata": metadata or {},
+                }
+                if state:
+                    raw_issue["state"] = state
+                    comment["state"] = state
+                comments.append(comment)
+                raw_issue["comments"] = comments
+                raw_issue["updated_at"] = now_iso
+                _write_issue_payload(path, payload)
+                return {
+                    "ok": True,
+                    "kind": self.kind,
+                    "issue_id": target_id,
+                    "event": event,
+                    "state": state,
+                    "comment_count": len(comments),
+                }
+
+        raise TrackerConfigError(f"local-json issue {target_id!r} not found in {path}")

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -56,6 +56,9 @@ properties:
         type: array
         items: {type: string}
 
+  tracker-feedback:
+    $ref: "#/definitions/tracker-feedback"
+
   runtimes:
     type: object
     minProperties: 1
@@ -318,6 +321,26 @@ properties:
         description: "Worker terminated if its runtime has shown no activity for this long. 0 = disabled."
 
 definitions:
+  tracker-feedback:
+    type: object
+    additionalProperties: false
+    properties:
+      enabled: {type: boolean}
+      comment-mode:
+        type: string
+        enum: [append]
+      include:
+        type: array
+        items: {type: string}
+      state-updates:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled: {type: boolean}
+        patternProperties:
+          "^on[-_.A-Za-z0-9]+$":
+            type: string
+
   acpx-codex-runtime:
     type: object
     additionalProperties: false

--- a/daedalus/workflows/issue_runner/issues.template.json
+++ b/daedalus/workflows/issue_runner/issues.template.json
@@ -3,14 +3,15 @@
     {
       "id": "ISSUE-1",
       "identifier": "ISSUE-1",
-      "title": "Sample tracker issue",
-      "description": "Replace this file with your tracker export or test fixture.",
-      "priority": 2,
+      "title": "Verify the Daedalus issue-runner bootstrap",
+      "description": "Read the workflow prompt, confirm the configured runtime can execute, and produce a short signoff. This local-json issue is intentionally safe: the default template marks it done after one successful run.",
+      "priority": 1,
       "state": "todo",
-      "branch_name": "issue-1-sample-tracker-issue",
+      "branch_name": "issue-1-daedalus-bootstrap",
       "url": "https://tracker.example/issues/ISSUE-1",
-      "labels": ["sample"],
+      "labels": ["demo", "daedalus"],
       "blocked_by": [],
+      "comments": [],
       "created_at": "2026-04-30T00:00:00Z",
       "updated_at": "2026-04-30T00:00:00Z"
     }

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -70,6 +70,9 @@ properties:
         type: array
         items: {type: string}
 
+  tracker-feedback:
+    $ref: "#/definitions/tracker-feedback"
+
   polling:
     type: object
     properties:
@@ -225,6 +228,26 @@ properties:
     type: string
 
 definitions:
+  tracker-feedback:
+    type: object
+    additionalProperties: false
+    properties:
+      enabled: {type: boolean}
+      comment-mode:
+        type: string
+        enum: [append]
+      include:
+        type: array
+        items: {type: string}
+      state-updates:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled: {type: boolean}
+        patternProperties:
+          "^on[-_.A-Za-z0-9]+$":
+            type: string
+
   acpx-codex-runtime:
     type: object
     required: [kind]

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -20,6 +20,26 @@ tracker:
     - done
     - canceled
 
+tracker-feedback:
+  enabled: true
+  comment-mode: append
+  include:
+    - issue.selected
+    - issue.dispatched
+    - issue.running
+    - issue.completed
+    - issue.failed
+    - issue.canceled
+    - issue.retry_scheduled
+  state-updates:
+    enabled: true
+    on-selected: in-progress
+    on-dispatched: in-progress
+    on-running: in-progress
+    on-completed: done
+    on-failed: todo
+    on-canceled: canceled
+
 polling:
   interval_ms: 30000
 
@@ -52,11 +72,10 @@ daedalus:
     default:
       kind: hermes-agent
       command:
-        - fake-agent
-        - --prompt
+        - python3
+        - -c
+        - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
         - "{prompt_path}"
-        - --issue
-        - "{issue_identifier}"
 
 storage:
   status: memory/workflow-status.json

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -49,6 +49,7 @@ from workflows.issue_runner.tracker import (
     issue_workspace_slug,
     select_issue,
 )
+from trackers.feedback import publish_tracker_feedback
 from trackers.github import (
     github_auth_host_from_slug,
     github_auth_success_accounts,
@@ -693,6 +694,96 @@ class IssueRunnerWorkspace(WorkflowDriver):
     def _clear_retry(self, issue_id: str | None) -> None:
         self.retry_entries = clear_work_entries(self.retry_entries, [issue_id])
 
+    def _terminal_states(self) -> set[str]:
+        tracker_cfg = self.config.get("tracker") or {}
+        return {
+            str(value).strip().lower()
+            for value in (
+                _cfg_value(tracker_cfg, "terminal_states", "terminal-states")
+                or ["done", "closed", "canceled", "cancelled", "resolved"]
+            )
+            if str(value).strip()
+        }
+
+    def _feedback_reached_terminal_state(self, feedback_result: dict[str, Any]) -> bool:
+        state = str(feedback_result.get("state") or "").strip().lower()
+        return bool(state and state in self._terminal_states())
+
+    def _publish_tracker_feedback(
+        self,
+        *,
+        issue: dict[str, Any],
+        event: str,
+        summary: str,
+        run_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload_metadata = {
+            "workflow": "issue-runner",
+            "run_id": run_id,
+            **(metadata or {}),
+        }
+        try:
+            result = publish_tracker_feedback(
+                tracker_client=self.tracker_client,
+                workflow_config=self.config,
+                issue=issue,
+                event=event,
+                summary=summary,
+                metadata=payload_metadata,
+            )
+        except Exception as exc:
+            result = {
+                "ok": False,
+                "event": event,
+                "issue_id": issue.get("id"),
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+        if result.get("skipped"):
+            return result
+
+        event_type = (
+            "issue_runner.tracker_feedback.published"
+            if result.get("ok")
+            else "issue_runner.tracker_feedback.failed"
+        )
+        self._emit_event(
+            event_type,
+            {
+                "issue_id": issue.get("id"),
+                "identifier": issue.get("identifier"),
+                "feedback_event": event,
+                "target_state": result.get("state"),
+                "tracker_kind": result.get("kind") or (self.config.get("tracker") or {}).get("kind"),
+                "run_id": run_id,
+                "error": result.get("error"),
+            },
+        )
+        return result
+
+    def _publish_selected_feedback(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None,
+    ) -> None:
+        for issue, retry_entry in selections:
+            attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
+            retrying = retry_entry is not None
+            verb = "Selected this issue for another execution attempt." if retrying else "Selected this issue for execution."
+            self._publish_tracker_feedback(
+                issue=issue,
+                event="issue.selected",
+                summary=verb,
+                run_id=run_id,
+                metadata={
+                    "attempt": attempt,
+                    "retrying": retrying,
+                    "state": issue.get("state"),
+                },
+            )
+
     def _record_metrics(self, result: PromptRunResult) -> dict[str, Any]:
         metrics = self._metrics_payload(result)
         totals = dict(self.codex_totals or {})
@@ -944,6 +1035,18 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 model=model,
                 resume_session_id=resume_thread_id,
             )
+            self._publish_tracker_feedback(
+                issue=issue,
+                event="issue.running",
+                summary="Started the configured runtime for this issue.",
+                run_id=run_id,
+                metadata={
+                    "attempt": attempt,
+                    "runtime": runtime_name,
+                    "runtime_kind": runtime_cfg.get("kind"),
+                    "workspace": str(issue_workspace),
+                },
+            )
 
             command = agent_cfg.get("command")
             if command is None:
@@ -1037,6 +1140,20 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 result["metrics"] = recorded_metrics
 
             if result.get("ok"):
+                feedback_result = self._publish_tracker_feedback(
+                    issue=issue,
+                    event="issue.completed",
+                    summary="The configured runtime completed this issue run successfully.",
+                    run_id=run_id,
+                    metadata={
+                        "attempt": result.get("attempt"),
+                        "workspace": result.get("workspace"),
+                        "output_path": result.get("outputPath"),
+                        "runtime": result.get("runtime"),
+                    },
+                )
+                if self._feedback_reached_terminal_state(feedback_result):
+                    result["suppressRetry"] = True
                 self._clear_retry(issue_id)
                 if result.get("suppressRetry"):
                     result["retry"] = None
@@ -1049,6 +1166,17 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         run_id=run_id,
                     )
                     result["retry"] = retry
+                    self._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.retry_scheduled",
+                        summary="Scheduled a continuation retry for this issue.",
+                        run_id=run_id,
+                        metadata={
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "delay_ms": retry.get("delay_ms"),
+                            "delay_type": retry.get("delay_type"),
+                        },
+                    )
                 self._emit_event(
                     "issue_runner.tick.completed",
                     {
@@ -1064,6 +1192,17 @@ class IssueRunnerWorkspace(WorkflowDriver):
             else:
                 if result.get("suppressRetry"):
                     result["retry"] = None
+                    self._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.canceled",
+                        summary=str(result.get("error") or "The issue run was canceled and will not be retried."),
+                        run_id=run_id,
+                        metadata={
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "retry_suppressed": True,
+                        },
+                    )
                     self._emit_event(
                         "issue_runner.tick.canceled",
                         {
@@ -1076,6 +1215,17 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         },
                     )
                 else:
+                    self._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.failed",
+                        summary=str(result.get("error") or "The configured runtime failed this issue run."),
+                        run_id=run_id,
+                        metadata={
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "runtime": result.get("runtime"),
+                        },
+                    )
                     retry = self._schedule_retry(
                         issue=issue,
                         error=str(result.get("error") or "issue execution failed"),
@@ -1083,6 +1233,22 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         run_id=run_id,
                     )
                     result["retry"] = retry
+                    self._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.retry_scheduled",
+                        summary=(
+                            "Scheduled a retry after the issue run failed."
+                            if retry.get("delay_type") != "continuation"
+                            else "Scheduled a continuation retry for this issue."
+                        ),
+                        run_id=run_id,
+                        metadata={
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "delay_ms": retry.get("delay_ms"),
+                            "delay_type": retry.get("delay_type"),
+                            "error": retry.get("error"),
+                        },
+                    )
                     self._emit_event(
                         "issue_runner.tick.failed",
                         {
@@ -1298,6 +1464,17 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     "run_id": run_id,
                 },
             )
+            self._publish_tracker_feedback(
+                issue=issue,
+                event="issue.dispatched",
+                summary="Dispatched a supervised worker for this issue.",
+                run_id=run_id,
+                metadata={
+                    "attempt": entry.get("attempt"),
+                    "worker_id": entry.get("worker_id"),
+                    "state": issue.get("state"),
+                },
+            )
         self._persist_scheduler_state()
         return dispatched
 
@@ -1348,11 +1525,25 @@ class IssueRunnerWorkspace(WorkflowDriver):
             if completed:
                 status = self._status_from_results(base_status=status, results=completed)
                 status["completedResults"] = status.get("results") or []
+            suppressed_completed_ids = {
+                str((result.get("issue") or {}).get("id") or "").strip()
+                for result in completed
+                if result.get("suppressRetry")
+            }
             cleanup = self._cleanup_terminal_workspaces(terminal_issues)
             status["cleanup"] = cleanup
 
-            issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
-            selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
+            dispatch_issues = [
+                issue
+                for issue in issues
+                if str(issue.get("id") or "").strip() not in suppressed_completed_ids
+            ]
+            issues_by_id = {
+                str(issue.get("id")): issue
+                for issue in dispatch_issues
+                if str(issue.get("id") or "").strip()
+            }
+            selections = self._select_issue_batch(issues=dispatch_issues, issues_by_id=issues_by_id)
             refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
             for selected, retry_entry in selections:
                 issue_id = str(selected.get("id") or "").strip()
@@ -1362,6 +1553,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             selections = refreshed_selections
             status["selectedIssues"] = [issue for issue, _retry_entry in selections]
             status["selectedIssue"] = selections[0][0] if selections else None
+            self._publish_selected_feedback(selections, run_id=engine_run["run_id"])
             dispatched = self._dispatch_supervised_workers(selections, run_id=engine_run["run_id"])
             status["dispatchedWorkers"] = dispatched
             if not completed and not dispatched:
@@ -1497,6 +1689,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 )
                 return status
 
+            self._publish_selected_feedback(selections, run_id=engine_run["run_id"])
             self._mark_running(selections, run_id=engine_run["run_id"])
             results: list[dict[str, Any]] = []
             try:
@@ -1542,15 +1735,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             self._apply_event_retention()
 
     def _cleanup_terminal_workspaces(self, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        tracker_cfg = self.config.get("tracker") or {}
-        terminal_states = {
-            str(value).strip().lower()
-            for value in (
-                _cfg_value(tracker_cfg, "terminal_states", "terminal-states")
-                or ["done", "closed", "canceled", "cancelled", "resolved"]
-            )
-            if str(value).strip()
-        }
+        terminal_states = self._terminal_states()
         cleaned: list[dict[str, Any]] = []
         for issue in issues:
             state = str(issue.get("state") or "").strip().lower()

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -20,6 +20,26 @@ tracker:
     - done
     - canceled
 
+tracker-feedback:
+  enabled: true
+  comment-mode: append
+  include:
+    - issue.selected
+    - issue.dispatched
+    - issue.running
+    - issue.completed
+    - issue.failed
+    - issue.canceled
+    - issue.retry_scheduled
+  state-updates:
+    enabled: true
+    on-selected: in-progress
+    on-dispatched: in-progress
+    on-running: in-progress
+    on-completed: done
+    on-failed: todo
+    on-canceled: canceled
+
 polling:
   interval_ms: 30000
 
@@ -52,11 +72,10 @@ daedalus:
     default:
       kind: hermes-agent
       command:
-        - fake-agent
-        - --prompt
+        - python3
+        - -c
+        - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
         - "{prompt_path}"
-        - --issue
-        - "{issue_identifier}"
 
 storage:
   status: memory/workflow-status.json

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -14,8 +14,9 @@ For each eligible tracker issue:
 4. run lifecycle hooks
 5. render the Markdown workflow body as the issue prompt template
 6. invoke the configured runtime/agent
-7. persist output and audit state
-8. persist scheduler state for running workers, continuation retries, failure backoff, recovery, and token totals
+7. optionally post tracker feedback and state updates
+8. persist output and audit state
+9. persist scheduler state for running workers, continuation retries, failure backoff, recovery, and token totals
 
 ## Use it when
 
@@ -32,6 +33,7 @@ For each eligible tracker issue:
 ## Key config blocks
 
 - `tracker`: shared tracker client kind, source path or endpoint, active/terminal states, label filters
+- `tracker-feedback`: shared tracker comments/state updates for lifecycle events; disabled unless explicitly enabled
 - `workspace`: per-issue workspace root
 - `hooks`: `after_create`, `before_run`, `after_run`, `before_remove`
 - `agent`: model/runtime plus scheduler-facing limits
@@ -63,6 +65,11 @@ Supported tracker kinds today:
 - `local-json` — local development and test fixture path
 - `linear` — experimental adapter, deferred until after the GitHub adapter is hardened
 
+The bundled `local-json` template includes one safe demo issue. With the
+default `tracker-feedback` block enabled, a successful runtime run appends
+comments to `config/issues.json`, moves the issue from `todo` to `done`, and
+suppresses the continuation retry.
+
 GitHub configuration is explicit. Put the repository slug under the tracker,
 not under `repository`:
 
@@ -75,6 +82,21 @@ tracker:
   github_slug: your-org/your-repo
   active_states: [open]
   terminal_states: [closed]
+```
+
+Feedback configuration is tracker-neutral. GitHub receives issue comments.
+`local-json` appends comment objects and applies configured state changes:
+
+```yaml
+tracker-feedback:
+  enabled: true
+  comment-mode: append
+  include: [issue.selected, issue.running, issue.completed, issue.failed, issue.retry_scheduled]
+  state-updates:
+    enabled: true
+    on-selected: in-progress
+    on-completed: done
+    on-failed: todo
 ```
 
 `issue-runner` composes the shared `trackers/` clients with workflow-specific

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -61,6 +61,7 @@ The YAML front matter is structured operator configuration:
 - `workflow` selects the workflow package.
 - `instance` names the workflow instance.
 - `tracker` and `repository` configure where issues and code live.
+- `tracker-feedback` controls tracker-facing comments and optional state updates.
 - `runtimes` and `agents` bind workflow roles to execution backends.
 - `hooks`, `gates`, `observability`, and `server` configure workflow-specific behavior.
 

--- a/tests/test_trackers_feedback.py
+++ b/tests/test_trackers_feedback.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+
+
+def test_local_json_feedback_appends_comment_and_updates_state(tmp_path):
+    from trackers.local_json import LocalJsonTrackerClient
+
+    issues_path = tmp_path / "config" / "issues.json"
+    issues_path.parent.mkdir()
+    issues_path.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "id": "ISSUE-1",
+                        "identifier": "ISSUE-1",
+                        "title": "Demo",
+                        "state": "todo",
+                        "comments": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    client = LocalJsonTrackerClient(
+        workflow_root=tmp_path,
+        tracker_cfg={"kind": "local-json", "path": "config/issues.json"},
+    )
+
+    result = client.post_feedback(
+        issue_id="ISSUE-1",
+        event="issue.running",
+        body="### Daedalus update\nRuntime started.\n",
+        summary="Runtime started.",
+        state="in-progress",
+        metadata={"run_id": "run-1"},
+    )
+
+    assert result["ok"] is True
+    assert result["state"] == "in-progress"
+    payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    issue = payload["issues"][0]
+    assert issue["state"] == "in-progress"
+    assert issue["updated_at"]
+    assert issue["comments"][0]["event"] == "issue.running"
+    assert issue["comments"][0]["summary"] == "Runtime started."
+    assert issue["comments"][0]["metadata"]["run_id"] == "run-1"
+
+
+def test_local_json_feedback_preserves_top_level_list_shape(tmp_path):
+    from trackers.local_json import LocalJsonTrackerClient
+
+    issues_path = tmp_path / "issues.json"
+    issues_path.write_text(
+        json.dumps([{"id": "ISSUE-1", "identifier": "ISSUE-1", "title": "Demo", "state": "todo"}]),
+        encoding="utf-8",
+    )
+    client = LocalJsonTrackerClient(
+        workflow_root=tmp_path,
+        tracker_cfg={"kind": "local-json", "path": "issues.json"},
+    )
+
+    client.post_feedback(
+        issue_id="ISSUE-1",
+        event="issue.completed",
+        body="Done.",
+        summary="Done.",
+        state="done",
+    )
+
+    payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    assert isinstance(payload, list)
+    assert payload[0]["state"] == "done"
+    assert payload[0]["comments"][0]["event"] == "issue.completed"
+
+
+def test_github_feedback_posts_issue_comment_with_repo_slug(tmp_path, monkeypatch):
+    from trackers import github as github_tracker
+
+    calls = []
+
+    def fake_run(command, *, cwd=None, check=None, capture_output=None, text=None):
+        calls.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "check": check,
+                "capture_output": capture_output,
+                "text": text,
+            }
+        )
+        return subprocess.CompletedProcess(command, 0, stdout="https://github.example/comment/1\n", stderr="")
+
+    monkeypatch.setattr(github_tracker.subprocess, "run", fake_run)
+    client = github_tracker.GithubTrackerClient(
+        workflow_root=tmp_path,
+        tracker_cfg={"kind": "github", "github_slug": "attmous/daedalus"},
+    )
+
+    result = client.post_feedback(
+        issue_id="#42",
+        event="issue.selected",
+        body="Daedalus selected this issue.",
+        summary="Selected.",
+        state="in-progress",
+    )
+
+    assert result["ok"] is True
+    assert result["url"] == "https://github.example/comment/1"
+    assert calls == [
+        {
+            "command": [
+                "gh",
+                "issue",
+                "comment",
+                "42",
+                "--body",
+                "Daedalus selected this issue.",
+                "--repo",
+                "attmous/daedalus",
+            ],
+            "cwd": None,
+            "check": True,
+            "capture_output": True,
+            "text": True,
+        }
+    ]

--- a/tests/test_workflows_code_review_schema.py
+++ b/tests/test_workflows_code_review_schema.py
@@ -102,6 +102,21 @@ def test_schema_accepts_codex_app_server_runtime_for_coder():
     jsonschema.validate(cfg, _load_schema())
 
 
+def test_schema_accepts_shared_tracker_feedback_config():
+    cfg = _minimal_valid_config()
+    cfg["tracker-feedback"] = {
+        "enabled": True,
+        "comment-mode": "append",
+        "include": ["issue.selected", "issue.completed"],
+        "state-updates": {
+            "enabled": True,
+            "on-completed": "done",
+        },
+    }
+
+    jsonschema.validate(cfg, _load_schema())
+
+
 def test_schema_rejects_missing_workflow_key():
     cfg = _minimal_valid_config()
     del cfg["workflow"]

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -155,3 +155,21 @@ def test_issue_runner_schema_accepts_github_tracker():
         "exclude_labels": ["blocked"],
     }
     jsonschema.validate(cfg, schema)
+
+
+def test_issue_runner_schema_accepts_tracker_feedback_config():
+    schema = yaml.safe_load(
+        (REPO_ROOT / "daedalus" / "workflows" / "issue_runner" / "schema.yaml").read_text(encoding="utf-8")
+    )
+    cfg = _config()
+    cfg["tracker-feedback"] = {
+        "enabled": True,
+        "comment-mode": "append",
+        "include": ["issue.selected", "issue.running", "issue.completed"],
+        "state-updates": {
+            "enabled": True,
+            "on-selected": "in-progress",
+            "on-completed": "done",
+        },
+    }
+    jsonschema.validate(cfg, schema)

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -282,6 +282,166 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     assert status["scheduler"]["retry_queue"][0]["error"] == "continuation"
 
 
+def test_issue_runner_tracker_feedback_marks_local_json_done_without_continuation_retry(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    cfg["tracker"]["active_states"] = ["todo", "in-progress"]
+    cfg["tracker-feedback"] = {
+        "enabled": True,
+        "comment-mode": "append",
+        "include": [
+            "issue.selected",
+            "issue.running",
+            "issue.completed",
+            "issue.retry_scheduled",
+        ],
+        "state-updates": {
+            "enabled": True,
+            "on-selected": "in-progress",
+            "on-running": "in-progress",
+            "on-completed": "done",
+        },
+    }
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    issues_path = _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Feedback issue",
+                "description": "Exercise tracker feedback.",
+                "priority": 1,
+                "state": "todo",
+                "branch_name": "issue-1-feedback",
+                "url": "https://tracker.example/issues/ISSUE-1",
+                "labels": [],
+                "blocked_by": [],
+                "comments": [],
+            }
+        ],
+        prompt_template="Issue: {{ issue.identifier }}",
+    )
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        class Result:
+            stdout = "signed off\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    result = workspace.tick()
+
+    assert result["ok"] is True
+    assert result["results"][0]["retry"] is None
+    assert workspace.build_status()["scheduler"]["retry_queue"] == []
+    payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    issue = payload["issues"][0]
+    assert issue["state"] == "done"
+    assert [comment["event"] for comment in issue["comments"]] == [
+        "issue.selected",
+        "issue.running",
+        "issue.completed",
+    ]
+    feedback_events = [
+        json.loads(line)["event"]
+        for line in (workflow_root / "memory" / "workflow-audit.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert "issue_runner.tracker_feedback.published" in feedback_events
+
+
+def test_issue_runner_supervised_feedback_completion_does_not_redispatch_stale_issue(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    cfg["tracker"]["active_states"] = ["todo", "in-progress"]
+    cfg["tracker-feedback"] = {
+        "enabled": True,
+        "comment-mode": "append",
+        "include": [
+            "issue.selected",
+            "issue.dispatched",
+            "issue.running",
+            "issue.completed",
+        ],
+        "state-updates": {
+            "enabled": True,
+            "on-selected": "in-progress",
+            "on-dispatched": "in-progress",
+            "on-running": "in-progress",
+            "on-completed": "done",
+        },
+    }
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    issues_path = _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Supervised feedback issue",
+                "description": "Exercise supervised tracker feedback.",
+                "priority": 1,
+                "state": "todo",
+                "branch_name": "issue-1-supervised-feedback",
+                "url": "https://tracker.example/issues/ISSUE-1",
+                "labels": [],
+                "blocked_by": [],
+                "comments": [],
+            }
+        ],
+        prompt_template="Issue: {{ issue.identifier }}",
+    )
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        class Result:
+            stdout = "signed off\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    first = workspace.supervise_once()
+    assert len(first["dispatchedWorkers"]) == 1
+    _wait_for_supervised_futures(workspace)
+
+    second = workspace.supervise_once()
+
+    assert second["completedResults"][0]["retry"] is None
+    assert second["dispatchedWorkers"] == []
+    payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    issue = payload["issues"][0]
+    assert issue["state"] == "done"
+    comment_events = [comment["event"] for comment in issue["comments"]]
+    assert comment_events[0] == "issue.selected"
+    assert comment_events[-1] == "issue.completed"
+    assert set(comment_events) == {
+        "issue.selected",
+        "issue.dispatched",
+        "issue.running",
+        "issue.completed",
+    }
+
+
 def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 


### PR DESCRIPTION
## Summary

Adds a shared tracker feedback contract and adapter API so workflows can publish lifecycle updates through tracker clients instead of hard-coding tracker behavior.

- Added `trackers.feedback` plus `TrackerClient.post_feedback`.
- Implemented GitHub issue-comment feedback and local-json comment/state persistence.
- Wired `issue-runner` lifecycle updates for selected, dispatched, running, completed, failed, canceled, and retry scheduled.
- Updated the issue-runner default template so the bootstrap demo issue can run once, record comments, move to `done`, and avoid a continuation retry.
- Added `tracker-feedback` schema support for both `issue-runner` and `change-delivery`.
- Updated workflow docs and examples.

## Validation

- `python -m compileall daedalus/trackers daedalus/workflows/issue_runner daedalus/workflows/change_delivery`
- `python -m pytest -q` -> `862 passed, 8 skipped`
- `git diff --check`

## Notes

`change-delivery` still keeps its existing GitHub comments publisher behavior for now, but its schema now accepts the shared `tracker-feedback` block so the next slice can cut it over cleanly.