### PR TITLE
Add shared runtime stage dispatcher

### DIFF
--- a/daedalus/runtimes/stages.py
+++ b/daedalus/runtimes/stages.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from . import PromptRunResult
+
+
+@dataclass(frozen=True)
+class RuntimeStageResult:
+    output: str
+    prompt_path: Path | None
+    command_argv: list[str] | None
+    runtime_result: Any
+    session_handle: Any
+
+    @property
+    def used_command(self) -> bool:
+        return self.command_argv is not None
+
+
+def command_output_result(output: str) -> PromptRunResult:
+    return PromptRunResult(
+        output=output,
+        tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        rate_limits=None,
+    )
+
+
+def prompt_result_from_stage(result: RuntimeStageResult) -> PromptRunResult:
+    runtime_result = result.runtime_result
+    if isinstance(runtime_result, PromptRunResult):
+        return runtime_result
+    if all(hasattr(runtime_result, name) for name in ("output", "tokens", "rate_limits")):
+        return runtime_result
+    return command_output_result(result.output)
+
+
+def raw_output_from_runtime_result(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    output = getattr(result, "output", None)
+    if output is not None:
+        return str(output)
+    stdout = getattr(result, "stdout", None)
+    if stdout is not None:
+        return str(stdout)
+    return str(result or "")
+
+
+def resolve_stage_command(*, agent_cfg: dict[str, Any], runtime_cfg: dict[str, Any]) -> list[str] | None:
+    command = agent_cfg.get("command")
+    if command:
+        return _ensure_argv(command)
+
+    command = runtime_cfg.get("command")
+    if not command:
+        return None
+
+    # For codex-app-server, runtime.command starts/connects the app-server
+    # transport. It is not a per-stage agent command.
+    if str(runtime_cfg.get("kind") or "") == "codex-app-server":
+        return None
+    return _ensure_argv(command)
+
+
+def materialize_prompt(*, worktree: Path, stage_name: str, prompt: str, prompt_path: Path | None = None) -> Path:
+    if prompt_path is None:
+        out_dir = Path(worktree) / ".daedalus" / "dispatch"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
+        prompt_path = out_dir / f"{stage_name}-{digest}.txt"
+    else:
+        prompt_path = Path(prompt_path)
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text(prompt, encoding="utf-8")
+    return prompt_path
+
+
+def substitute_command_placeholders(argv: list[str], values: dict[str, str]) -> list[str]:
+    resolved = []
+    for arg in argv:
+        text = str(arg)
+        for key, value in values.items():
+            text = text.replace("{" + key + "}", value)
+        resolved.append(text)
+    return resolved
+
+
+def run_runtime_stage(
+    *,
+    runtime: Any,
+    runtime_cfg: dict[str, Any],
+    agent_cfg: dict[str, Any],
+    stage_name: str,
+    worktree: Path,
+    session_name: str,
+    prompt: str,
+    prompt_path: Path | None = None,
+    env: dict[str, str] | None = None,
+    placeholders: dict[str, str] | None = None,
+    resume_session_id: str | None = None,
+    cancel_event: Any | None = None,
+    progress_callback: Callable[[Any], None] | None = None,
+    on_session_ready: Callable[[Any], None] | None = None,
+) -> RuntimeStageResult:
+    """Run one workflow stage through a configured runtime profile.
+
+    Workflows own policy, prompts, and state transitions. This helper owns the
+    common runtime boundary: session setup, command overrides, prompt-file
+    materialization, placeholder substitution, cancellation/progress hooks, and
+    a normalized output/result shape.
+    """
+    worktree = Path(worktree)
+    model = str(agent_cfg.get("model") or "")
+    command = resolve_stage_command(agent_cfg=agent_cfg, runtime_cfg=runtime_cfg)
+    set_cancel_event = getattr(runtime, "set_cancel_event", None)
+    set_progress_callback = getattr(runtime, "set_progress_callback", None)
+    if callable(set_cancel_event):
+        set_cancel_event(cancel_event)
+    if callable(set_progress_callback):
+        set_progress_callback(progress_callback)
+
+    session_handle = None
+    try:
+        ensure_session = getattr(runtime, "ensure_session", None)
+        if callable(ensure_session):
+            session_handle = ensure_session(
+                worktree=worktree,
+                session_name=session_name,
+                model=model,
+                resume_session_id=resume_session_id,
+            )
+        if on_session_ready is not None:
+            on_session_ready(session_handle)
+
+        if command is not None:
+            resolved_prompt_path = materialize_prompt(
+                worktree=worktree,
+                stage_name=stage_name,
+                prompt=prompt,
+                prompt_path=prompt_path,
+            )
+            argv = substitute_command_placeholders(
+                command,
+                {
+                    "model": model,
+                    "prompt": prompt,
+                    "prompt_path": str(resolved_prompt_path),
+                    "worktree": str(worktree),
+                    "session_name": session_name,
+                    **(placeholders or {}),
+                },
+            )
+            output = raw_output_from_runtime_result(
+                runtime.run_command(worktree=worktree, command_argv=argv, env=env)
+            )
+            return RuntimeStageResult(
+                output=output,
+                prompt_path=resolved_prompt_path,
+                command_argv=argv,
+                runtime_result=command_output_result(output),
+                session_handle=session_handle,
+            )
+
+        runner = getattr(runtime, "run_prompt_result", None)
+        if callable(runner):
+            runtime_result = runner(
+                worktree=worktree,
+                session_name=session_name,
+                prompt=prompt,
+                model=model,
+            )
+        else:
+            runtime_result = runtime.run_prompt(
+                worktree=worktree,
+                session_name=session_name,
+                prompt=prompt,
+                model=model,
+            )
+        output = raw_output_from_runtime_result(runtime_result)
+        return RuntimeStageResult(
+            output=output,
+            prompt_path=prompt_path,
+            command_argv=None,
+            runtime_result=runtime_result,
+            session_handle=session_handle,
+        )
+    finally:
+        if callable(set_progress_callback):
+            set_progress_callback(None)
+        if callable(set_cancel_event):
+            set_cancel_event(None)
+
+
+def _ensure_argv(command: Any) -> list[str]:
+    if not isinstance(command, list) or not command:
+        raise RuntimeError("agent.command and runtime command must be a non-empty argv list")
+    return [str(part) for part in command]

--- a/daedalus/workflows/change_delivery/dispatch.py
+++ b/daedalus/workflows/change_delivery/dispatch.py
@@ -12,9 +12,15 @@ actually drives what the agent sees.
 """
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 from typing import Any
+
+from runtimes.stages import (
+    materialize_prompt,
+    resolve_stage_command,
+    run_runtime_stage,
+    substitute_command_placeholders,
+)
 
 _BUNDLED_PROMPTS = Path(__file__).parent / "prompts"
 
@@ -131,36 +137,22 @@ def _compose_with_workflow_policy(prompt_text: str, workflow_policy: str | None)
 def _materialize_prompt(*, worktree: Path, role: str, tier: str | None, rendered_text: str) -> Path:
     """Write the already-rendered prompt to a deterministic file under
     <worktree>/.daedalus/dispatch/, return the path."""
-    out_dir = Path(worktree) / ".daedalus" / "dispatch"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    digest = hashlib.sha256(rendered_text.encode("utf-8")).hexdigest()[:12]
-    label = f"{role}-{tier}" if tier else role
-    out = out_dir / f"{label}-{digest}.txt"
-    out.write_text(rendered_text, encoding="utf-8")
-    return out
+    return materialize_prompt(
+        worktree=Path(worktree),
+        stage_name=f"{role}-{tier}" if tier else role,
+        prompt=rendered_text,
+    )
 
 
 def _resolve_command(*, agent_cfg: dict, runtime_cfg: dict) -> list[str] | None:
     """Agent command wins; falls back to runtime profile command; None if neither."""
-    cmd = agent_cfg.get("command")
-    if cmd:
-        return list(cmd)
-    cmd = runtime_cfg.get("command")
-    if cmd:
-        return list(cmd)
-    return None
+    return resolve_stage_command(agent_cfg=agent_cfg, runtime_cfg=runtime_cfg)
 
 
 def _substitute(argv: list[str], values: dict[str, str]) -> list[str]:
     """Replace {key} placeholders in each argv element. Unknown placeholders
     pass through unchanged so adapters can interpret them."""
-    out = []
-    for a in argv:
-        s = a
-        for k, v in values.items():
-            s = s.replace("{" + k + "}", v)
-        out.append(s)
-    return out
+    return substitute_command_placeholders(argv, values)
 
 
 def dispatch_agent(
@@ -194,7 +186,6 @@ def dispatch_agent(
     runtime = workspace.runtime(runtime_name)
     runtimes_cfg = (workspace.config or {}).get("runtimes") or {}
     runtime_cfg = runtimes_cfg.get(runtime_name) or {}
-    model = cfg.get("model") or ""
 
     # Resolve + load + render the template (the dispatcher, not the caller,
     # owns this so workspace/agent overrides actually take effect).
@@ -214,28 +205,18 @@ def dispatch_agent(
     )
     rendered_text = template_text.format(**(prompt_kwargs or {}))
 
-    command = _resolve_command(agent_cfg=cfg, runtime_cfg=runtime_cfg)
-
-    if command is None:
-        # Legacy path: runtime owns the invocation.
-        return runtime.run_prompt(
-            worktree=worktree,
-            session_name=session_name,
-            prompt=rendered_text,
-            model=model,
-        )
-
-    prompt_path = _materialize_prompt(
-        worktree=worktree, role=role, tier=tier, rendered_text=rendered_text,
-    )
-    placeholders = {
-        "model": model,
-        "prompt_path": str(prompt_path),
-        "worktree": str(worktree),
-        "session_name": session_name,
-    }
+    placeholders = {}
     if extra_placeholders:
         placeholders.update(extra_placeholders)
 
-    argv = _substitute(command, placeholders)
-    return runtime.run_command(worktree=worktree, command_argv=argv)
+    result = run_runtime_stage(
+        runtime=runtime,
+        runtime_cfg=runtime_cfg,
+        agent_cfg=cfg,
+        stage_name=f"{role}-{tier}" if tier else role,
+        worktree=Path(worktree),
+        session_name=session_name,
+        prompt=rendered_text,
+        placeholders=placeholders,
+    )
+    return result.output

--- a/daedalus/workflows/change_delivery/reviews.py
+++ b/daedalus/workflows/change_delivery/reviews.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 import subprocess
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Callable
 
+from runtimes.stages import raw_output_from_runtime_result, run_runtime_stage
 from workflows.change_delivery.migrations import get_lane_state_review_field, get_review
 
 
@@ -1633,48 +1632,6 @@ def audit_inter_review_agent_transition(
         )
 
 
-def _runtime_prompt_command(*, agent_cfg: dict[str, Any], runtime_cfg: dict[str, Any]) -> list[str] | None:
-    command = agent_cfg.get("command")
-    if command:
-        return list(command)
-    runtime_kind = str(runtime_cfg.get("kind") or "")
-    command = runtime_cfg.get("command")
-    if runtime_kind != "codex-app-server" and isinstance(command, list):
-        return list(command)
-    return None
-
-
-def _materialize_inter_review_agent_prompt(*, worktree: Any, prompt: str) -> Path:
-    out_dir = Path(worktree) / ".daedalus" / "dispatch"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
-    out = out_dir / f"internal-reviewer-{digest}.txt"
-    out.write_text(prompt, encoding="utf-8")
-    return out
-
-
-def _substitute_command_placeholders(argv: list[str], values: dict[str, str]) -> list[str]:
-    resolved = []
-    for arg in argv:
-        text = str(arg)
-        for key, value in values.items():
-            text = text.replace("{" + key + "}", value)
-        resolved.append(text)
-    return resolved
-
-
-def _raw_output_from_runtime_result(result: Any) -> str:
-    if isinstance(result, str):
-        return result.strip()
-    output = getattr(result, "output", None)
-    if output is not None:
-        return str(output).strip()
-    stdout = getattr(result, "stdout", None)
-    if stdout is not None:
-        return str(stdout).strip()
-    return str(result or "").strip()
-
-
 def _parse_inter_review_agent_raw_output(raw_output: str, *, source_label: str) -> dict[str, Any]:
     try:
         payload = extract_inter_review_agent_payload(raw_output)
@@ -1720,7 +1677,6 @@ def run_inter_review_agent_review_via_runtime(
     codex-app-server, Hermes Agent, Claude CLI, or any future registered
     runtime without workflow-specific subprocess wiring.
     """
-    model = str(agent_cfg.get("model") or "")
     prompt = _inter_review_agent_prompt_with_output_contract(
         render_prompt_fn(
             issue=issue,
@@ -1730,53 +1686,22 @@ def run_inter_review_agent_review_via_runtime(
             head_sha=head_sha,
         )
     )
-    command = _runtime_prompt_command(agent_cfg=agent_cfg, runtime_cfg=runtime_cfg)
     try:
-        if command is not None:
-            prompt_path = _materialize_inter_review_agent_prompt(
-                worktree=worktree,
-                prompt=prompt,
-            )
-            argv = _substitute_command_placeholders(
-                command,
-                {
-                    "model": model,
-                    "prompt": prompt,
-                    "prompt_path": str(prompt_path),
-                    "worktree": str(worktree),
-                    "session_name": session_name,
-                    "head_sha": str(head_sha or ""),
-                    "issue_number": str((issue or {}).get("number") or ""),
-                },
-            )
-            raw_output = _raw_output_from_runtime_result(
-                runtime.run_command(worktree=Path(worktree), command_argv=argv)
-            )
-        else:
-            ensure_session = getattr(runtime, "ensure_session", None)
-            if callable(ensure_session):
-                ensure_session(
-                    worktree=Path(worktree),
-                    session_name=session_name,
-                    model=model,
-                    resume_session_id=None,
-                )
-            runner = getattr(runtime, "run_prompt_result", None)
-            if callable(runner):
-                result = runner(
-                    worktree=Path(worktree),
-                    session_name=session_name,
-                    prompt=prompt,
-                    model=model,
-                )
-            else:
-                result = runtime.run_prompt(
-                    worktree=Path(worktree),
-                    session_name=session_name,
-                    prompt=prompt,
-                    model=model,
-                )
-            raw_output = _raw_output_from_runtime_result(result)
+        result = run_runtime_stage(
+            runtime=runtime,
+            runtime_cfg=runtime_cfg,
+            agent_cfg=agent_cfg,
+            stage_name="internal-reviewer",
+            worktree=worktree,
+            session_name=session_name,
+            prompt=prompt,
+            placeholders={
+                "head_sha": str(head_sha or ""),
+                "issue_number": str((issue or {}).get("number") or ""),
+                "issue_url": str((issue or {}).get("url") or ""),
+            },
+        )
+        raw_output = result.output.strip()
     except error_cls as exc:
         raw_output = (getattr(exc, "stdout", "") or "").strip()
         if raw_output:
@@ -1793,7 +1718,7 @@ def run_inter_review_agent_review_via_runtime(
         ) from exc
     except Exception as exc:
         result = getattr(exc, "result", None)
-        raw_output = _raw_output_from_runtime_result(result)
+        raw_output = raw_output_from_runtime_result(result).strip()
         if raw_output:
             try:
                 return _parse_inter_review_agent_raw_output(

--- a/daedalus/workflows/change_delivery/runtimes/stages.py
+++ b/daedalus/workflows/change_delivery/runtimes/stages.py
@@ -1,0 +1,1 @@
+from runtimes.stages import *  # noqa: F401,F403

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -67,15 +67,14 @@ codex:
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
 
-daedalus:
-  runtimes:
-    default:
-      kind: hermes-agent
-      command:
-        - python3
-        - -c
-        - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
-        - "{prompt_path}"
+runtimes:
+  default:
+    kind: hermes-agent
+    command:
+      - python3
+      - -c
+      - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
+      - "{prompt_path}"
 
 storage:
   status: memory/workflow-status.json

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -36,6 +36,7 @@ from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
 from engine.work_items import work_item_from_issue
 from runtimes import PromptRunResult, Runtime, build_runtimes
+from runtimes.stages import prompt_result_from_stage, run_runtime_stage
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
 from workflows.shared.paths import runtime_paths
@@ -972,7 +973,6 @@ class IssueRunnerWorkspace(WorkflowDriver):
         env: dict[str, str] | None = None
         created_workspace = False
         attempt = self._issue_attempt(issue=issue, retry_entry=retry_entry)
-        set_cancel_event_fn = None
 
         try:
             if cancel_event is not None and cancel_event.is_set():
@@ -1021,58 +1021,43 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 runtime = self.runtime(runtime_name)
             else:
                 runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
-            set_cancel_event_fn = getattr(runtime, "set_cancel_event", None)
-            if callable(set_cancel_event_fn) and cancel_event is not None:
-                set_cancel_event_fn(cancel_event)
             session_name = issue_session_name(issue)
-            model = str(agent_cfg.get("model") or "")
             resume_thread_id = None
             if str(runtime_cfg.get("kind") or "").strip() == "codex-app-server":
                 resume_thread_id = self._codex_thread_for_issue(issue)
-            runtime.ensure_session(
+            stage_result = run_runtime_stage(
+                runtime=runtime,
+                runtime_cfg=runtime_cfg,
+                agent_cfg=agent_cfg,
+                stage_name="issue-runner",
                 worktree=issue_workspace,
                 session_name=session_name,
-                model=model,
+                prompt=prompt,
+                prompt_path=prompt_path,
+                env=env,
                 resume_session_id=resume_thread_id,
-            )
-            self._publish_tracker_feedback(
-                issue=issue,
-                event="issue.running",
-                summary="Started the configured runtime for this issue.",
-                run_id=run_id,
-                metadata={
-                    "attempt": attempt,
-                    "runtime": runtime_name,
-                    "runtime_kind": runtime_cfg.get("kind"),
-                    "workspace": str(issue_workspace),
+                cancel_event=cancel_event,
+                placeholders={
+                    "issue_id": str(issue.get("id") or ""),
+                    "issue_identifier": str(issue.get("identifier") or ""),
+                    "issue_title": str(issue.get("title") or ""),
+                    "workflow_root": str(self.path),
                 },
-            )
-
-            command = agent_cfg.get("command")
-            if command is None:
-                runtime_command = runtime_cfg.get("command")
-                if isinstance(runtime_command, list):
-                    command = runtime_command
-            if command:
-                argv = self._render_command(
-                    command=command,
-                    worktree=issue_workspace,
-                    model=model,
-                    session_name=session_name,
-                    prompt_path=prompt_path,
+                on_session_ready=lambda _handle: self._publish_tracker_feedback(
                     issue=issue,
-                )
-                output = runtime.run_command(worktree=issue_workspace, command_argv=argv, env=env)
-                run_result = self._runtime_result_from_command_output(output)
-            else:
-                run_result = self._run_runtime_prompt(
-                    runtime=runtime,
-                    worktree=issue_workspace,
-                    session_name=session_name,
-                    prompt=prompt,
-                    model=model,
-                )
-                output = run_result.output
+                    event="issue.running",
+                    summary="Started the configured runtime for this issue.",
+                    run_id=run_id,
+                    metadata={
+                        "attempt": attempt,
+                        "runtime": runtime_name,
+                        "runtime_kind": runtime_cfg.get("kind"),
+                        "workspace": str(issue_workspace),
+                    },
+                ),
+            )
+            run_result = prompt_result_from_stage(stage_result)
+            output = stage_result.output
             output_path.write_text(output, encoding="utf-8")
             hook_results.append(self._run_hook("after_run", issue_workspace, env))
             return {
@@ -1105,10 +1090,6 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 "runtime": runtime_name if runtime is not None else None,
                 "runtimeKind": runtime_cfg.get("kind") if runtime is not None else None,
             }
-        finally:
-            if callable(set_cancel_event_fn):
-                set_cancel_event_fn(None)
-
     def _apply_issue_results(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         applied: list[dict[str, Any]] = []
         for result in results:
@@ -1884,62 +1865,6 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "ran": True,
             "returncode": getattr(completed, "returncode", 0),
         }
-
-    def _render_command(
-        self,
-        *,
-        command: Any,
-        worktree: Path,
-        model: str,
-        session_name: str,
-        prompt_path: Path,
-        issue: dict[str, Any],
-    ) -> list[str]:
-        if not isinstance(command, list) or not command:
-            raise RuntimeError("agent.command and runtime command must be a non-empty argv list")
-        fmt = {
-            "worktree": str(worktree),
-            "model": model,
-            "session_name": session_name,
-            "prompt_path": str(prompt_path),
-            "issue_id": str(issue.get("id") or ""),
-            "issue_identifier": str(issue.get("identifier") or ""),
-            "issue_title": str(issue.get("title") or ""),
-            "workflow_root": str(self.path),
-        }
-        return [str(part).format(**fmt) for part in command]
-
-    def _run_runtime_prompt(
-        self,
-        *,
-        runtime: Runtime,
-        worktree: Path,
-        session_name: str,
-        prompt: str,
-        model: str,
-    ) -> PromptRunResult:
-        runner = getattr(runtime, "run_prompt_result", None)
-        if callable(runner):
-            return runner(
-                worktree=worktree,
-                session_name=session_name,
-                prompt=prompt,
-                model=model,
-            )
-        output = runtime.run_prompt(
-            worktree=worktree,
-            session_name=session_name,
-            prompt=prompt,
-            model=model,
-        )
-        return self._runtime_result_from_command_output(output)
-
-    def _runtime_result_from_command_output(self, output: str) -> PromptRunResult:
-        return PromptRunResult(
-            output=output,
-            tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-            rate_limits=None,
-        )
 
     def _metrics_payload(self, result: PromptRunResult) -> dict[str, Any]:
         return {

--- a/daedalus/workflows/shared/runtimes/stages.py
+++ b/daedalus/workflows/shared/runtimes/stages.py
@@ -1,0 +1,1 @@
+from runtimes.stages import *  # noqa: F401,F403

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -22,6 +22,29 @@ class Runtime(Protocol):
 
 `last_activity_ts()` is the Symphony §8.5 hook that lets [stall detection](stalls.md) work. Runtimes without it are skipped by the reconciler — they opt out silently.
 
+## Runtime Stages
+
+Workflow code does not invoke runtime adapters directly. It runs named stages
+through `daedalus/runtimes/stages.py`. The shared stage dispatcher owns the
+execution boundary:
+
+- receives the workflow-selected runtime profile and agent config
+- ensures/resumes the runtime session before dispatch
+- chooses `agent.command` or runtime `command` for command-backed runtimes
+- renders `{prompt_path}`, `{worktree}`, `{session_name}`, `{model}`, and workflow-specific placeholders
+- calls `run_prompt_result()` / `run_prompt()` for prompt-native runtimes
+- wires cancellation/progress callbacks when the runtime supports them
+- normalizes command output into a `PromptRunResult`-shaped metrics source
+
+The workflow still owns state, prompts, gates, and tracker/code-host effects.
+This is what lets `issue-runner`, `change-delivery`, and future workflows bind
+Codex app-server or Hermes Agent to any runtime-backed stage without hard-coded
+runtime names in the workflow logic.
+
+Important: for `codex-app-server`, `runtime.command` starts or connects the
+app-server transport. It is not treated as a per-stage command. Use
+`agent.command` only when a role should run a command-backed adapter.
+
 ## Adapter shape comparison
 
 || | `claude-cli` | `acpx-codex` | `hermes-agent` | `codex-app-server` |
@@ -66,7 +89,7 @@ The `hermes-agent` runtime delegates turns to a local Hermes agent process. It i
 runtimes:
   my-agent-runtime:
     kind: hermes-agent
-    command: ["python3", "-m", "my_agent", "--workflow-root", "{{workflow_root}}"]
+    command: ["python3", "-m", "my_agent", "--workflow-root", "{workflow_root}"]
     timeout-seconds: 1200
 ```
 
@@ -188,6 +211,7 @@ surfaces without changing the shared runtime protocol.
 ## Where this lives in code
 
 - Protocol: `daedalus/runtimes/__init__.py`
+- Stage dispatcher: `daedalus/runtimes/stages.py`
 - Adapters: `daedalus/runtimes/{claude_cli,acpx_codex,hermes_agent,codex_app_server}.py`
 - Workflow compatibility shims: `daedalus/workflows/change_delivery/runtimes/`
 - Preflight: `daedalus/workflows/change_delivery/preflight.py`

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -67,15 +67,14 @@ codex:
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
 
-daedalus:
-  runtimes:
-    default:
-      kind: hermes-agent
-      command:
-        - python3
-        - -c
-        - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
-        - "{prompt_path}"
+runtimes:
+  default:
+    kind: hermes-agent
+    command:
+      - python3
+      - -c
+      - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
+      - "{prompt_path}"
 
 storage:
   status: memory/workflow-status.json

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -45,15 +45,20 @@ of the default generic `issue-runner` workflow.
 `change-delivery` composes shared `runtimes/`, `trackers/`, and `code_hosts/`
 backends with workflow-specific prompts, reviewers, and merge policy.
 
+Runtime-backed stages are dispatched through the same shared stage boundary used
+by `issue-runner`. The coder tiers and internal reviewer each select a runtime
+with `agents.*.runtime`; the workflow owns prompts and gates, while the runtime
+profile owns execution.
+
 ## Codex Runtime Options
 
-The default template uses `acpx-codex` for the coder role. To run the coder
-through Codex app-server instead, change only `runtimes` and
-`agents.coder.*.runtime` in `WORKFLOW.md`:
+The default template uses `acpx-codex` for the coder role and `claude-cli` for
+internal review. To run either role through Codex app-server instead, change
+only `runtimes` and the matching `agents.*.runtime` binding in `WORKFLOW.md`:
 
 ```yaml
 runtimes:
-  coder-runtime:
+  codex-runtime:
     kind: codex-app-server
     mode: external
     endpoint: ws://127.0.0.1:4500
@@ -68,7 +73,11 @@ agents:
     default:
       name: Internal_Coder_Agent
       model: gpt-5.5
-      runtime: coder-runtime
+      runtime: codex-runtime
+  internal-reviewer:
+    name: Internal_Reviewer_Agent
+    model: gpt-5.5
+    runtime: codex-runtime
 ```
 
 When `codex-app-server` is selected, Daedalus stores

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -38,7 +38,12 @@ For each eligible tracker issue:
 - `hooks`: `after_create`, `before_run`, `after_run`, `before_remove`
 - `agent`: model/runtime plus scheduler-facing limits
 - `codex`: spec-shaped Codex runner settings; set `mode: external` and `endpoint: ws://127.0.0.1:<port>` to connect to an already-running app-server, and keep `ephemeral: false` if you want Codex threads to remain inspectable
-- `daedalus.runtimes`: shared runtime backend profiles used by the current implementation when you are not using the top-level `codex` block
+- `runtimes`: shared runtime backend profiles; `agent.runtime` selects one profile for the issue execution stage
+
+The issue execution stage uses the shared runtime stage dispatcher. Command
+runtimes such as `hermes-agent` receive a rendered `{prompt_path}`. Prompt-native
+runtimes such as `codex-app-server` receive the prompt through `run_prompt_result`
+and can persist thread/token metrics.
 
 External Codex app-server example:
 

--- a/tests/test_runtime_stage_dispatcher.py
+++ b/tests/test_runtime_stage_dispatcher.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+
+def test_runtime_stage_runs_command_runtime_with_prompt_file_and_callbacks(tmp_path):
+    from runtimes import PromptRunResult, SessionHandle
+    from runtimes.stages import prompt_result_from_stage, run_runtime_stage
+
+    calls = {}
+
+    class FakeRuntime:
+        def set_cancel_event(self, event):
+            calls.setdefault("cancel_events", []).append(event)
+
+        def set_progress_callback(self, callback):
+            calls.setdefault("progress_callbacks", []).append(callback)
+
+        def ensure_session(self, **kwargs):
+            calls["ensure"] = kwargs
+            return SessionHandle(record_id="rec-1", session_id="sess-1", name=kwargs["session_name"])
+
+        def run_command(self, *, worktree, command_argv, env=None):
+            calls["command"] = command_argv
+            calls["env"] = env
+            return "command output"
+
+    cancel_event = threading.Event()
+    session_handles = []
+    result = run_runtime_stage(
+        runtime=FakeRuntime(),
+        runtime_cfg={
+            "kind": "hermes-agent",
+            "command": ["agent", "--model", "{model}", "--prompt", "{prompt_path}", "--issue", "{issue_id}"],
+        },
+        agent_cfg={"model": "gpt-test", "runtime": "hermes"},
+        stage_name="issue-runner",
+        worktree=tmp_path,
+        session_name="issue-1",
+        prompt="do the work",
+        env={"A": "B"},
+        placeholders={"issue_id": "ISSUE-1"},
+        cancel_event=cancel_event,
+        progress_callback=lambda _result: None,
+        on_session_ready=session_handles.append,
+    )
+
+    assert result.output == "command output"
+    assert result.used_command is True
+    assert calls["ensure"]["model"] == "gpt-test"
+    assert calls["cancel_events"][0] is cancel_event
+    assert calls["cancel_events"][-1] is None
+    assert callable(calls["progress_callbacks"][0])
+    assert calls["progress_callbacks"][-1] is None
+    assert calls["env"] == {"A": "B"}
+    assert calls["command"][:3] == ["agent", "--model", "gpt-test"]
+    assert calls["command"][-1] == "ISSUE-1"
+    assert result.prompt_path is not None
+    assert result.prompt_path.read_text(encoding="utf-8") == "do the work"
+    assert session_handles[0].session_id == "sess-1"
+    metrics_source = prompt_result_from_stage(result)
+    assert isinstance(metrics_source, PromptRunResult)
+    assert metrics_source.tokens == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def test_runtime_stage_runs_prompt_runtime_and_ignores_codex_transport_command(tmp_path):
+    from runtimes.stages import prompt_result_from_stage, run_runtime_stage
+
+    calls = {}
+
+    class FakeCodexRuntime:
+        def ensure_session(self, **kwargs):
+            calls["ensure"] = kwargs
+
+        def run_prompt_result(self, **kwargs):
+            calls["prompt"] = kwargs
+            return SimpleNamespace(
+                output="prompt output",
+                session_id="thread-1",
+                thread_id="thread-1",
+                turn_id="turn-1",
+                last_event="turn/completed",
+                last_message="done",
+                turn_count=1,
+                tokens={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                rate_limits={"requests_remaining": 99},
+            )
+
+        def run_command(self, **kwargs):
+            raise AssertionError("codex app-server transport command must not be treated as stage command")
+
+    result = run_runtime_stage(
+        runtime=FakeCodexRuntime(),
+        runtime_cfg={"kind": "codex-app-server", "command": ["codex", "app-server"]},
+        agent_cfg={"model": "gpt-test", "runtime": "codex"},
+        stage_name="coder",
+        worktree=tmp_path,
+        session_name="lane-1",
+        prompt="continue",
+        resume_session_id="thread-previous",
+    )
+
+    assert result.output == "prompt output"
+    assert result.used_command is False
+    assert calls["ensure"]["resume_session_id"] == "thread-previous"
+    assert calls["prompt"]["prompt"] == "continue"
+    metrics_source = prompt_result_from_stage(result)
+    assert metrics_source.thread_id == "thread-1"
+    assert metrics_source.tokens["total_tokens"] == 3


### PR DESCRIPTION
## Summary
- add a shared runtime stage dispatcher for session setup, command/prompt execution, prompt materialization, placeholders, cancellation/progress hooks, and command-output metrics normalization
- rewire change-delivery generic dispatch, change-delivery internal review, and issue-runner execution through the shared stage boundary
- move issue-runner public template/example to top-level runtimes and document the stage/runtime split

## Tests
- python -m pytest -q
- python -m pytest tests/test_runtime_stage_dispatcher.py tests/test_workflows_issue_runner_workspace.py::test_issue_runner_tick_uses_codex_app_server_and_persists_metrics tests/test_workflows_code_review_reviews.py::test_run_inter_review_agent_review_via_runtime_uses_prompt_runtime -q