### PR TITLE
[codex] Expand live GitHub smoke coverage

### DIFF
--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -107,6 +107,7 @@ def build_tracker_client(
     tracker_cfg: dict[str, Any],
     post_json: Callable[..., dict[str, Any]] | None = None,
     repo_path: Path | None = None,
+    run: Callable[..., Any] | None = None,
     run_json: Callable[..., Any] | None = None,
 ) -> TrackerClient:
     kind = tracker_kind(tracker_cfg)
@@ -125,6 +126,7 @@ def build_tracker_client(
         kwargs["post_json"] = post_json or http_post_json
     if kind == "github":
         kwargs["repo_path"] = repo_path
+        kwargs["run"] = run
         kwargs["run_json"] = run_json
     return cls(**kwargs)
 
@@ -134,12 +136,14 @@ def load_issues(
     workflow_root: Path,
     tracker_cfg: dict[str, Any],
     repo_path: Path | None = None,
+    run: Callable[..., Any] | None = None,
     run_json: Callable[..., Any] | None = None,
 ) -> list[dict[str, Any]]:
     return build_tracker_client(
         workflow_root=workflow_root,
         tracker_cfg=tracker_cfg,
         repo_path=repo_path,
+        run=run,
         run_json=run_json,
     ).list_all()
 

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -131,6 +131,16 @@ def _subprocess_run_json(command: list[str], *, cwd: Path | None = None) -> Any:
     return payload
 
 
+def _subprocess_run(command: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def github_slug_from_config(
     tracker_cfg: dict[str, Any],
     repository_cfg: dict[str, Any] | None = None,
@@ -243,6 +253,7 @@ class GithubTrackerClient:
         workflow_root: Path,
         tracker_cfg: dict[str, Any],
         repo_path: Path | None = None,
+        run: Callable[..., subprocess.CompletedProcess[str]] | None = None,
         run_json: Callable[..., Any] | None = None,
     ):
         self._workflow_root = workflow_root
@@ -254,6 +265,7 @@ class GithubTrackerClient:
             required=github_slug_from_config(tracker_cfg) is None,
         )
         self._repo_slug = github_slug_from_config(tracker_cfg)
+        self._run = run or _subprocess_run
         self._run_json = run_json or _subprocess_run_json
 
     @property
@@ -426,19 +438,34 @@ class GithubTrackerClient:
         issue_number = _coerce_issue_number(issue_id)
         if issue_number is None:
             raise TrackerConfigError("issue_id is required when posting GitHub feedback")
-        completed = subprocess.run(
+        completed = self._run(
             self._with_repo(["gh", "issue", "comment", issue_number, "--body", body]),
-            cwd=str(self._repo_path) if self._repo_path else None,
-            check=True,
-            capture_output=True,
-            text=True,
+            cwd=self._repo_path,
         )
+        applied_state = None
+        requested_state = str(state or "").strip().lower()
+        if requested_state:
+            if requested_state == "closed":
+                self._run(
+                    self._with_repo(["gh", "issue", "close", issue_number]),
+                    cwd=self._repo_path,
+                )
+                applied_state = "closed"
+            elif requested_state == "open":
+                self._run(
+                    self._with_repo(["gh", "issue", "reopen", issue_number]),
+                    cwd=self._repo_path,
+                )
+                applied_state = "open"
+            else:
+                applied_state = None
         return {
             "ok": True,
             "kind": self.kind,
             "issue_id": issue_number,
             "event": event,
-            "state": None,
+            "state": applied_state,
             "requested_state": state,
+            "unsupported_state": requested_state if requested_state and applied_state is None else None,
             "url": (completed.stdout or "").strip() or None,
         }

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -2060,6 +2060,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             workflow_root=self.path,
             tracker_cfg=tracker_client_cfg,
             repo_path=repo_path,
+            run=self._run,
             run_json=self._run_json,
         )
         previous_scheduler_path = self.scheduler_path
@@ -2125,12 +2126,15 @@ def load_workspace_from_config(
             path = (root / path).resolve()
         return path
 
+    runner = run or _subprocess_run
+    runner_json = run_json or _subprocess_run_json
     tracker_source = describe_tracker_source(workflow_root=root, tracker_cfg=tracker_source_cfg)
     tracker_client = build_tracker_client(
         workflow_root=root,
         tracker_cfg=tracker_client_cfg,
         repo_path=repo_path,
-        run_json=run_json or _subprocess_run_json,
+        run=runner,
+        run_json=runner_json,
     )
     issue_workspace_root = _resolve_path(_cfg_value(workspace_cfg, "root", default="workspace/issues"), "workspace/issues")
     status_path = _resolve_path(storage_cfg.get("status") or "memory/workflow-status.json", "memory/workflow-status.json")
@@ -2145,8 +2149,6 @@ def load_workspace_from_config(
         now_epoch=_now_epoch,
     )
 
-    runner = run or _subprocess_run
-    runner_json = run_json or _subprocess_run_json
     runtimes = _build_runtimes_from_config(cfg, run=runner, run_json=runner_json)
 
     workspace = IssueRunnerWorkspace(

--- a/docs/concepts/tracker-feedback.md
+++ b/docs/concepts/tracker-feedback.md
@@ -36,7 +36,7 @@ tracker-feedback:
 
 | Tracker | Feedback behavior |
 |---|---|
-| GitHub | Posts issue comments through `gh issue comment`. |
+| GitHub | Posts issue comments through `gh issue comment`; applies configured `open`/`closed` state updates and ignores other tracker states. |
 | `local-json` | Appends `comments[]`, updates `updated_at`, and applies configured state changes. |
 | Linear | Adapter exists for reads; feedback publishing is deferred. |
 

--- a/docs/operator/codex-app-server-smoke.md
+++ b/docs/operator/codex-app-server-smoke.md
@@ -44,6 +44,23 @@ Keep this test opt-in. It depends on local Codex installation, account state,
 quota, model availability, and live runtime timing. Use it before production
 changes to Codex runtime/service behavior, not as a required CI gate.
 
+## Change-Delivery Fixture Smoke
+
+`change-delivery` has an opt-in fixture smoke skeleton for prepared workflow
+roots. It does not create GitHub issues or PRs by itself; point it at a workflow
+root you already prepared with a `change-delivery` `WORKFLOW.md` and at least
+one `codex-app-server` runtime profile.
+
+```bash
+DAEDALUS_CHANGE_DELIVERY_CODEX_E2E=1 \
+DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-change-delivery \
+pytest tests/test_change_delivery_codex_app_server_smoke.py -q -s
+```
+
+This is the first harness anchor for a fuller issue-to-PR-to-review-to-merge
+Codex app-server E2E. Keep it opt-in until the fixture can create and clean up
+its own GitHub issue, branch, PR, and review artifacts.
+
 ## Token Accounting Rule
 
 When Codex emits both `tokenUsage.last` and cumulative `tokenUsage.total`,

--- a/docs/operator/github-smoke.md
+++ b/docs/operator/github-smoke.md
@@ -1,8 +1,10 @@
 # GitHub Smoke Test
 
-Use this only against a repository where temporary issues are acceptable. The
-test creates one labeled issue, lets `issue-runner` select and dispatch it, then
-closes the issue and verifies terminal cleanup.
+Use this only against a repository where temporary issues and comments are
+acceptable. The test creates one labeled issue, lets `issue-runner` select and
+dispatch it, forces one runtime failure, verifies retry recovery, writes tracker
+feedback comments, closes the issue through `tracker-feedback`, and verifies
+terminal cleanup.
 
 ## Prerequisites
 
@@ -33,6 +35,9 @@ to be a git checkout.
 - `tracker.kind: github` can select issues via `gh`
 - `tracker.github_slug` is the GitHub repository source of truth
 - required-label filtering works against live GitHub data
-- a no-op runtime can dispatch from the selected issue
-- scheduler state records the continuation retry
+- a supervised worker dispatches from the selected issue
+- tracker feedback writes issue comments for selected, dispatched, running,
+  failed, retry scheduled, and completed stages
+- scheduler state records failure retry/backoff and clears it after recovery
+- `tracker-feedback.state-updates.on-completed: closed` closes the GitHub issue
 - terminal GitHub state clears retry state and removes the issue workspace

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -37,7 +37,7 @@ should be backed by documentation, tests, or an operator smoke path.
 | Public-surface guardrails | Strong | Generic examples, placeholder-only `projects/`, packaging checks |
 | Agent-legible workflows | Good | Workflow docs link the default templates and operator paths |
 | Custom structural checks | Good | Public harness tests and workflow-template drift checks |
-| Live integration evidence | Partial | GitHub and real Codex app-server smoke tests are opt-in |
+| Live integration evidence | Partial | Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup; real Codex app-server smokes remain opt-in |
 | Recurring cleanup discipline | Partial | Guardrails exist, but no scheduled quality task yet |
 
 ## Gates Before Community Launch
@@ -49,18 +49,20 @@ should be backed by documentation, tests, or an operator smoke path.
 5. Keep Linear documented as experimental until it has first-class operator docs.
 6. Keep workflow examples synchronized with packaged templates.
 7. Keep Codex app-server real-runtime tests opt-in and fake protocol tests in CI.
-8. Add live GitHub coverage for comments, labels, and failure recovery before
-   calling GitHub automation production-grade.
-9. Add an end-to-end `change-delivery` Codex app-server smoke before calling the
-   flagship workflow app-server-complete.
+8. Keep the live GitHub smoke runnable before calling GitHub automation
+   production-grade.
+9. Expand the `change-delivery` Codex app-server smoke from fixture validation
+   into a full issue-to-PR-to-review-to-merge E2E before calling the flagship
+   workflow app-server-complete.
 10. Add scheduled cleanup or scorecard refresh work before claiming mature
     harness-engineering discipline.
 
 ## Next Hardening Slice
 
-The highest-leverage next implementation slice is live integration evidence:
+The highest-leverage next implementation slice is public-surface drift control:
 
-1. Extend the GitHub smoke to cover issue comments, labels, and retry/failure
-   recovery.
-2. Add a skipped-by-default `change-delivery` Codex app-server end-to-end smoke.
-3. Add docs/CLI drift checks for commands shown in operator docs.
+1. Add docs/CLI drift checks for commands shown in operator docs.
+2. Teach the `change-delivery` Codex app-server smoke fixture to create and
+   clean up its own GitHub artifacts.
+3. Add a one-command local harness that runs all opt-in live smokes when the
+   required environment variables are present.

--- a/docs/symphony-conformance.md
+++ b/docs/symphony-conformance.md
@@ -54,8 +54,8 @@ Daedalus currently differs from the Symphony draft in four material ways:
    extensions isolated under `daedalus:`.
 2. Add stronger cancellation semantics for command-style runtimes, including
    subprocess group termination where safe.
-3. Add broader GitHub integration coverage for comments, labels, and failure
-   recovery against a real repository.
+3. Expand the opt-in `change-delivery` Codex app-server fixture smoke into a
+   full issue-to-PR-to-review-to-merge live E2E.
 4. Expand harness checks for public docs, generic examples, workflow-template
    drift, and operator CLI/docs drift.
 

--- a/tests/test_change_delivery_codex_app_server_smoke.py
+++ b/tests/test_change_delivery_codex_app_server_smoke.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from workflows.contract import load_workflow_contract
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_E2E"),
+    reason="set DAEDALUS_CHANGE_DELIVERY_CODEX_E2E=1 to run the change-delivery Codex app-server smoke skeleton",
+)
+def test_live_change_delivery_codex_app_server_fixture_is_runnable():
+    workflow_root_raw = os.environ.get("DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT")
+    if not workflow_root_raw:
+        pytest.skip("set DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT to a prepared change-delivery workflow root")
+
+    workflow_root = Path(workflow_root_raw).expanduser().resolve()
+    assert workflow_root.exists(), workflow_root
+
+    contract = load_workflow_contract(workflow_root)
+    config = contract.config
+    assert config["workflow"] == "change-delivery"
+
+    runtime_profiles = config.get("runtimes") or (config.get("daedalus") or {}).get("runtimes") or {}
+    assert any(
+        isinstance(profile, dict) and profile.get("kind") == "codex-app-server"
+        for profile in runtime_profiles.values()
+    ), "prepared fixture must use at least one codex-app-server runtime"
+
+    status = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "workflows",
+            "--workflow-root",
+            str(workflow_root),
+            "status",
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert status.returncode == 0, status.stderr or status.stdout

--- a/tests/test_github_issue_runner_smoke.py
+++ b/tests/test_github_issue_runner_smoke.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -14,11 +15,51 @@ def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[s
     return subprocess.run(cmd, check=check, capture_output=True, text=True)
 
 
+def _run_json(cmd: list[str]) -> object:
+    return json.loads(_run(cmd).stdout or "null")
+
+
+def _write_fail_once_runtime(path: Path, *, marker_path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "import sys",
+                f"marker = Path({str(marker_path)!r})",
+                "prompt = Path(sys.argv[1]).read_text(encoding='utf-8')",
+                "if not marker.exists():",
+                "    marker.write_text('failed-once\\n', encoding='utf-8')",
+                "    print('intentional smoke failure after reading prompt:', prompt[:80], file=sys.stderr)",
+                "    raise SystemExit(7)",
+                "print('signed off after retry')",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _wait_for_supervised_futures(workspace, *, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        futures = list(workspace._supervisor_futures.values())
+        if futures and all(future.done() for future in futures):
+            return
+        time.sleep(0.05)
+    raise AssertionError("supervised smoke worker did not finish")
+
+
+def _issue_comment_bodies(*, repo: str, issue_number: str) -> list[str]:
+    comments = _run_json(["gh", "api", f"repos/{repo}/issues/{issue_number}/comments"])
+    assert isinstance(comments, list)
+    return [str(comment.get("body") or "") for comment in comments if isinstance(comment, dict)]
+
+
 @pytest.mark.skipif(
     not os.environ.get("DAEDALUS_GITHUB_SMOKE_REPO"),
     reason="set DAEDALUS_GITHUB_SMOKE_REPO=owner/repo to run the live GitHub smoke",
 )
-def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_issue(tmp_path):
+def test_live_github_issue_runner_feedback_retry_recovery_and_cleanup(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 
     smoke_repo = os.environ["DAEDALUS_GITHUB_SMOKE_REPO"].strip()
@@ -70,6 +111,9 @@ def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_iss
 
         workflow_root = tmp_path / "workflow"
         workflow_root.mkdir()
+        runtime_script = tmp_path / "fail_once_runtime.py"
+        fail_marker = tmp_path / "runtime-failed-once.marker"
+        _write_fail_once_runtime(runtime_script, marker_path=fail_marker)
         cfg = {
             "workflow": "issue-runner",
             "schema-version": 1,
@@ -88,6 +132,23 @@ def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_iss
                 "model": "local-smoke",
                 "runtime": "smoke",
                 "max_concurrent_agents": 1,
+                "max_retry_backoff_ms": 1,
+            },
+            "tracker-feedback": {
+                "enabled": True,
+                "comment-mode": "append",
+                "include": [
+                    "issue.selected",
+                    "issue.dispatched",
+                    "issue.running",
+                    "issue.failed",
+                    "issue.retry_scheduled",
+                    "issue.completed",
+                ],
+                "state-updates": {
+                    "enabled": True,
+                    "on-completed": "closed",
+                },
             },
             "daedalus": {
                 "runtimes": {
@@ -95,8 +156,7 @@ def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_iss
                         "kind": "hermes-agent",
                         "command": [
                             sys.executable,
-                            "-c",
-                            "from pathlib import Path; import sys; print(Path(sys.argv[1]).read_text())",
+                            str(runtime_script),
                             "{prompt_path}",
                         ],
                     }
@@ -118,30 +178,51 @@ def test_live_github_issue_runner_selects_dispatches_and_reconciles_terminal_iss
         )
         workspace = load_workspace_from_config(workspace_root=workflow_root)
 
-        result = workspace.tick()
+        first = workspace.supervise_once()
+        assert first["ok"] is True
+        assert first["selectedIssue"]["id"] == issue_number
+        assert first["dispatchedWorkers"][0]["issue_id"] == issue_number
 
-        assert result["ok"] is True
-        assert result["selectedIssue"]["id"] == issue_number
-        assert Path(result["outputPath"]).read_text(encoding="utf-8")
+        _wait_for_supervised_futures(workspace)
+        failed = workspace.supervise_once()
+        assert failed["completedResults"][0]["ok"] is False
+        assert failed["completedResults"][0]["retry"]["issue_id"] == issue_number
         scheduler = workspace._load_scheduler_state()
         assert scheduler["retry_queue"][0]["issue_id"] == issue_number
+        assert scheduler["retry_queue"][0]["error"]
 
-        _run(
-            [
-                "gh",
-                "issue",
-                "close",
-                issue_number,
-                "--repo",
-                smoke_repo,
-                "--comment",
-                "Closing Daedalus issue-runner smoke issue.",
-            ]
-        )
+        time.sleep(0.05)
+        retry_dispatch = workspace.supervise_once()
+        assert retry_dispatch["selectedIssue"]["id"] == issue_number
+        assert retry_dispatch["dispatchedWorkers"][0]["issue_id"] == issue_number
+        assert retry_dispatch["dispatchedWorkers"][0]["attempt"] == 2
+
+        _wait_for_supervised_futures(workspace)
+        completed = workspace.supervise_once()
+        assert completed["completedResults"][0]["ok"] is True
+        assert completed["completedResults"][0]["retry"] is None
+        assert Path(completed["completedResults"][0]["outputPath"]).read_text(encoding="utf-8") == "signed off after retry\n"
+        assert workspace._load_scheduler_state().get("retry_queue") == []
+
+        issue_view = _run_json(["gh", "issue", "view", issue_number, "--repo", smoke_repo, "--json", "state,labels"])
+        assert isinstance(issue_view, dict)
+        assert str(issue_view["state"]).lower() == "closed"
+        assert label in {item["name"] for item in issue_view.get("labels") or []}
+
+        comment_bodies = _issue_comment_bodies(repo=smoke_repo, issue_number=issue_number)
+        for event in [
+            "issue.selected",
+            "issue.dispatched",
+            "issue.running",
+            "issue.failed",
+            "issue.retry_scheduled",
+            "issue.completed",
+        ]:
+            assert any(f"Daedalus update: {event}" in body for body in comment_bodies), event
 
         cleanup_result = None
         for _ in range(10):
-            cleanup_result = workspace.tick()
+            cleanup_result = workspace.supervise_once()
             cleaned = cleanup_result.get("cleanup") or []
             if any(str(item.get("issue_id")) == issue_number for item in cleaned):
                 break

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -106,7 +106,7 @@ def test_release_readiness_tracks_public_beta_gates():
     assert "First-class tracker: GitHub" in readiness
     assert "Experimental tracker: Linear" in readiness
     assert "Keep `daedalus/projects/` placeholder-only" in readiness
-    assert "GitHub and real Codex app-server smoke tests are opt-in" in readiness
+    assert "Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup" in readiness
     assert "strict Symphony contract" in readiness
     assert "issue-runner` is the workflow that should converge" in conformance
     assert "release-readiness.md" in conformance

--- a/tests/test_workflows_issue_runner_tracker.py
+++ b/tests/test_workflows_issue_runner_tracker.py
@@ -393,3 +393,103 @@ def test_github_tracker_client_accepts_host_qualified_repo_slug_without_checkout
     assert client.repo_slug == "github.example.com/attmous/daedalus"
     assert client.list_candidates()[0]["title"] == "Enterprise issue"
     assert any(command[:3] == ["gh", "issue", "list"] for command in commands)
+
+
+def test_github_tracker_feedback_comments_and_applies_supported_state(tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    commands = []
+
+    class Completed:
+        stdout = "https://github.com/attmous/daedalus/issues/42#issuecomment-1\n"
+        stderr = ""
+        returncode = 0
+
+    def fake_run(command, cwd=None):
+        commands.append((command, cwd))
+        return Completed()
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "github",
+            "github_slug": "attmous/daedalus",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        run=fake_run,
+        run_json=lambda *args, **kwargs: [],
+    )
+
+    result = client.post_feedback(
+        issue_id="42",
+        event="issue.completed",
+        body="Completed by Daedalus.",
+        summary="Completed by Daedalus.",
+        state="closed",
+        metadata={"attempt": 1},
+    )
+
+    assert result["ok"] is True
+    assert result["state"] == "closed"
+    assert commands == [
+        (
+            [
+                "gh",
+                "issue",
+                "comment",
+                "42",
+                "--body",
+                "Completed by Daedalus.",
+                "--repo",
+                "attmous/daedalus",
+            ],
+            None,
+        ),
+        (
+            ["gh", "issue", "close", "42", "--repo", "attmous/daedalus"],
+            None,
+        ),
+    ]
+
+
+def test_github_tracker_feedback_ignores_unsupported_state_after_comment(tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    class Completed:
+        stdout = ""
+        stderr = ""
+        returncode = 0
+
+    commands = []
+
+    def fake_run(command, cwd=None):
+        commands.append(command)
+        return Completed()
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "github",
+            "github_slug": "attmous/daedalus",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        run=fake_run,
+        run_json=lambda *args, **kwargs: [],
+    )
+
+    result = client.post_feedback(
+        issue_id="42",
+        event="issue.completed",
+        body="Completed by Daedalus.",
+        summary="Completed by Daedalus.",
+        state="done",
+    )
+
+    assert result["ok"] is True
+    assert result["state"] is None
+    assert result["unsupported_state"] == "done"
+    assert commands == [
+        ["gh", "issue", "comment", "42", "--body", "Completed by Daedalus.", "--repo", "attmous/daedalus"]
+    ]


### PR DESCRIPTION
## Summary

- extend the opt-in live GitHub issue-runner smoke to cover supervised dispatch, tracker feedback comments, forced runtime failure, retry recovery, successful signoff, GitHub close via tracker-feedback, retry suppression, and terminal cleanup
- allow GitHub tracker feedback to apply `open`/`closed` state updates while still posting comments for unsupported generic states
- pass the issue-runner injected runner into the GitHub tracker client so tests and workflow wiring use the same command path
- add a skipped-by-default `change-delivery` Codex app-server fixture smoke skeleton and update operator/readiness/conformance docs

## Validation

- `python -m pytest -q` -> `822 passed, 9 skipped`
- `git diff --check`

The live GitHub and change-delivery Codex E2E paths remain opt-in and skipped by default unless their environment variables are set.