### PR TITLE
[codex] Add public surface drift guards

### DIFF
--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -26,6 +26,8 @@ The harness tests should catch these regressions before review:
 - release readiness must keep the public-beta posture and launch gates explicit
 - public examples must use generic placeholders like `your-org/your-repo`
 - bundled workflow templates must match their public docs copies
+- documented `/daedalus`, `/workflow`, and `hermes daedalus ...` commands must
+  map to real parser surfaces
 - bootstrap must safely promote `WORKFLOW.md` to `WORKFLOW-<workflow>.md`
   without overwriting existing named contracts
 - `daedalus/projects/` must stay placeholder-only in the public repository
@@ -40,10 +42,11 @@ The harness tests should catch these regressions before review:
 
 Add tests for the next hardening slice in this order:
 
-1. CLI/docs drift checks for every command shown in the install guide.
-2. End-to-end `change-delivery` Codex app-server smoke around a real active
+1. End-to-end `change-delivery` Codex app-server smoke around a real active
    lane, PR update, and review loop.
-3. Live GitHub recovery coverage for labels, comments, and failure replay.
+2. A one-command local harness that runs all opt-in live smokes when the
+   required environment variables are present.
+3. Scheduled scorecard refresh automation for release-readiness gates.
 
 ## Harness Principles
 

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -229,13 +229,6 @@ This is the bundled generic tracker-driven workflow.
 || `/workflow issue-runner run` | Run the supervised long-lived issue-runner polling loop |
 || `/workflow issue-runner serve` | Run the optional localhost HTTP status server |
 
-### Webhook commands
-
-|| Command | What it does |
-|---|---|---|
-|| `/workflow change-delivery webhooks status` | Show configured webhook subscribers |
-|| `/workflow change-delivery webhooks test` | Fire a test event to all webhooks |
-
 ## Most useful day-to-day, in order
 
 1. `/daedalus watch` — live overview of every active lane in one frame

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -34,7 +34,7 @@ should be backed by documentation, tests, or an operator smoke path.
 | Area | Status | Evidence |
 |---|---|---|
 | Repo knowledge as system of record | Strong | Architecture, workflow, operator, security, and conformance docs |
-| Public-surface guardrails | Strong | Generic examples, placeholder-only `projects/`, packaging checks |
+| Public-surface guardrails | Strong | Generic examples, placeholder-only `projects/`, packaging checks, CLI/docs drift checks |
 | Agent-legible workflows | Good | Workflow docs link the default templates and operator paths |
 | Custom structural checks | Good | Public harness tests and workflow-template drift checks |
 | Live integration evidence | Partial | Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup; real Codex app-server smokes remain opt-in |
@@ -59,10 +59,10 @@ should be backed by documentation, tests, or an operator smoke path.
 
 ## Next Hardening Slice
 
-The highest-leverage next implementation slice is public-surface drift control:
+The highest-leverage next implementation slice is deeper live E2E evidence:
 
-1. Add docs/CLI drift checks for commands shown in operator docs.
-2. Teach the `change-delivery` Codex app-server smoke fixture to create and
+1. Teach the `change-delivery` Codex app-server smoke fixture to create and
    clean up its own GitHub artifacts.
-3. Add a one-command local harness that runs all opt-in live smokes when the
+2. Add a one-command local harness that runs all opt-in live smokes when the
    required environment variables are present.
+3. Add scheduled scorecard refresh automation for release-readiness gates.

--- a/tests/test_docs_public_workflow_template.py
+++ b/tests/test_docs_public_workflow_template.py
@@ -57,3 +57,31 @@ def test_public_workflow_template_uses_markdown_body_for_shared_policy(workflow_
 @pytest.mark.parametrize(("workflow_name", "template_path", "payload_template_path", "_schema_path"), WORKFLOW_EXAMPLES)
 def test_payload_workflow_template_matches_docs_copy(workflow_name, template_path, payload_template_path, _schema_path):
     assert payload_template_path.read_text(encoding="utf-8") == template_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "workflow_doc", "template_path", "payload_template_path", "_schema_path"),
+    [
+        (
+            name,
+            REPO_ROOT / "docs" / "workflows" / f"{name}.md",
+            template,
+            payload,
+            schema,
+        )
+        for name, template, payload, schema in WORKFLOW_EXAMPLES
+    ],
+)
+def test_workflow_docs_link_their_public_and_packaged_templates(
+    workflow_name,
+    workflow_doc,
+    template_path,
+    payload_template_path,
+    _schema_path,
+):
+    text = workflow_doc.read_text(encoding="utf-8")
+
+    assert f"docs/examples/{workflow_name}.workflow.md" in text
+    assert payload_template_path.relative_to(REPO_ROOT).as_posix() in text
+    assert template_path.exists()
+    assert payload_template_path.exists()

--- a/tests/test_public_cli_docs_drift.py
+++ b/tests/test_public_cli_docs_drift.py
@@ -1,0 +1,245 @@
+import argparse
+import importlib.util
+import re
+import shlex
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DAEDALUS_ROOT = REPO_ROOT / "daedalus"
+DOCS_WITH_OPERATOR_COMMANDS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "operator" / "installation.md",
+    REPO_ROOT / "docs" / "operator" / "codex-app-server.md",
+    REPO_ROOT / "docs" / "operator" / "slash-commands.md",
+]
+DOCS_WITH_WORKFLOW_COMMANDS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "operator" / "installation.md",
+    REPO_ROOT / "docs" / "operator" / "slash-commands.md",
+    REPO_ROOT / "docs" / "workflows" / "change-delivery.md",
+    REPO_ROOT / "docs" / "workflows" / "issue-runner.md",
+]
+DOCS_WITH_DIRECT_WORKFLOW_COMMANDS = [
+    REPO_ROOT / "docs" / "operator" / "cheat-sheet.md",
+    REPO_ROOT / "docs" / "operator" / "http-status.md",
+    REPO_ROOT / "docs" / "concepts" / "migration.md",
+]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _subparser_choices(parser: argparse.ArgumentParser) -> dict[str, argparse.ArgumentParser]:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return dict(action.choices)
+    return {}
+
+
+def _daedalus_parser() -> argparse.ArgumentParser:
+    return _load_module("daedalus_cli_docs_drift", DAEDALUS_ROOT / "daedalus_cli.py").build_parser()
+
+
+def _workflow_parser(workflow_name: str) -> argparse.ArgumentParser:
+    slug = workflow_name.replace("-", "_")
+    return _load_module(
+        f"{slug}_cli_docs_drift",
+        DAEDALUS_ROOT / "workflows" / slug / "cli.py",
+    ).build_parser()
+
+
+def _operator_command_mentions(prefix: str, paths: list[Path]) -> list[tuple[Path, str]]:
+    pattern = re.compile(rf"`({re.escape(prefix)}(?:\s+[^`]+)?)`")
+    mentions: list[tuple[Path, str]] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for match in pattern.finditer(text):
+            command = " ".join(match.group(1).split())
+            if "<" in command or "[" in command:
+                continue
+            mentions.append((path, command))
+    return mentions
+
+
+def _shell_commands_from_fences(paths: list[Path], *, prefix: str) -> list[tuple[Path, str]]:
+    commands: list[tuple[Path, str]] = []
+    fence_re = re.compile(r"```(?:bash|shell|sh|text)?\n(.*?)```", re.DOTALL)
+    for path in paths:
+        for fence in fence_re.findall(path.read_text(encoding="utf-8")):
+            pending = ""
+            for raw_line in fence.splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#") or line.startswith("export "):
+                    continue
+                line = line.split("#", 1)[0].rstrip()
+                if pending:
+                    line = f"{pending} {line}"
+                if line.endswith("\\"):
+                    pending = line[:-1].strip()
+                    continue
+                pending = ""
+                if line.startswith(prefix):
+                    commands.append((path, " ".join(line.split())))
+    return commands
+
+
+def _without_workflow_root(argv: list[str]) -> list[str]:
+    out: list[str] = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--workflow-root":
+            index += 2
+            continue
+        if arg.startswith("--workflow-root="):
+            index += 1
+            continue
+        out.append(arg)
+        index += 1
+    return out
+
+
+def test_documented_daedalus_commands_exist_on_operator_parser():
+    parser = _daedalus_parser()
+    daedalus_choices = _subparser_choices(parser)
+    mentions = _operator_command_mentions("/daedalus", [REPO_ROOT / "docs" / "operator" / "slash-commands.md"])
+
+    missing: list[str] = []
+    for path, command in mentions:
+        argv = shlex.split(command)
+        if len(argv) < 2:
+            continue
+        subcommand = argv[1]
+        if subcommand not in daedalus_choices:
+            missing.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+            continue
+        if subcommand == "codex-app-server" and len(argv) >= 3:
+            codex_choices = _subparser_choices(daedalus_choices[subcommand])
+            if argv[2] not in codex_choices:
+                missing.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+
+    assert missing == []
+
+
+def test_documented_hermes_daedalus_snippets_parse_with_operator_parser():
+    parser = _daedalus_parser()
+    commands = _shell_commands_from_fences(DOCS_WITH_OPERATOR_COMMANDS, prefix="hermes daedalus")
+    inline = [
+        (path, command.replace("`", ""))
+        for path, command in _operator_command_mentions("hermes daedalus", DOCS_WITH_OPERATOR_COMMANDS)
+    ]
+    commands.extend(inline)
+
+    failures: list[str] = []
+    for path, command in sorted(set(commands), key=lambda item: (str(item[0]), item[1])):
+        argv = shlex.split(command)[2:]
+        try:
+            parser.parse_args(argv)
+        except SystemExit:
+            failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+
+    assert failures == []
+
+
+def test_documented_workflow_commands_exist_on_workflow_parsers():
+    parsers = {
+        "change-delivery": _workflow_parser("change-delivery"),
+        "issue-runner": _workflow_parser("issue-runner"),
+    }
+    choices = {name: _subparser_choices(parser) for name, parser in parsers.items()}
+    mentions = _operator_command_mentions("/workflow", DOCS_WITH_WORKFLOW_COMMANDS)
+
+    failures: list[str] = []
+    for path, command in mentions:
+        argv = shlex.split(command)
+        if len(argv) < 3 or argv[1].startswith("<"):
+            continue
+        workflow_name = argv[1]
+        if workflow_name not in parsers:
+            failures.append(f"{path.relative_to(REPO_ROOT)}: unknown workflow in {command}")
+            continue
+        workflow_args = argv[2:]
+        if workflow_args and workflow_args[0] not in choices[workflow_name]:
+            failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+            continue
+        try:
+            parsers[workflow_name].parse_args(workflow_args or ["--help"])
+        except SystemExit as exc:
+            if exc.code != 0:
+                failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+
+    assert failures == []
+
+
+def test_documented_direct_workflow_python_commands_map_to_workflow_parsers():
+    parsers = {
+        "change-delivery": _workflow_parser("change-delivery"),
+        "issue-runner": _workflow_parser("issue-runner"),
+    }
+    choices = {name: _subparser_choices(parser) for name, parser in parsers.items()}
+    commands = []
+    commands.extend(
+        _shell_commands_from_fences(DOCS_WITH_DIRECT_WORKFLOW_COMMANDS, prefix="python3 -m workflows")
+    )
+    commands.extend(
+        _shell_commands_from_fences(
+            DOCS_WITH_DIRECT_WORKFLOW_COMMANDS,
+            prefix="python3 ~/.hermes/plugins/daedalus/workflows/__main__.py",
+        )
+    )
+
+    failures: list[str] = []
+    for path, command in sorted(set(commands), key=lambda item: (str(item[0]), item[1])):
+        argv = shlex.split(command)
+        if argv[:3] == ["python3", "-m", "workflows.change_delivery"]:
+            parser = parsers["change-delivery"]
+            workflow_args = _without_workflow_root(argv[3:])
+        elif argv[:3] == ["python3", "-m", "workflows.issue_runner"]:
+            parser = parsers["issue-runner"]
+            workflow_args = _without_workflow_root(argv[3:])
+        elif argv[:3] == ["python3", "-m", "workflows"] or argv[:2] == [
+            "python3",
+            "~/.hermes/plugins/daedalus/workflows/__main__.py",
+        ]:
+            start = 3 if argv[:3] == ["python3", "-m", "workflows"] else 2
+            workflow_args = _without_workflow_root(argv[start:])
+            if not workflow_args:
+                failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+                continue
+            if not any(workflow_args[0] in workflow_choices for workflow_choices in choices.values()):
+                failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+                continue
+            parser = next(
+                parser
+                for workflow_name, parser in parsers.items()
+                if workflow_args[0] in choices[workflow_name]
+            )
+        else:
+            continue
+        try:
+            parser.parse_args(workflow_args)
+        except SystemExit as exc:
+            if exc.code != 0:
+                failures.append(f"{path.relative_to(REPO_ROOT)}: {command}")
+
+    assert failures == []
+
+
+def test_readme_quickstart_keeps_issue_runner_default_path():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    quickstart_match = re.search(r"## Quick Start\n\n```bash\n(.*?)```", readme, re.DOTALL)
+    assert quickstart_match is not None
+    quickstart = quickstart_match.group(1)
+
+    assert "hermes daedalus bootstrap\n" in quickstart
+    assert "hermes daedalus bootstrap --workflow" not in quickstart
+    assert "hermes daedalus validate" in quickstart
+    assert "hermes daedalus service-up" in quickstart
+    assert readme.index("hermes daedalus bootstrap") < readme.index("hermes daedalus validate")
+    assert "`issue-runner` is the default public bootstrap path." in readme

--- a/tests/test_public_harness_checks.py
+++ b/tests/test_public_harness_checks.py
@@ -107,8 +107,10 @@ def test_release_readiness_tracks_public_beta_gates():
     assert "Experimental tracker: Linear" in readiness
     assert "Keep `daedalus/projects/` placeholder-only" in readiness
     assert "Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup" in readiness
+    assert "CLI/docs drift checks" in readiness
     assert "strict Symphony contract" in readiness
     assert "issue-runner` is the workflow that should converge" in conformance
     assert "release-readiness.md" in conformance
     assert "Harness Principles" in harness
     assert "release readiness" in harness
+    assert "commands must" in harness


### PR DESCRIPTION
## Summary

Adds parser-backed public-surface drift tests so documented Daedalus operator commands, workflow commands, `hermes daedalus ...` snippets, and direct workflow Python examples must map to real CLI parser surfaces.

Also removes stale webhook slash-command documentation and tightens workflow-template documentation checks so each workflow guide links both the public example and packaged template.

## Impact

This keeps the landing/operator docs from advertising commands or templates that are not actually shipped, and moves release-readiness/harness docs forward to the next live E2E evidence slice.

## Validation

- `python -m pytest tests/test_public_cli_docs_drift.py tests/test_docs_public_workflow_template.py tests/test_public_harness_checks.py tests/test_public_onboarding_smoke.py tests/test_tools_format_flag.py tests/test_tools_run_cli_command_dispatch.py tests/test_workflows_dispatcher.py -q`
- `python -m pytest -q`
- `git diff --check`