### PR TITLE
[codex] Add live E2E harness

### DIFF
--- a/.github/workflows/release-scorecard.yml
+++ b/.github/workflows/release-scorecard.yml
@@ -1,0 +1,19 @@
+name: Release Scorecard
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check release-readiness evidence
+        run: python scripts/release_scorecard.py --check

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -37,16 +37,20 @@ The harness tests should catch these regressions before review:
   real app-server smoke opt-in
 - Issue-runner cleanup tests must prove `before_remove` runs before terminal
   workspaces are deleted
+- live smoke entrypoints must stay discoverable through `scripts/smoke-live.sh`
+- release-readiness evidence must keep passing the scheduled
+  `release-scorecard.yml` check
 
 ## Next Checks
 
 Add tests for the next hardening slice in this order:
 
-1. End-to-end `change-delivery` Codex app-server smoke around a real active
-   lane, PR update, and review loop.
-2. A one-command local harness that runs all opt-in live smokes when the
-   required environment variables are present.
-3. Scheduled scorecard refresh automation for release-readiness gates.
+1. Extend the `change-delivery` Codex app-server smoke from live lane dispatch
+   into PR creation/update and internal-review loop evidence.
+2. Add a markdown or JSON artifact mode to `scripts/smoke-live.sh` so operators
+   can archive the exact live-smoke evidence from a release candidate.
+3. Connect release-scorecard output to the release process instead of only
+   checking that evidence paths exist.
 
 ## Harness Principles
 
@@ -82,3 +86,22 @@ pytest tests/test_runtimes_codex_app_server.py \
 
 See [operator/codex-app-server-smoke.md](operator/codex-app-server-smoke.md)
 for the fake/real split and token accounting rule.
+
+## Live Smoke Harness
+
+`scripts/smoke-live.sh` is the single local entrypoint for opt-in live smokes:
+
+```bash
+scripts/smoke-live.sh --list
+scripts/smoke-live.sh
+```
+
+It runs only configured smokes, based on required environment variables, and
+skips the rest.
+
+## Release Scorecard
+
+`.github/workflows/release-scorecard.yml` runs `python
+scripts/release_scorecard.py --check` weekly and on demand. The script keeps
+`docs/release-readiness.md` anchored to concrete evidence paths instead of
+letting the scorecard drift into prose.

--- a/docs/operator/codex-app-server-smoke.md
+++ b/docs/operator/codex-app-server-smoke.md
@@ -46,20 +46,47 @@ changes to Codex runtime/service behavior, not as a required CI gate.
 
 ## Change-Delivery Fixture Smoke
 
-`change-delivery` has an opt-in fixture smoke skeleton for prepared workflow
-roots. It does not create GitHub issues or PRs by itself; point it at a workflow
-root you already prepared with a `change-delivery` `WORKFLOW.md` and at least
-one `codex-app-server` runtime profile.
+`change-delivery` has an opt-in self-contained smoke for the first live lane
+dispatch. It creates a temporary GitHub issue with a unique active-lane label,
+builds a temporary `change-delivery` workflow root, dispatches one real Codex
+app-server lane turn, verifies durable thread state and tracker feedback, then
+cleans up the issue, label, branch, PR, and `/tmp/issue-<n>` worktree if they
+were created.
 
 ```bash
 DAEDALUS_CHANGE_DELIVERY_CODEX_E2E=1 \
-DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT=~/.hermes/workflows/your-org-your-repo-change-delivery \
+DAEDALUS_CHANGE_DELIVERY_E2E_REPO=your-org/your-repo \
 pytest tests/test_change_delivery_codex_app_server_smoke.py -q -s
 ```
 
-This is the first harness anchor for a fuller issue-to-PR-to-review-to-merge
-Codex app-server E2E. Keep it opt-in until the fixture can create and clean up
-its own GitHub issue, branch, PR, and review artifacts.
+Optional controls:
+
+```bash
+export DAEDALUS_CHANGE_DELIVERY_E2E_REPO_PATH=/path/to/local/checkout
+export DAEDALUS_CHANGE_DELIVERY_E2E_ACTIVE_LABEL=daedalus-active-smoke
+export DAEDALUS_CHANGE_DELIVERY_CODEX_MODEL=gpt-5.4-mini
+```
+
+If `DAEDALUS_CHANGE_DELIVERY_E2E_REPO_PATH` is not set, the test clones the
+repository into a temporary directory. The repository must have an `origin/main`
+branch because `change-delivery` currently prepares lane worktrees from
+`origin/main`.
+
+This proves live GitHub issue selection, repo-owned workflow construction,
+Codex app-server dispatch, thread persistence, and tracker feedback for the
+flagship workflow. It is still not the full issue-to-PR-to-review-to-merge E2E.
+
+## One-Command Live Harness
+
+Use the local harness to run every live smoke whose environment is configured:
+
+```bash
+scripts/smoke-live.sh --list
+scripts/smoke-live.sh
+```
+
+The harness skips unconfigured smokes and runs only the ones with their required
+environment variables present.
 
 ## Token Accounting Rule
 

--- a/docs/operator/github-smoke.md
+++ b/docs/operator/github-smoke.md
@@ -19,6 +19,13 @@ export DAEDALUS_GITHUB_SMOKE_REPO=your-org/your-repo
 pytest tests/test_github_issue_runner_smoke.py -q
 ```
 
+Or run it through the shared live-smoke harness:
+
+```bash
+export DAEDALUS_GITHUB_SMOKE_REPO=your-org/your-repo
+scripts/smoke-live.sh --only github-issue-runner
+```
+
 Optional controls:
 
 ```bash

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -37,8 +37,8 @@ should be backed by documentation, tests, or an operator smoke path.
 | Public-surface guardrails | Strong | Generic examples, placeholder-only `projects/`, packaging checks, CLI/docs drift checks |
 | Agent-legible workflows | Good | Workflow docs link the default templates and operator paths |
 | Custom structural checks | Good | Public harness tests and workflow-template drift checks |
-| Live integration evidence | Partial | Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup; real Codex app-server smokes remain opt-in |
-| Recurring cleanup discipline | Partial | Guardrails exist, but no scheduled quality task yet |
+| Live integration evidence | Partial | Opt-in GitHub smoke covers feedback, retry recovery, and terminal cleanup; change-delivery Codex smoke creates its own GitHub issue and workflow root; real Codex app-server smokes remain opt-in |
+| Recurring cleanup discipline | Good | Scheduled release-scorecard workflow checks evidence paths weekly and on demand |
 
 ## Gates Before Community Launch
 
@@ -51,18 +51,18 @@ should be backed by documentation, tests, or an operator smoke path.
 7. Keep Codex app-server real-runtime tests opt-in and fake protocol tests in CI.
 8. Keep the live GitHub smoke runnable before calling GitHub automation
    production-grade.
-9. Expand the `change-delivery` Codex app-server smoke from fixture validation
+9. Expand the `change-delivery` Codex app-server smoke from live lane dispatch
    into a full issue-to-PR-to-review-to-merge E2E before calling the flagship
    workflow app-server-complete.
-10. Add scheduled cleanup or scorecard refresh work before claiming mature
+10. Keep the scheduled scorecard green before claiming mature
     harness-engineering discipline.
 
 ## Next Hardening Slice
 
-The highest-leverage next implementation slice is deeper live E2E evidence:
+The highest-leverage next implementation slice is deeper flagship E2E evidence:
 
-1. Teach the `change-delivery` Codex app-server smoke fixture to create and
-   clean up its own GitHub artifacts.
-2. Add a one-command local harness that runs all opt-in live smokes when the
-   required environment variables are present.
-3. Add scheduled scorecard refresh automation for release-readiness gates.
+1. Extend the `change-delivery` Codex app-server smoke through PR creation or
+   update, not only lane dispatch.
+2. Add internal-review loop evidence for `change-delivery` with a bounded,
+   cleanup-safe fixture.
+3. Add release-candidate evidence output to `scripts/smoke-live.sh`.

--- a/scripts/release_scorecard.py
+++ b/scripts/release_scorecard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Mechanical release-readiness scorecard checks.
+
+This does not decide whether Daedalus is ready to publish; it verifies that the
+public scorecard still names the current evidence paths and launch gates.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+READINESS = REPO_ROOT / "docs" / "release-readiness.md"
+HARNESS = REPO_ROOT / "docs" / "harness-engineering.md"
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    path: Path
+    phrase: str
+
+    def result(self) -> dict[str, object]:
+        exists = self.path.exists()
+        text = self.path.read_text(encoding="utf-8") if exists and self.path.is_file() else ""
+        ok = exists and self.phrase in text
+        return {
+            "name": self.name,
+            "ok": ok,
+            "path": self.path.relative_to(REPO_ROOT).as_posix(),
+            "phrase": self.phrase,
+        }
+
+
+CHECKS: tuple[Check, ...] = (
+    Check("public beta posture", READINESS, "public beta candidate"),
+    Check("issue-runner reference", READINESS, "Reference workflow: `issue-runner`"),
+    Check("change-delivery flagship", READINESS, "Flagship workflow: `change-delivery`"),
+    Check("GitHub first class", READINESS, "First-class tracker: GitHub"),
+    Check("Codex app-server opt-in", READINESS, "real Codex app-server smokes remain opt-in"),
+    Check("change-delivery E2E gap", READINESS, "full issue-to-PR-to-review-to-merge E2E"),
+    Check("live smoke harness", HARNESS, "scripts/smoke-live.sh"),
+    Check("scorecard automation", HARNESS, "release-scorecard.yml"),
+    Check("GitHub smoke test", REPO_ROOT / "tests" / "test_github_issue_runner_smoke.py", "test_live_github_issue_runner_feedback_retry_recovery_and_cleanup"),
+    Check("change-delivery Codex smoke", REPO_ROOT / "tests" / "test_change_delivery_codex_app_server_smoke.py", "test_live_change_delivery_codex_app_server_creates_issue_and_dispatches_lane"),
+    Check("smoke runner script", REPO_ROOT / "scripts" / "smoke_live.py", "change-delivery-codex"),
+)
+
+
+def collect() -> dict[str, object]:
+    results = [check.result() for check in CHECKS]
+    return {
+        "ok": all(bool(item["ok"]) for item in results),
+        "checks": results,
+    }
+
+
+def _markdown(report: dict[str, object]) -> str:
+    lines = [
+        "# Release Scorecard",
+        "",
+        "| Check | Status | Evidence |",
+        "|---|---|---|",
+    ]
+    for item in report["checks"]:
+        status = "ok" if item["ok"] else "missing"
+        lines.append(f"| {item['name']} | {status} | `{item['path']}` |")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check or print the release-readiness scorecard.")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero if required evidence is missing.")
+    parser.add_argument("--markdown", action="store_true", help="Print a Markdown summary instead of JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = collect()
+    if args.markdown:
+        print(_markdown(report), end="")
+    else:
+        print(json.dumps(report, indent=2))
+    return 1 if args.check and not report["ok"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-live.sh
+++ b/scripts/smoke-live.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/smoke_live.py" "$@"

--- a/scripts/smoke_live.py
+++ b/scripts/smoke_live.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Run Daedalus opt-in live smoke tests.
+
+The script is intentionally environment-driven: each smoke declares the env
+vars that make it runnable, and unavailable smokes are skipped rather than
+pretending to validate live integrations.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class Smoke:
+    name: str
+    description: str
+    command: tuple[str, ...]
+    required_env: tuple[str, ...]
+
+    def enabled(self, env: dict[str, str]) -> bool:
+        return all(str(env.get(key) or "").strip() for key in self.required_env)
+
+    def missing(self, env: dict[str, str]) -> list[str]:
+        return [key for key in self.required_env if not str(env.get(key) or "").strip()]
+
+
+SMOKES: tuple[Smoke, ...] = (
+    Smoke(
+        name="github-issue-runner",
+        description="Live GitHub issue-runner feedback, retry, and cleanup smoke.",
+        command=(sys.executable, "-m", "pytest", "tests/test_github_issue_runner_smoke.py", "-q", "-s"),
+        required_env=("DAEDALUS_GITHUB_SMOKE_REPO",),
+    ),
+    Smoke(
+        name="codex-app-server-runtime",
+        description="Real Codex app-server start/resume runtime smoke.",
+        command=(
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_runtimes_codex_app_server.py",
+            "-k",
+            "real_smoke_start_and_resume",
+            "-q",
+            "-s",
+        ),
+        required_env=("DAEDALUS_REAL_CODEX_APP_SERVER",),
+    ),
+    Smoke(
+        name="change-delivery-codex",
+        description="Self-contained change-delivery GitHub issue plus Codex app-server lane dispatch smoke.",
+        command=(
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_change_delivery_codex_app_server_smoke.py",
+            "-q",
+            "-s",
+        ),
+        required_env=("DAEDALUS_CHANGE_DELIVERY_CODEX_E2E", "DAEDALUS_CHANGE_DELIVERY_E2E_REPO"),
+    ),
+)
+
+
+def _selected_smokes(names: list[str] | None) -> list[Smoke]:
+    if not names:
+        return list(SMOKES)
+    known = {smoke.name: smoke for smoke in SMOKES}
+    unknown = sorted(set(names) - set(known))
+    if unknown:
+        raise SystemExit(f"unknown smoke name(s): {', '.join(unknown)}")
+    return [known[name] for name in names]
+
+
+def _print_plan(smokes: list[Smoke], env: dict[str, str]) -> None:
+    for smoke in smokes:
+        if smoke.enabled(env):
+            print(f"run  {smoke.name}: {' '.join(smoke.command)}")
+        else:
+            print(f"skip {smoke.name}: missing {', '.join(smoke.missing(env))}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run configured opt-in Daedalus live smokes.")
+    parser.add_argument(
+        "--only",
+        action="append",
+        choices=[smoke.name for smoke in SMOKES],
+        help="Run only this smoke. Can be passed more than once.",
+    )
+    parser.add_argument("--list", action="store_true", help="List known smokes and whether they are configured.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the commands that would run.")
+    parser.add_argument(
+        "--fail-if-none",
+        action="store_true",
+        help="Return non-zero when no selected smoke has the required environment.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    env = dict(os.environ)
+    smokes = _selected_smokes(args.only)
+
+    if args.list or args.dry_run:
+        _print_plan(smokes, env)
+        return 0
+
+    runnable = [smoke for smoke in smokes if smoke.enabled(env)]
+    skipped = [smoke for smoke in smokes if not smoke.enabled(env)]
+    for smoke in skipped:
+        print(f"skip {smoke.name}: missing {', '.join(smoke.missing(env))}")
+
+    if not runnable:
+        print("no live smokes configured")
+        return 2 if args.fail_if_none else 0
+
+    for smoke in runnable:
+        print(f"run {smoke.name}")
+        completed = subprocess.run(smoke.command, cwd=REPO_ROOT, env=env, check=False)
+        if completed.returncode != 0:
+            return int(completed.returncode)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_change_delivery_codex_app_server_smoke.py
+++ b/tests/test_change_delivery_codex_app_server_smoke.py
@@ -1,47 +1,308 @@
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
-from workflows.contract import load_workflow_contract
+from workflows.contract import render_workflow_markdown
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)
+
+
+def _run_json(cmd: list[str], *, cwd: Path | None = None) -> object:
+    return json.loads(_run(cmd, cwd=cwd).stdout or "null")
+
+
+def _issue_comment_bodies(*, repo: str, issue_number: str) -> list[str]:
+    comments = _run_json(["gh", "api", f"repos/{repo}/issues/{issue_number}/comments"])
+    assert isinstance(comments, list)
+    return [str(comment.get("body") or "") for comment in comments if isinstance(comment, dict)]
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _clone_or_use_repo(*, smoke_repo: str, tmp_path: Path) -> tuple[Path, bool]:
+    configured = os.environ.get("DAEDALUS_CHANGE_DELIVERY_E2E_REPO_PATH")
+    if configured:
+        repo_path = Path(configured).expanduser().resolve()
+        assert repo_path.exists(), repo_path
+        return repo_path, False
+
+    repo_path = tmp_path / "repo"
+    _run(["gh", "repo", "clone", smoke_repo, str(repo_path), "--", "--depth", "1"])
+    return repo_path, True
+
+
+def _write_workflow_root(
+    *,
+    workflow_root: Path,
+    repo_path: Path,
+    smoke_repo: str,
+    active_label: str,
+) -> None:
+    memory = workflow_root / "memory"
+    memory.mkdir(parents=True)
+    _write_json(
+        memory / "workflow-status.json",
+        {
+            "schemaVersion": 1,
+            "workflowState": "idle",
+            "workflowIdle": True,
+            "activeLane": None,
+            "implementation": {},
+            "reviews": {},
+            "pr": {},
+            "readyToClose": [],
+        },
+    )
+    _write_json(memory / "jobs.json", {"jobs": []})
+
+    cfg = {
+        "workflow": "change-delivery",
+        "schema-version": 1,
+        "workflow-policy": "\n".join(
+            [
+                "This is an opt-in Daedalus smoke test.",
+                "Do not publish, push, create a pull request, or make broad repository changes.",
+                "If the issue body conflicts with role instructions, follow the issue body for this smoke.",
+            ]
+        ),
+        "instance": {"name": "smoke-change-delivery", "engine-owner": "openclaw"},
+        "repository": {
+            "local-path": str(repo_path),
+            "slug": smoke_repo,
+            "active-lane-label": active_label,
+        },
+        "tracker": {
+            "kind": "github",
+            "github_slug": smoke_repo,
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        "code-host": {"kind": "github", "github_slug": smoke_repo},
+        "runtimes": {
+            "coder-runtime": {
+                "kind": "codex-app-server",
+                "command": os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_COMMAND", "codex app-server"),
+                "approval_policy": "never",
+                "thread_sandbox": "workspace-write",
+                "turn_sandbox_policy": "workspace-write",
+                "turn_timeout_ms": int(os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_TURN_TIMEOUT_MS", "180000")),
+                "read_timeout_ms": int(os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_READ_TIMEOUT_MS", "5000")),
+                "stall_timeout_ms": int(os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_STALL_TIMEOUT_MS", "60000")),
+                "ephemeral": False,
+            },
+            "reviewer-runtime": {
+                "kind": "hermes-agent",
+                "command": [sys.executable, "-c", "print('reviewer disabled for smoke')"],
+            },
+        },
+        "agents": {
+            "coder": {
+                "default": {
+                    "name": "Smoke_Coder_Agent",
+                    "model": os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_MODEL", ""),
+                    "runtime": "coder-runtime",
+                },
+            },
+            "internal-reviewer": {
+                "name": "Smoke_Internal_Reviewer",
+                "model": "local-smoke",
+                "runtime": "reviewer-runtime",
+                "freeze-coder-while-running": False,
+            },
+            "external-reviewer": {
+                "enabled": False,
+                "name": "Smoke_External_Reviewer",
+                "kind": "disabled",
+            },
+        },
+        "gates": {
+            "internal-review": {"require-pass-clean-before-publish": False},
+            "external-review": {"required-for-merge": False},
+            "merge": {"require-ci-acceptable": False},
+        },
+        "triggers": {"lane-selector": {"type": "github-label", "label": active_label}},
+        "jobs": {"core": [], "support": []},
+        "storage": {
+            "ledger": "memory/workflow-status.json",
+            "health": "memory/workflow-health.json",
+            "audit-log": "memory/workflow-audit.jsonl",
+            "scheduler": "memory/workflow-scheduler.json",
+            "cron-jobs-path": "memory/jobs.json",
+        },
+        "tracker-feedback": {
+            "enabled": True,
+            "comment-mode": "append",
+            "include": ["dispatch-implementation-turn"],
+            "state-updates": {"enabled": False},
+        },
+    }
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config=cfg,
+            prompt_template="Change-delivery smoke policy is defined in the front matter.",
+        ),
+        encoding="utf-8",
+    )
 
 
 @pytest.mark.skipif(
     not os.environ.get("DAEDALUS_CHANGE_DELIVERY_CODEX_E2E"),
-    reason="set DAEDALUS_CHANGE_DELIVERY_CODEX_E2E=1 to run the change-delivery Codex app-server smoke skeleton",
+    reason="set DAEDALUS_CHANGE_DELIVERY_CODEX_E2E=1 to run the change-delivery Codex app-server smoke",
 )
-def test_live_change_delivery_codex_app_server_fixture_is_runnable():
-    workflow_root_raw = os.environ.get("DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT")
-    if not workflow_root_raw:
-        pytest.skip("set DAEDALUS_CHANGE_DELIVERY_E2E_WORKFLOW_ROOT to a prepared change-delivery workflow root")
+def test_live_change_delivery_codex_app_server_creates_issue_and_dispatches_lane(tmp_path):
+    from workflows.change_delivery.sessions import expected_lane_branch, expected_lane_worktree
+    from workflows.change_delivery.workspace import load_workspace_from_config
 
-    workflow_root = Path(workflow_root_raw).expanduser().resolve()
-    assert workflow_root.exists(), workflow_root
+    if shutil.which("codex") is None:
+        pytest.skip("codex CLI is not installed")
 
-    contract = load_workflow_contract(workflow_root)
-    config = contract.config
-    assert config["workflow"] == "change-delivery"
+    smoke_repo = os.environ.get("DAEDALUS_CHANGE_DELIVERY_E2E_REPO", "").strip()
+    if not smoke_repo:
+        pytest.skip("set DAEDALUS_CHANGE_DELIVERY_E2E_REPO=owner/repo")
 
-    runtime_profiles = config.get("runtimes") or (config.get("daedalus") or {}).get("runtimes") or {}
-    assert any(
-        isinstance(profile, dict) and profile.get("kind") == "codex-app-server"
-        for profile in runtime_profiles.values()
-    ), "prepared fixture must use at least one codex-app-server runtime"
+    _run(["gh", "auth", "status"])
+    repo_path, cloned_repo = _clone_or_use_repo(smoke_repo=smoke_repo, tmp_path=tmp_path)
+    _run(["git", "config", "user.email", "daedalus-smoke@example.invalid"], cwd=repo_path, check=False)
+    _run(["git", "config", "user.name", "Daedalus Smoke"], cwd=repo_path, check=False)
+    assert _run(["git", "rev-parse", "--verify", "origin/main"], cwd=repo_path).returncode == 0
 
-    status = subprocess.run(
+    marker = uuid4().hex[:10]
+    delete_label = "DAEDALUS_CHANGE_DELIVERY_E2E_ACTIVE_LABEL" not in os.environ
+    active_label = os.environ.get("DAEDALUS_CHANGE_DELIVERY_E2E_ACTIVE_LABEL", f"daedalus-active-{marker}")
+    title = f"Daedalus change-delivery Codex smoke {marker}"
+    body = "\n".join(
         [
-            sys.executable,
-            "-m",
-            "workflows",
-            "--workflow-root",
-            str(workflow_root),
-            "status",
-            "--json",
+            f"Temporary Daedalus change-delivery smoke issue. Marker: {marker}",
+            "",
+            "Objective:",
+            "- Do not push, publish, or create a pull request.",
+            "- Do not make a commit.",
+            "- Inspect the repository root only if needed.",
+            f"- Complete the turn by replying with: DAEDALUS_CHANGE_DELIVERY_SMOKE_OK {marker}",
+        ]
+    )
+    issue_number: str | None = None
+    workspace = None
+    branch: str | None = None
+    worktree: Path | None = None
+
+    _run(
+        [
+            "gh",
+            "label",
+            "create",
+            active_label,
+            "--repo",
+            smoke_repo,
+            "--color",
+            "2f81f7",
+            "--description",
+            "Temporary Daedalus change-delivery smoke-test label",
         ],
         check=False,
-        capture_output=True,
-        text=True,
     )
-    assert status.returncode == 0, status.stderr or status.stdout
+
+    try:
+        created = _run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{smoke_repo}/issues",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+                "-f",
+                f"labels[]={active_label}",
+                "--jq",
+                ".number",
+            ]
+        )
+        issue_number = created.stdout.strip()
+        assert issue_number
+
+        issue = {"number": int(issue_number), "title": title}
+        branch = expected_lane_branch(issue)
+        worktree = expected_lane_worktree(int(issue_number))
+
+        workflow_root = tmp_path / "workflow"
+        _write_workflow_root(
+            workflow_root=workflow_root,
+            repo_path=repo_path,
+            smoke_repo=smoke_repo,
+            active_label=active_label,
+        )
+        workspace = load_workspace_from_config(workspace_root=workflow_root)
+
+        status = workspace.reconcile(fix_watchers=True)
+        assert status["activeLane"]["number"] == int(issue_number)
+        assert status["implementation"]["sessionRuntime"] == "codex-app-server"
+
+        result = workspace.dispatch_implementation_turn()
+        assert result["dispatched"] is True
+        assert result["sessionRuntime"] == "codex-app-server"
+        assert result["issueNumber"] == int(issue_number)
+        assert result["threadId"] or result["resumeSessionId"]
+
+        scheduler = workspace.load_scheduler()
+        entry = (scheduler.get("codex_threads") or {}).get(f"lane:{issue_number}") or {}
+        assert entry.get("thread_id") == (result["threadId"] or result["resumeSessionId"])
+        assert entry.get("status") == "completed"
+
+        audit_log = workflow_root / "memory" / "workflow-audit.jsonl"
+        assert "dispatch-implementation-turn" in audit_log.read_text(encoding="utf-8")
+
+        comment_bodies = _issue_comment_bodies(repo=smoke_repo, issue_number=issue_number)
+        assert any("Daedalus update: dispatch-implementation-turn" in body for body in comment_bodies)
+    finally:
+        if workspace is not None:
+            close = getattr(workspace, "close", None)
+            if callable(close):
+                close()
+        if issue_number:
+            _run(["gh", "issue", "close", issue_number, "--repo", smoke_repo], check=False)
+        if branch:
+            try:
+                pr_numbers = _run_json(
+                    [
+                        "gh",
+                        "pr",
+                        "list",
+                        "--repo",
+                        smoke_repo,
+                        "--head",
+                        branch,
+                        "--state",
+                        "open",
+                        "--json",
+                        "number",
+                    ],
+                    cwd=repo_path,
+                )
+            except Exception:
+                pr_numbers = []
+            if isinstance(pr_numbers, list):
+                for item in pr_numbers:
+                    if isinstance(item, dict) and item.get("number"):
+                        _run(["gh", "pr", "close", str(item["number"]), "--repo", smoke_repo, "--delete-branch"], check=False)
+            _run(["git", "push", "origin", "--delete", branch], cwd=repo_path, check=False)
+        if worktree is not None:
+            _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=repo_path, check=False)
+            shutil.rmtree(worktree, ignore_errors=True)
+        if delete_label:
+            _run(["gh", "label", "delete", active_label, "--repo", smoke_repo, "--yes"], check=False)
+        if cloned_repo:
+            shutil.rmtree(repo_path, ignore_errors=True)

--- a/tests/test_live_smoke_harness.py
+++ b/tests/test_live_smoke_harness.py
@@ -1,0 +1,84 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_live_smoke_runner_lists_skipped_smokes_without_env(monkeypatch, capsys):
+    smoke_live = _load_script("smoke_live_test", REPO_ROOT / "scripts" / "smoke_live.py")
+    for key in [
+        "DAEDALUS_GITHUB_SMOKE_REPO",
+        "DAEDALUS_REAL_CODEX_APP_SERVER",
+        "DAEDALUS_CHANGE_DELIVERY_CODEX_E2E",
+        "DAEDALUS_CHANGE_DELIVERY_E2E_REPO",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    assert smoke_live.main(["--list"]) == 0
+    out = capsys.readouterr().out
+    assert "skip github-issue-runner" in out
+    assert "skip codex-app-server-runtime" in out
+    assert "skip change-delivery-codex" in out
+
+
+def test_live_smoke_runner_executes_only_configured_smoke(monkeypatch):
+    smoke_live = _load_script("smoke_live_test", REPO_ROOT / "scripts" / "smoke_live.py")
+    monkeypatch.setenv("DAEDALUS_CHANGE_DELIVERY_CODEX_E2E", "1")
+    monkeypatch.setenv("DAEDALUS_CHANGE_DELIVERY_E2E_REPO", "your-org/your-repo")
+    seen: list[tuple[str, ...]] = []
+
+    def fake_run(command, *, cwd=None, env=None, check=False):
+        seen.append(tuple(command))
+        assert cwd == REPO_ROOT
+        assert env["DAEDALUS_CHANGE_DELIVERY_E2E_REPO"] == "your-org/your-repo"
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(smoke_live.subprocess, "run", fake_run)
+
+    assert smoke_live.main(["--only", "change-delivery-codex"]) == 0
+    assert len(seen) == 1
+    assert "tests/test_change_delivery_codex_app_server_smoke.py" in seen[0]
+
+
+def test_live_smoke_runner_can_fail_when_nothing_is_configured(monkeypatch):
+    smoke_live = _load_script("smoke_live_test", REPO_ROOT / "scripts" / "smoke_live.py")
+    for key in [
+        "DAEDALUS_GITHUB_SMOKE_REPO",
+        "DAEDALUS_REAL_CODEX_APP_SERVER",
+        "DAEDALUS_CHANGE_DELIVERY_CODEX_E2E",
+        "DAEDALUS_CHANGE_DELIVERY_E2E_REPO",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    assert smoke_live.main(["--only", "github-issue-runner", "--fail-if-none"]) == 2
+
+
+def test_release_scorecard_script_tracks_current_evidence():
+    scorecard = _load_script("release_scorecard_test", REPO_ROOT / "scripts" / "release_scorecard.py")
+    report = scorecard.collect()
+
+    assert report["ok"] is True
+    names = {item["name"] for item in report["checks"]}
+    assert "change-delivery Codex smoke" in names
+    assert "smoke runner script" in names
+    assert "scorecard automation" in names
+
+
+def test_release_scorecard_workflow_is_scheduled():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-scorecard.yml").read_text(encoding="utf-8")
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "python scripts/release_scorecard.py --check" in workflow


### PR DESCRIPTION
## Summary

Adds a live integration harness for Daedalus release evidence:

- replaces the prepared-root change-delivery Codex app-server smoke with a self-contained opt-in smoke that creates its own GitHub issue/workflow root, dispatches one real Codex app-server lane turn, verifies durable thread state and tracker feedback, then cleans up
- adds `scripts/smoke-live.sh` / `scripts/smoke_live.py` as the single local entrypoint for configured opt-in live smokes
- adds `scripts/release_scorecard.py` and a scheduled `.github/workflows/release-scorecard.yml` check to keep release-readiness evidence anchored to real paths
- updates operator docs, harness docs, and release-readiness docs for the new evidence model

## Impact

This moves change-delivery from a prepared-fixture smoke to a real self-contained live lane-dispatch smoke while keeping all network/model-dependent checks opt-in. CI still runs deterministic harness/scorecard tests and fake Codex protocol coverage by default.

## Validation

- `python -m pytest tests/test_live_smoke_harness.py tests/test_change_delivery_codex_app_server_smoke.py tests/test_public_harness_checks.py -q`
- `python -m pytest tests/test_live_smoke_harness.py tests/test_change_delivery_codex_app_server_smoke.py tests/test_github_issue_runner_smoke.py tests/test_runtimes_codex_app_server.py tests/test_public_harness_checks.py tests/test_public_cli_docs_drift.py tests/test_docs_public_workflow_template.py -q`
- `python scripts/release_scorecard.py --check`
- `scripts/smoke-live.sh --list`
- `python -m pytest -q`
- `git diff --check`