### PR TITLE
Make change-delivery internal review runtime-neutral

### DIFF
--- a/daedalus/workflows/change_delivery/reviews.py
+++ b/daedalus/workflows/change_delivery/reviews.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import subprocess
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable
 
 from workflows.change_delivery.migrations import get_lane_state_review_field, get_review
@@ -105,6 +107,37 @@ class InterReviewAgentError(RuntimeError):
         self.failure_class = failure_class
 
 
+def inter_review_agent_output_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "verdict": {"type": "string", "enum": ["PASS_CLEAN", "PASS_WITH_FINDINGS", "REWORK"]},
+            "summary": {"type": "string"},
+            "blockingFindings": {"type": "array", "items": {"type": "string"}},
+            "majorConcerns": {"type": "array", "items": {"type": "string"}},
+            "minorSuggestions": {"type": "array", "items": {"type": "string"}},
+            "requiredNextAction": {"type": ["string", "null"]},
+        },
+        "required": ["verdict", "summary", "blockingFindings", "majorConcerns", "minorSuggestions", "requiredNextAction"],
+        "additionalProperties": False,
+    }
+
+
+def inter_review_agent_output_schema_json() -> str:
+    return json.dumps(inter_review_agent_output_schema(), separators=(",", ":"))
+
+
+def normalize_inter_review_agent_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        'verdict': payload.get('verdict'),
+        'summary': payload.get('summary'),
+        'blockingFindings': list(payload.get('blockingFindings') or []),
+        'majorConcerns': list(payload.get('majorConcerns') or []),
+        'minorSuggestions': list(payload.get('minorSuggestions') or []),
+        'requiredNextAction': payload.get('requiredNextAction'),
+    }
+
+
 def classify_inter_review_agent_failure_text(text: str) -> str:
     lowered = (text or "").lower()
     if "error_max_turns" in lowered or "maximum number of turns" in lowered:
@@ -174,6 +207,37 @@ def inter_review_agent_failure_class(
 ) -> str:
     parts = [exc.stdout or "", exc.stderr or ""]
     return classify_failure_text_fn("\n".join(part for part in parts if part))
+
+
+def inter_review_agent_runtime_failure_message(exc: Exception) -> str:
+    parts = ["Internal review agent runtime failed"]
+    returncode = getattr(exc, "returncode", None)
+    if returncode is not None:
+        parts[0] = f"Internal review agent runtime failed with exit status {returncode}"
+    result = getattr(exc, "result", None)
+    for value in (
+        getattr(result, "last_message", None),
+        getattr(exc, "stderr", None),
+        getattr(exc, "stdout", None),
+        str(exc),
+    ):
+        text = str(value or "").strip()
+        if text:
+            parts.append(text)
+            break
+    return ": ".join(parts)
+
+
+def inter_review_agent_runtime_failure_class(exc: Exception) -> str:
+    result = getattr(exc, "result", None)
+    parts = [
+        getattr(result, "output", None),
+        getattr(result, "last_message", None),
+        getattr(exc, "stdout", None),
+        getattr(exc, "stderr", None),
+        str(exc),
+    ]
+    return classify_inter_review_agent_failure_text("\n".join(str(part) for part in parts if part))
 
 
 def classify_lane_failure(
@@ -1569,6 +1633,185 @@ def audit_inter_review_agent_transition(
         )
 
 
+def _runtime_prompt_command(*, agent_cfg: dict[str, Any], runtime_cfg: dict[str, Any]) -> list[str] | None:
+    command = agent_cfg.get("command")
+    if command:
+        return list(command)
+    runtime_kind = str(runtime_cfg.get("kind") or "")
+    command = runtime_cfg.get("command")
+    if runtime_kind != "codex-app-server" and isinstance(command, list):
+        return list(command)
+    return None
+
+
+def _materialize_inter_review_agent_prompt(*, worktree: Any, prompt: str) -> Path:
+    out_dir = Path(worktree) / ".daedalus" / "dispatch"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
+    out = out_dir / f"internal-reviewer-{digest}.txt"
+    out.write_text(prompt, encoding="utf-8")
+    return out
+
+
+def _substitute_command_placeholders(argv: list[str], values: dict[str, str]) -> list[str]:
+    resolved = []
+    for arg in argv:
+        text = str(arg)
+        for key, value in values.items():
+            text = text.replace("{" + key + "}", value)
+        resolved.append(text)
+    return resolved
+
+
+def _raw_output_from_runtime_result(result: Any) -> str:
+    if isinstance(result, str):
+        return result.strip()
+    output = getattr(result, "output", None)
+    if output is not None:
+        return str(output).strip()
+    stdout = getattr(result, "stdout", None)
+    if stdout is not None:
+        return str(stdout).strip()
+    return str(result or "").strip()
+
+
+def _parse_inter_review_agent_raw_output(raw_output: str, *, source_label: str) -> dict[str, Any]:
+    try:
+        payload = extract_inter_review_agent_payload(raw_output)
+    except Exception as exc:
+        raise InterReviewAgentError(
+            f"{source_label} returned invalid structured output: {str(exc).strip() or 'unknown parse error'}",
+            failure_class="invalid_structured_output",
+        ) from exc
+    return normalize_inter_review_agent_payload(payload)
+
+
+def _inter_review_agent_prompt_with_output_contract(prompt: str) -> str:
+    return "\n".join(
+        [
+            str(prompt).rstrip(),
+            "",
+            "Output contract for all runtimes:",
+            "Return only one JSON object, no markdown fences, matching this JSON Schema:",
+            inter_review_agent_output_schema_json(),
+            "",
+        ]
+    )
+
+
+def run_inter_review_agent_review_via_runtime(
+    *,
+    issue: dict[str, Any],
+    worktree: Any,
+    lane_memo_path: Any,
+    lane_state_path: Any,
+    head_sha: str,
+    runtime: Any,
+    runtime_cfg: dict[str, Any],
+    agent_cfg: dict[str, Any],
+    session_name: str,
+    render_prompt_fn: Callable[..., str],
+    error_cls: type = subprocess.CalledProcessError,
+) -> dict[str, Any]:
+    """Run the internal review role through its configured runtime profile.
+
+    The workflow owns the prompt and output contract; the runtime only owns
+    execution. This lets the same internal-review stage run through
+    codex-app-server, Hermes Agent, Claude CLI, or any future registered
+    runtime without workflow-specific subprocess wiring.
+    """
+    model = str(agent_cfg.get("model") or "")
+    prompt = _inter_review_agent_prompt_with_output_contract(
+        render_prompt_fn(
+            issue=issue,
+            worktree=worktree,
+            lane_memo_path=lane_memo_path,
+            lane_state_path=lane_state_path,
+            head_sha=head_sha,
+        )
+    )
+    command = _runtime_prompt_command(agent_cfg=agent_cfg, runtime_cfg=runtime_cfg)
+    try:
+        if command is not None:
+            prompt_path = _materialize_inter_review_agent_prompt(
+                worktree=worktree,
+                prompt=prompt,
+            )
+            argv = _substitute_command_placeholders(
+                command,
+                {
+                    "model": model,
+                    "prompt": prompt,
+                    "prompt_path": str(prompt_path),
+                    "worktree": str(worktree),
+                    "session_name": session_name,
+                    "head_sha": str(head_sha or ""),
+                    "issue_number": str((issue or {}).get("number") or ""),
+                },
+            )
+            raw_output = _raw_output_from_runtime_result(
+                runtime.run_command(worktree=Path(worktree), command_argv=argv)
+            )
+        else:
+            ensure_session = getattr(runtime, "ensure_session", None)
+            if callable(ensure_session):
+                ensure_session(
+                    worktree=Path(worktree),
+                    session_name=session_name,
+                    model=model,
+                    resume_session_id=None,
+                )
+            runner = getattr(runtime, "run_prompt_result", None)
+            if callable(runner):
+                result = runner(
+                    worktree=Path(worktree),
+                    session_name=session_name,
+                    prompt=prompt,
+                    model=model,
+                )
+            else:
+                result = runtime.run_prompt(
+                    worktree=Path(worktree),
+                    session_name=session_name,
+                    prompt=prompt,
+                    model=model,
+                )
+            raw_output = _raw_output_from_runtime_result(result)
+    except error_cls as exc:
+        raw_output = (getattr(exc, "stdout", "") or "").strip()
+        if raw_output:
+            try:
+                return _parse_inter_review_agent_raw_output(
+                    raw_output,
+                    source_label="Internal review agent runtime",
+                )
+            except InterReviewAgentError:
+                pass
+        raise InterReviewAgentError(
+            inter_review_agent_failure_message(exc),
+            failure_class=inter_review_agent_failure_class(exc),
+        ) from exc
+    except Exception as exc:
+        result = getattr(exc, "result", None)
+        raw_output = _raw_output_from_runtime_result(result)
+        if raw_output:
+            try:
+                return _parse_inter_review_agent_raw_output(
+                    raw_output,
+                    source_label="Internal review agent runtime",
+                )
+            except InterReviewAgentError:
+                pass
+        raise InterReviewAgentError(
+            inter_review_agent_runtime_failure_message(exc),
+            failure_class=inter_review_agent_runtime_failure_class(exc),
+        ) from exc
+    return _parse_inter_review_agent_raw_output(
+        raw_output,
+        source_label="Internal review agent runtime",
+    )
+
+
 def run_inter_review_agent_review(
     *,
     issue: dict[str, Any],
@@ -1597,19 +1840,7 @@ def run_inter_review_agent_review(
         lane_state_path=lane_state_path,
         head_sha=head_sha,
     )
-    review_schema = json.dumps({
-        "type": "object",
-        "properties": {
-            "verdict": {"type": "string", "enum": ["PASS_CLEAN", "PASS_WITH_FINDINGS", "REWORK"]},
-            "summary": {"type": "string"},
-            "blockingFindings": {"type": "array", "items": {"type": "string"}},
-            "majorConcerns": {"type": "array", "items": {"type": "string"}},
-            "minorSuggestions": {"type": "array", "items": {"type": "string"}},
-            "requiredNextAction": {"type": ["string", "null"]},
-        },
-        "required": ["verdict", "summary", "blockingFindings", "majorConcerns", "minorSuggestions", "requiredNextAction"],
-        "additionalProperties": False,
-    }, separators=(",", ":"))
+    review_schema = inter_review_agent_output_schema_json()
     command = [
         'claude',
         '--model',
@@ -1639,14 +1870,7 @@ def run_inter_review_agent_review(
                     failure_class=inter_review_agent_failure_class(exc),
                 ) from exc
             else:
-                return {
-                    'verdict': payload.get('verdict'),
-                    'summary': payload.get('summary'),
-                    'blockingFindings': list(payload.get('blockingFindings') or []),
-                    'majorConcerns': list(payload.get('majorConcerns') or []),
-                    'minorSuggestions': list(payload.get('minorSuggestions') or []),
-                    'requiredNextAction': payload.get('requiredNextAction'),
-                }
+                return normalize_inter_review_agent_payload(payload)
         raise InterReviewAgentError(
             inter_review_agent_failure_message(exc),
             failure_class=inter_review_agent_failure_class(exc),
@@ -1658,11 +1882,4 @@ def run_inter_review_agent_review(
             f"Internal review agent CLI returned invalid structured output: {str(exc).strip() or 'unknown parse error'}",
             failure_class="invalid_structured_output",
         ) from exc
-    return {
-        'verdict': payload.get('verdict'),
-        'summary': payload.get('summary'),
-        'blockingFindings': list(payload.get('blockingFindings') or []),
-        'majorConcerns': list(payload.get('majorConcerns') or []),
-        'minorSuggestions': list(payload.get('minorSuggestions') or []),
-        'requiredNextAction': payload.get('requiredNextAction'),
-    }
+    return normalize_inter_review_agent_payload(payload)

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -1637,16 +1637,29 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def _run_inter_review_agent_review(*, issue, worktree, lane_memo_path, lane_state_path, head_sha):
         adapter_reviews = ns._load_adapter_reviews_module()
+        agent_cfg = {
+            "name": ns.INTERNAL_REVIEWER_AGENT_NAME,
+            "model": ns.INTER_REVIEW_AGENT_MODEL,
+            "runtime": "claude-cli",
+        }
+        agent_cfg.update(
+            (((getattr(ns, "WORKFLOW_YAML", {}) or {}).get("agents") or {}).get("internal-reviewer") or {})
+        )
+        runtime_name = str(agent_cfg.get("runtime") or "claude-cli")
+        runtime_cfg = dict(((getattr(ns, "RUNTIME_PROFILES", {}) or {}).get(runtime_name) or {}))
+        session_name = f"internal-review-{(issue or {}).get('number') or str(head_sha or '')[:12] or 'lane'}"
         try:
-            return adapter_reviews.run_inter_review_agent_review(
+            return adapter_reviews.run_inter_review_agent_review_via_runtime(
                 issue=issue,
                 worktree=worktree,
                 lane_memo_path=lane_memo_path,
                 lane_state_path=lane_state_path,
                 head_sha=head_sha,
-                run_fn=ns._run,
-                inter_review_agent_model=ns.INTER_REVIEW_AGENT_MODEL,
-                inter_review_agent_max_turns=ns.INTER_REVIEW_AGENT_MAX_TURNS,
+                runtime=ns.runtime(runtime_name),
+                runtime_cfg=runtime_cfg,
+                agent_cfg=agent_cfg,
+                session_name=session_name,
+                render_prompt_fn=ns._render_inter_review_agent_prompt,
                 error_cls=subprocess.CalledProcessError,
             )
         except adapter_reviews.InterReviewAgentError as exc:

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -1,6 +1,8 @@
 import importlib.util
+import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
@@ -13,6 +15,88 @@ def load_module(module_name: str, relative_path: str):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _review_json(**overrides):
+    payload = {
+        "verdict": "PASS_CLEAN",
+        "summary": "looks ready",
+        "blockingFindings": [],
+        "majorConcerns": [],
+        "minorSuggestions": [],
+        "requiredNextAction": None,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def test_run_inter_review_agent_review_via_runtime_uses_command_runtime(tmp_path):
+    reviews_module = load_module("daedalus_workflows_change_delivery_reviews_runtime_command", "workflows/change_delivery/reviews.py")
+    calls = {}
+
+    class FakeRuntime:
+        def run_command(self, *, worktree, command_argv, env=None):
+            calls["worktree"] = worktree
+            calls["argv"] = command_argv
+            return _review_json(verdict="PASS_WITH_FINDINGS", minorSuggestions=["tighten docs"])
+
+    result = reviews_module.run_inter_review_agent_review_via_runtime(
+        issue={"number": 224, "title": "Test"},
+        worktree=tmp_path,
+        lane_memo_path=tmp_path / ".lane-memo.md",
+        lane_state_path=tmp_path / ".lane-state.json",
+        head_sha="abc123",
+        runtime=FakeRuntime(),
+        runtime_cfg={
+            "kind": "hermes-agent",
+            "command": ["hermes", "run", "--model", "{model}", "--prompt", "{prompt_path}", "--issue", "{issue_number}"],
+        },
+        agent_cfg={"name": "Reviewer", "model": "review-model", "runtime": "reviewer-runtime"},
+        session_name="internal-review-224",
+        render_prompt_fn=lambda **kwargs: f"review head {kwargs['head_sha']}",
+    )
+
+    assert result["verdict"] == "PASS_WITH_FINDINGS"
+    assert calls["argv"][:4] == ["hermes", "run", "--model", "review-model"]
+    assert calls["argv"][-1] == "224"
+    prompt_path = Path(calls["argv"][5])
+    assert prompt_path.exists()
+    prompt_text = prompt_path.read_text(encoding="utf-8")
+    assert "review head abc123" in prompt_text
+    assert "Output contract for all runtimes" in prompt_text
+
+
+def test_run_inter_review_agent_review_via_runtime_uses_prompt_runtime(tmp_path):
+    reviews_module = load_module("daedalus_workflows_change_delivery_reviews_runtime_prompt", "workflows/change_delivery/reviews.py")
+    calls = {}
+
+    class FakeRuntime:
+        def ensure_session(self, **kwargs):
+            calls["ensure"] = kwargs
+
+        def run_prompt_result(self, **kwargs):
+            calls["prompt"] = kwargs
+            return SimpleNamespace(output=_review_json(summary="codex reviewed"))
+
+    result = reviews_module.run_inter_review_agent_review_via_runtime(
+        issue={"number": 225, "title": "Test"},
+        worktree=tmp_path,
+        lane_memo_path=None,
+        lane_state_path=None,
+        head_sha="def456",
+        runtime=FakeRuntime(),
+        runtime_cfg={"kind": "codex-app-server", "command": "codex app-server"},
+        agent_cfg={"name": "Reviewer", "model": "gpt-review", "runtime": "codex-runtime"},
+        session_name="internal-review-225",
+        render_prompt_fn=lambda **kwargs: f"review {kwargs['issue']['number']}",
+    )
+
+    assert result["summary"] == "codex reviewed"
+    assert calls["ensure"]["session_name"] == "internal-review-225"
+    assert calls["ensure"]["model"] == "gpt-review"
+    assert calls["prompt"]["session_name"] == "internal-review-225"
+    assert calls["prompt"]["model"] == "gpt-review"
+    assert "Output contract for all runtimes" in calls["prompt"]["prompt"]
 
 
 def test_should_dispatch_claude_repair_handoff_when_local_review_is_actionable_and_routable():

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -556,6 +556,64 @@ def test_workspace_yaml_can_select_codex_app_server_coder_runtime(tmp_path):
     assert hasattr(ws.runtime("coder-runtime"), "run_prompt_result")
 
 
+def test_workspace_internal_review_uses_configured_runtime(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_yaml_config(tmp_path)
+    cfg["workflow-policy"] = "Shared policy from WORKFLOW.md."
+    cfg["runtimes"] = {
+        "coder-runtime": {
+            "kind": "acpx-codex",
+            "session-idle-freshness-seconds": 900,
+            "session-idle-grace-seconds": 1800,
+            "session-nudge-cooldown-seconds": 600,
+        },
+        "reviewer-runtime": {
+            "kind": "hermes-agent",
+            "command": ["reviewer-bin", "--model", "{model}", "--prompt", "{prompt_path}", "--head", "{head_sha}"],
+        },
+    }
+    cfg["agents"]["coder"]["default"]["runtime"] = "coder-runtime"
+    cfg["agents"]["internal-reviewer"]["runtime"] = "reviewer-runtime"
+    cfg["agents"]["internal-reviewer"]["model"] = "review-model"
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+    captured = {}
+
+    class FakeRuntime:
+        def run_command(self, *, worktree, command_argv, env=None):
+            captured["worktree"] = worktree
+            captured["argv"] = command_argv
+            return json.dumps({
+                "verdict": "PASS_CLEAN",
+                "summary": "ready",
+                "blockingFindings": [],
+                "majorConcerns": [],
+                "minorSuggestions": [],
+                "requiredNextAction": None,
+            })
+
+    original_runtime = ws.runtime
+    ws.runtime = lambda name: FakeRuntime() if name == "reviewer-runtime" else original_runtime(name)
+    result = ws._run_inter_review_agent_review(
+        issue={"number": 224, "title": "Test", "url": "https://example.invalid/224"},
+        worktree=worktree,
+        lane_memo_path=None,
+        lane_state_path=None,
+        head_sha="abc123",
+    )
+
+    assert result["verdict"] == "PASS_CLEAN"
+    assert captured["argv"][0] == "reviewer-bin"
+    assert "claude" not in captured["argv"]
+    assert "review-model" in captured["argv"]
+    prompt_path = Path(captured["argv"][4])
+    prompt_text = prompt_path.read_text(encoding="utf-8")
+    assert "Shared policy from WORKFLOW.md." in prompt_text
+    assert "Target local head SHA: abc123" in prompt_text
+
+
 def test_workspace_records_change_delivery_codex_threads_and_totals(tmp_path):
     from workflows.change_delivery.workspace import make_workspace
 


### PR DESCRIPTION
## Summary
- route change-delivery internal review through the configured runtime profile instead of a hard-coded Claude CLI subprocess
- add a generic runtime-backed internal review helper with shared JSON output contract and command/prompt runtime execution paths
- add tests for Hermes-style command runtimes, Codex app-server-style prompt runtimes, and workspace wiring

## Tests
- python -m pytest -q