### PR TITLE
Add structured Hermes runtime support

### DIFF
--- a/daedalus/runtimes/hermes_agent.py
+++ b/daedalus/runtimes/hermes_agent.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
-from . import SessionHandle, SessionHealth, register
+from . import PromptRunResult, SessionHandle, SessionHealth, register
 
 
 @register("hermes-agent")
@@ -12,6 +13,8 @@ class HermesAgentRuntime:
         self._cfg = cfg
         self._run = run
         self._last_activity: float | None = None
+        self._last_result: PromptRunResult | None = None
+        self._resume_session_ids: dict[str, str | None] = {}
 
     def _record_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -27,7 +30,8 @@ class HermesAgentRuntime:
         model: str,
         resume_session_id: str | None = None,
     ) -> SessionHandle:
-        return SessionHandle(record_id=None, session_id=None, name=session_name)
+        self._resume_session_ids[session_name] = resume_session_id
+        return SessionHandle(record_id=None, session_id=resume_session_id, name=session_name)
 
     def run_prompt(
         self,
@@ -37,10 +41,43 @@ class HermesAgentRuntime:
         prompt: str,
         model: str,
     ) -> str:
-        raise RuntimeError(
-            "hermes-agent runtime requires a `command:` override on the runtime "
-            "profile or agent role; no built-in invocation is provided."
+        return self.run_prompt_result(
+            worktree=worktree,
+            session_name=session_name,
+            prompt=prompt,
+            model=model,
+        ).output
+
+    def run_prompt_result(
+        self,
+        *,
+        worktree: Path,
+        session_name: str,
+        prompt: str,
+        model: str,
+    ) -> PromptRunResult:
+        command = self._prompt_command(session_name=session_name, prompt=prompt, model=model)
+        self._record_activity()
+        completed = self._run(
+            command,
+            cwd=worktree,
+            timeout=self._timeout(),
+            env=self._env(model=model, session_name=session_name),
         )
+        self._record_activity()
+        output = getattr(completed, "stdout", "") or ""
+        result = PromptRunResult(
+            output=output,
+            session_id=self._resume_session_ids.get(session_name),
+            thread_id=self._resume_session_ids.get(session_name),
+            last_event="turn/completed",
+            last_message=(output.strip().splitlines()[-1] if output.strip() else None),
+            turn_count=1,
+            tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            rate_limits=None,
+        )
+        self._last_result = result
+        return result
 
     def assess_health(
         self,
@@ -54,6 +91,9 @@ class HermesAgentRuntime:
     def close_session(self, *, worktree: Path, session_name: str) -> None:
         return None
 
+    def last_result(self) -> PromptRunResult | None:
+        return self._last_result
+
     def run_command(
         self,
         *,
@@ -62,6 +102,88 @@ class HermesAgentRuntime:
         env: dict | None = None,
     ) -> str:
         self._record_activity()
-        completed = self._run(command_argv, cwd=worktree, env=env)
+        completed = self._run(command_argv, cwd=worktree, timeout=self._timeout(), env=env)
         self._record_activity()
         return getattr(completed, "stdout", "") or ""
+
+    def _prompt_command(self, *, session_name: str, prompt: str, model: str) -> list[str]:
+        mode = str(self._cfg.get("mode") or "final").strip().lower()
+        if mode not in {"final", "chat"}:
+            raise RuntimeError("hermes-agent mode must be 'final' or 'chat'")
+        executable = str(self._cfg.get("executable") or "hermes")
+        command = [executable]
+        profile = self._cfg.get("profile")
+        if profile:
+            command.extend(["--profile", str(profile)])
+        if self._bool_cfg("yolo"):
+            command.append("--yolo")
+        if self._bool_cfg("pass-session-id"):
+            command.append("--pass-session-id")
+        if self._bool_cfg("ignore-user-config"):
+            command.append("--ignore-user-config")
+        if self._bool_cfg("ignore-rules"):
+            command.append("--ignore-rules")
+
+        if mode == "final":
+            command.extend(["-z", prompt])
+            self._append_common_overrides(command, model=model, include_chat_only=False)
+            return command
+
+        command.extend(["chat", "--quiet"])
+        resume_session_id = self._resume_session_ids.get(session_name)
+        if resume_session_id:
+            command.extend(["--resume", str(resume_session_id)])
+        elif self._cfg.get("continue"):
+            continue_value = self._cfg.get("continue")
+            command.append("--continue")
+            if not isinstance(continue_value, bool):
+                command.append(str(continue_value))
+        self._append_common_overrides(command, model=model, include_chat_only=True)
+        command.extend(["-q", prompt])
+        return command
+
+    def _append_common_overrides(self, command: list[str], *, model: str, include_chat_only: bool) -> None:
+        provider = self._cfg.get("provider")
+        if provider:
+            command.extend(["--provider", str(provider)])
+        if model:
+            command.extend(["--model", str(model)])
+        if not include_chat_only:
+            command.extend(str(arg) for arg in self._cfg.get("extra-args") or self._cfg.get("extra_args") or [])
+            return
+        source = self._cfg.get("source", "daedalus")
+        if source:
+            command.extend(["--source", str(source)])
+        max_turns = self._cfg.get("max-turns", self._cfg.get("max_turns"))
+        if max_turns is not None:
+            command.extend(["--max-turns", str(max_turns)])
+        toolsets = self._cfg.get("toolsets")
+        if isinstance(toolsets, list):
+            toolsets = ",".join(str(item) for item in toolsets)
+        if toolsets:
+            command.extend(["--toolsets", str(toolsets)])
+        skills = self._cfg.get("skills") or []
+        if isinstance(skills, str):
+            skills = [skills]
+        for skill in skills:
+            command.extend(["--skills", str(skill)])
+        command.extend(str(arg) for arg in self._cfg.get("extra-args") or self._cfg.get("extra_args") or [])
+
+    def _env(self, *, model: str, session_name: str) -> dict[str, str]:
+        env = {
+            "DAEDALUS_RUNTIME_KIND": "hermes-agent",
+            "DAEDALUS_SESSION_NAME": session_name,
+        }
+        if model:
+            env["DAEDALUS_MODEL"] = model
+        return env
+
+    def _timeout(self) -> int | None:
+        value = self._cfg.get("timeout-seconds", self._cfg.get("timeout_seconds"))
+        if value is None:
+            return None
+        return int(value)
+
+    def _bool_cfg(self, key: str) -> bool:
+        value: Any = self._cfg.get(key, self._cfg.get(key.replace("-", "_")))
+        return bool(value)

--- a/daedalus/runtimes/stages.py
+++ b/daedalus/runtimes/stages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -15,6 +16,7 @@ class RuntimeStageResult:
     command_argv: list[str] | None
     runtime_result: Any
     session_handle: Any
+    result_path: Path | None = None
 
     @property
     def used_command(self) -> bool:
@@ -27,6 +29,45 @@ def command_output_result(output: str) -> PromptRunResult:
         tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         rate_limits=None,
     )
+
+
+def prompt_result_from_payload(payload: dict[str, Any], *, fallback_output: str = "") -> PromptRunResult:
+    metrics = payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {}
+    output = payload.get("output")
+    if output is None:
+        output = payload.get("text")
+    if output is None:
+        output = fallback_output
+    tokens = payload.get("tokens")
+    if tokens is None:
+        tokens = payload.get("token_usage") or metrics.get("tokens")
+    rate_limits = payload.get("rate_limits")
+    if rate_limits is None:
+        rate_limits = metrics.get("rate_limits")
+    turn_count = payload.get("turn_count")
+    if turn_count is None:
+        turn_count = metrics.get("turn_count") or 0
+    return PromptRunResult(
+        output=str(output or ""),
+        session_id=_first_str(payload, metrics, "session_id", "sessionId"),
+        thread_id=_first_str(payload, metrics, "thread_id", "threadId"),
+        turn_id=_first_str(payload, metrics, "turn_id", "turnId"),
+        last_event=_first_str(payload, metrics, "last_event", "lastEvent"),
+        last_message=_first_str(payload, metrics, "last_message", "lastMessage"),
+        turn_count=int(turn_count or 0),
+        tokens=tokens if isinstance(tokens, dict) else None,
+        rate_limits=rate_limits if isinstance(rate_limits, dict) else None,
+    )
+
+
+def load_structured_result(path: Path, *, fallback_output: str = "") -> PromptRunResult | None:
+    path = Path(path)
+    if not path.exists() or path.stat().st_size <= 0:
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"structured runtime result must be a JSON object: {path}")
+    return prompt_result_from_payload(payload, fallback_output=fallback_output)
 
 
 def prompt_result_from_stage(result: RuntimeStageResult) -> PromptRunResult:
@@ -77,6 +118,15 @@ def materialize_prompt(*, worktree: Path, stage_name: str, prompt: str, prompt_p
         prompt_path.parent.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt, encoding="utf-8")
     return prompt_path
+
+
+def runtime_result_path(*, worktree: Path, stage_name: str, prompt: str, prompt_path: Path | None = None) -> Path:
+    if prompt_path is not None:
+        return Path(prompt_path).with_suffix(".result.json")
+    out_dir = Path(worktree) / ".daedalus" / "dispatch"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
+    return out_dir / f"{stage_name}-{digest}.result.json"
 
 
 def substitute_command_placeholders(argv: list[str], values: dict[str, str]) -> list[str]:
@@ -143,26 +193,46 @@ def run_runtime_stage(
                 prompt=prompt,
                 prompt_path=prompt_path,
             )
+            resolved_result_path = runtime_result_path(
+                worktree=worktree,
+                stage_name=stage_name,
+                prompt=prompt,
+                prompt_path=resolved_prompt_path,
+            )
+            if resolved_result_path.exists():
+                resolved_result_path.unlink()
             argv = substitute_command_placeholders(
                 command,
                 {
                     "model": model,
                     "prompt": prompt,
                     "prompt_path": str(resolved_prompt_path),
+                    "result_path": str(resolved_result_path),
                     "worktree": str(worktree),
                     "session_name": session_name,
                     **(placeholders or {}),
                 },
             )
+            stage_env = dict(env or {})
+            stage_env.setdefault("DAEDALUS_PROMPT_PATH", str(resolved_prompt_path))
+            stage_env.setdefault("DAEDALUS_RESULT_PATH", str(resolved_result_path))
+            stage_env.setdefault("DAEDALUS_WORKTREE", str(worktree))
+            stage_env.setdefault("DAEDALUS_SESSION_NAME", session_name)
+            stage_env.setdefault("DAEDALUS_MODEL", model)
             output = raw_output_from_runtime_result(
-                runtime.run_command(worktree=worktree, command_argv=argv, env=env)
+                runtime.run_command(worktree=worktree, command_argv=argv, env=stage_env)
+            )
+            runtime_result = (
+                load_structured_result(resolved_result_path, fallback_output=output)
+                or command_output_result(output)
             )
             return RuntimeStageResult(
-                output=output,
+                output=runtime_result.output,
                 prompt_path=resolved_prompt_path,
                 command_argv=argv,
-                runtime_result=command_output_result(output),
+                runtime_result=runtime_result,
                 session_handle=session_handle,
+                result_path=resolved_result_path,
             )
 
         runner = getattr(runtime, "run_prompt_result", None)
@@ -199,3 +269,13 @@ def _ensure_argv(command: Any) -> list[str]:
     if not isinstance(command, list) or not command:
         raise RuntimeError("agent.command and runtime command must be a non-empty argv list")
     return [str(part) for part in command]
+
+
+def _first_str(primary: dict[str, Any], secondary: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = primary.get(key)
+        if value is None:
+            value = secondary.get(key)
+        if value is not None:
+            return str(value)
+    return None

--- a/daedalus/skills/operator/SKILL.md
+++ b/daedalus/skills/operator/SKILL.md
@@ -146,7 +146,7 @@ agents:
 **Runtime kinds:**
 - `acpx-codex` — persistent Codex sessions via `acpx`
 - `claude-cli` — one-shot Claude CLI invocations
-- `hermes-agent` — operator-supplied hermes-agent CLI; requires `command:` (no built-in invocation)
+- `hermes-agent` — Hermes CLI runtime; built-in `final` mode uses `hermes -z`, `chat` mode uses `hermes chat --quiet -q`, and custom `command:` overrides are supported
 - `codex-app-server` — managed stdio or external WebSocket Codex app-server runtime with durable thread resume
 
 To swap a coder from Codex to Claude, change one line:

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -415,6 +415,44 @@ definitions:
         type: array
         items: {type: string}
         minItems: 1
+      mode:
+        type: string
+        enum: [final, chat]
+      executable: {type: string}
+      profile: {type: string}
+      provider: {type: string}
+      source: {type: string}
+      max-turns: {type: integer, minimum: 1}
+      max_turns: {type: integer, minimum: 1}
+      timeout-seconds: {type: integer, minimum: 1}
+      timeout_seconds: {type: integer, minimum: 1}
+      toolsets:
+        oneOf:
+          - type: string
+          - type: array
+            items: {type: string}
+      skills:
+        oneOf:
+          - type: string
+          - type: array
+            items: {type: string}
+      yolo: {type: boolean}
+      pass-session-id: {type: boolean}
+      pass_session_id: {type: boolean}
+      ignore-user-config: {type: boolean}
+      ignore_user_config: {type: boolean}
+      ignore-rules: {type: boolean}
+      ignore_rules: {type: boolean}
+      continue:
+        oneOf:
+          - type: boolean
+          - type: string
+      extra-args:
+        type: array
+        items: {type: string}
+      extra_args:
+        type: array
+        items: {type: string}
 
   coder-tier:
     type: object

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -40,11 +40,6 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
             raise RuntimeError(f"agent.runtime={runtime_name!r} does not reference a declared runtime profile")
         runtime_cfg = runtimes.get(runtime_name) or {}
         runtime_kind = str(runtime_cfg.get("kind") or "").strip()
-        if runtime_kind == "hermes-agent":
-            if not (agent.get("command") or runtime_cfg.get("command")):
-                raise RuntimeError(
-                    "hermes-agent runtime requires command on the runtime profile or agent block"
-                )
         if runtime_kind == "codex-app-server":
             if not (runtime_cfg.get("command") or codex_cfg.get("command")):
                 raise RuntimeError(

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -261,6 +261,44 @@ definitions:
         type: array
         minItems: 1
         items: {type: string}
+      mode:
+        type: string
+        enum: [final, chat]
+      executable: {type: string}
+      profile: {type: string}
+      provider: {type: string}
+      source: {type: string}
+      max-turns: {type: integer, minimum: 1}
+      max_turns: {type: integer, minimum: 1}
+      timeout-seconds: {type: integer, minimum: 1}
+      timeout_seconds: {type: integer, minimum: 1}
+      toolsets:
+        oneOf:
+          - type: string
+          - type: array
+            items: {type: string}
+      skills:
+        oneOf:
+          - type: string
+          - type: array
+            items: {type: string}
+      yolo: {type: boolean}
+      pass-session-id: {type: boolean}
+      pass_session_id: {type: boolean}
+      ignore-user-config: {type: boolean}
+      ignore_user_config: {type: boolean}
+      ignore-rules: {type: boolean}
+      ignore_rules: {type: boolean}
+      continue:
+        oneOf:
+          - type: boolean
+          - type: string
+      extra-args:
+        type: array
+        items: {type: string}
+      extra_args:
+        type: array
+        items: {type: string}
   claude-cli-runtime:
     type: object
     required: [kind]

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -51,7 +51,7 @@ app-server transport. It is not treated as a per-stage command. Use
 |---|---|---|---|---|---|
 | Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot | ✅ resumable Codex thread |
 | `ensure_session` | no-op | `acpx codex sessions ensure` | no-op | no-op |
-| `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | requires `command:` override | JSON-RPC over stdio to `codex app-server` |
+| `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | `hermes -z` or `hermes chat --quiet -q` | JSON-RPC over stdio to `codex app-server` |
 | `assess_health` | always healthy | freshness + grace window | always healthy | always healthy |
 | `close_session` | no-op | `acpx codex sessions close` | no-op | no-op |
 | Records `last_activity_ts` | yes (before + after `_run`) | yes | yes | yes |
@@ -83,17 +83,34 @@ The preflight pass walks `runtimes.<name>.kind` and `agents.external-reviewer.ki
 
 ### `hermes-agent` runtime
 
-The `hermes-agent` runtime delegates turns to a local Hermes agent process. It is **one-shot** (no persistent session) and requires a `command:` override in `WORKFLOW.md` because the exact invocation depends on the agent's entry point.
+The `hermes-agent` runtime delegates turns to a local Hermes Agent CLI. By
+default it uses the documented scripted path, `hermes -z`, which returns only
+the final answer. Set `mode: chat` to use `hermes chat --quiet -q` when you need
+Hermes chat features such as `--source`, `--max-turns`, skills, toolsets, or
+session resume.
 
 ```yaml
 runtimes:
-  my-agent-runtime:
+  hermes-final:
     kind: hermes-agent
-    command: ["python3", "-m", "my_agent", "--workflow-root", "{workflow_root}"]
+    mode: final
+    provider: openrouter
     timeout-seconds: 1200
+
+  hermes-chat:
+    kind: hermes-agent
+    mode: chat
+    source: daedalus
+    max-turns: 90
+    toolsets: terminal,skills
 ```
 
-Because it is one-shot, `assess_health` always returns healthy and `last_activity_ts` records the subprocess start/end timestamps.
+Custom `command:` overrides still work. Command-backed stages receive
+`{prompt_path}`, `{result_path}`, `{worktree}`, `{session_name}`, and `{model}`
+placeholders plus `DAEDALUS_*` environment variables. If the command writes a
+JSON object to `{result_path}`, Daedalus records its `output`, `session_id`,
+`thread_id`, `turn_id`, `tokens`, `rate_limits`, and related fields as the
+runtime result.
 
 ### `codex-app-server` runtime
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -54,8 +54,9 @@ stateDiagram-v2
 
 ### `hermes-agent` (one-shot)
 
-- No persistent session.
-- Requires a `command:` override in `WORKFLOW.md`.
+- Built-in final mode uses `hermes -z`.
+- Built-in chat mode uses `hermes chat --quiet -q` and can pass `--resume` when the workflow has a session id.
+- Custom `command:` overrides can write structured metadata to `{result_path}`.
 - `assess_health` always returns healthy.
 - `last_activity_ts` records subprocess start/end timestamps.
 

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -40,10 +40,13 @@ For each eligible tracker issue:
 - `codex`: spec-shaped Codex runner settings; set `mode: external` and `endpoint: ws://127.0.0.1:<port>` to connect to an already-running app-server, and keep `ephemeral: false` if you want Codex threads to remain inspectable
 - `runtimes`: shared runtime backend profiles; `agent.runtime` selects one profile for the issue execution stage
 
-The issue execution stage uses the shared runtime stage dispatcher. Command
-runtimes such as `hermes-agent` receive a rendered `{prompt_path}`. Prompt-native
-runtimes such as `codex-app-server` receive the prompt through `run_prompt_result`
-and can persist thread/token metrics.
+The issue execution stage uses the shared runtime stage dispatcher. Hermes can
+run directly through `mode: final` (`hermes -z`) or `mode: chat`
+(`hermes chat --quiet -q`). Command overrides receive rendered `{prompt_path}`
+and `{result_path}` placeholders; writing JSON to `{result_path}` lets Daedalus
+record command runtime metadata and token/rate-limit metrics. Prompt-native
+runtimes such as `codex-app-server` receive the prompt through
+`run_prompt_result`.
 
 External Codex app-server example:
 

--- a/tests/test_runtime_agnostic_phase_a.py
+++ b/tests/test_runtime_agnostic_phase_a.py
@@ -77,6 +77,84 @@ def test_hermes_agent_run_command(tmp_path):
     assert out == "agent-out"
 
 
+def test_hermes_agent_final_mode_uses_scripted_one_shot(tmp_path):
+    from workflows.change_delivery.runtimes.hermes_agent import HermesAgentRuntime
+
+    fake_run = MagicMock(return_value=MagicMock(stdout="final answer\n"))
+    rt = HermesAgentRuntime(
+        {"kind": "hermes-agent", "mode": "final", "provider": "openrouter"},
+        run=fake_run,
+        run_json=None,
+    )
+    result = rt.run_prompt_result(
+        worktree=tmp_path,
+        session_name="issue-1",
+        prompt="answer this",
+        model="anthropic/claude-sonnet-4.6",
+    )
+
+    assert result.output == "final answer\n"
+    cmd = fake_run.call_args[0][0]
+    assert cmd == [
+        "hermes",
+        "-z",
+        "answer this",
+        "--provider",
+        "openrouter",
+        "--model",
+        "anthropic/claude-sonnet-4.6",
+    ]
+    assert fake_run.call_args.kwargs["cwd"] == tmp_path
+    assert fake_run.call_args.kwargs["env"]["DAEDALUS_RUNTIME_KIND"] == "hermes-agent"
+
+
+def test_hermes_agent_chat_mode_uses_quiet_query_with_session_options(tmp_path):
+    from workflows.change_delivery.runtimes.hermes_agent import HermesAgentRuntime
+
+    fake_run = MagicMock(return_value=MagicMock(stdout="chat answer\n"))
+    rt = HermesAgentRuntime(
+        {
+            "kind": "hermes-agent",
+            "mode": "chat",
+            "source": "daedalus",
+            "max-turns": 7,
+            "toolsets": ["terminal", "skills"],
+            "skills": ["operator"],
+        },
+        run=fake_run,
+        run_json=None,
+    )
+    rt.ensure_session(worktree=tmp_path, session_name="lane-1", model="gpt-5.5", resume_session_id="session-123")
+    result = rt.run_prompt_result(
+        worktree=tmp_path,
+        session_name="lane-1",
+        prompt="continue",
+        model="gpt-5.5",
+    )
+
+    assert result.session_id == "session-123"
+    cmd = fake_run.call_args[0][0]
+    assert cmd == [
+        "hermes",
+        "chat",
+        "--quiet",
+        "--resume",
+        "session-123",
+        "--model",
+        "gpt-5.5",
+        "--source",
+        "daedalus",
+        "--max-turns",
+        "7",
+        "--toolsets",
+        "terminal,skills",
+        "--skills",
+        "operator",
+        "-q",
+        "continue",
+    ]
+
+
 def test_hermes_agent_ensure_session_is_noop(tmp_path):
     from workflows.change_delivery.runtimes.hermes_agent import HermesAgentRuntime
 

--- a/tests/test_runtime_stage_dispatcher.py
+++ b/tests/test_runtime_stage_dispatcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 from types import SimpleNamespace
 
@@ -53,7 +54,10 @@ def test_runtime_stage_runs_command_runtime_with_prompt_file_and_callbacks(tmp_p
     assert calls["cancel_events"][-1] is None
     assert callable(calls["progress_callbacks"][0])
     assert calls["progress_callbacks"][-1] is None
-    assert calls["env"] == {"A": "B"}
+    assert calls["env"]["A"] == "B"
+    assert calls["env"]["DAEDALUS_SESSION_NAME"] == "issue-1"
+    assert calls["env"]["DAEDALUS_MODEL"] == "gpt-test"
+    assert "DAEDALUS_RESULT_PATH" in calls["env"]
     assert calls["command"][:3] == ["agent", "--model", "gpt-test"]
     assert calls["command"][-1] == "ISSUE-1"
     assert result.prompt_path is not None
@@ -62,6 +66,60 @@ def test_runtime_stage_runs_command_runtime_with_prompt_file_and_callbacks(tmp_p
     metrics_source = prompt_result_from_stage(result)
     assert isinstance(metrics_source, PromptRunResult)
     assert metrics_source.tokens == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def test_runtime_stage_reads_structured_command_result(tmp_path):
+    from runtimes.stages import prompt_result_from_stage, run_runtime_stage
+
+    calls = {}
+
+    class FakeRuntime:
+        def ensure_session(self, **kwargs):
+            return None
+
+        def run_command(self, *, worktree, command_argv, env=None):
+            calls["argv"] = command_argv
+            calls["env"] = env
+            result_path = env["DAEDALUS_RESULT_PATH"]
+            with open(result_path, "w", encoding="utf-8") as fh:
+                json.dump(
+                    {
+                        "output": "structured output",
+                        "session_id": "hermes-session-1",
+                        "thread_id": "hermes-thread-1",
+                        "turn_id": "hermes-turn-1",
+                        "last_event": "turn/completed",
+                        "last_message": "done",
+                        "turn_count": 2,
+                        "tokens": {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8},
+                        "rate_limits": {"requests_remaining": 42},
+                    },
+                    fh,
+                )
+            return "plain stdout fallback"
+
+    result = run_runtime_stage(
+        runtime=FakeRuntime(),
+        runtime_cfg={
+            "kind": "hermes-agent",
+            "command": ["agent", "--prompt", "{prompt_path}", "--result", "{result_path}"],
+        },
+        agent_cfg={"model": "m", "runtime": "hermes"},
+        stage_name="internal-reviewer",
+        worktree=tmp_path,
+        session_name="review-1",
+        prompt="review",
+    )
+
+    assert calls["argv"][-1] == calls["env"]["DAEDALUS_RESULT_PATH"]
+    assert result.output == "structured output"
+    assert result.result_path is not None
+    metrics_source = prompt_result_from_stage(result)
+    assert metrics_source.session_id == "hermes-session-1"
+    assert metrics_source.thread_id == "hermes-thread-1"
+    assert metrics_source.turn_id == "hermes-turn-1"
+    assert metrics_source.tokens == {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8}
+    assert metrics_source.rate_limits == {"requests_remaining": 42}
 
 
 def test_runtime_stage_runs_prompt_runtime_and_ignores_codex_transport_command(tmp_path):

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -282,6 +282,79 @@ def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
     assert status["scheduler"]["retry_queue"][0]["error"] == "continuation"
 
 
+def test_issue_runner_records_structured_hermes_command_result_metrics(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    cfg["daedalus"]["runtimes"]["default"]["command"] = [
+        "fake-hermes",
+        "--prompt",
+        "{prompt_path}",
+        "--result",
+        "{result_path}",
+    ]
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    _write_issue_runner_contract(
+        workflow_root=workflow_root,
+        cfg=cfg,
+        issues=[
+            {
+                "id": "ISSUE-1",
+                "identifier": "ISSUE-1",
+                "title": "Hermes metrics",
+                "description": "Emit structured runtime metrics.",
+                "priority": 1,
+                "state": "todo",
+                "labels": [],
+                "blocked_by": [],
+            }
+        ],
+    )
+
+    def fake_run(command, *, cwd=None, timeout=None, env=None):
+        if command and command[0] == "fake-hermes":
+            assert command[-1] == env["DAEDALUS_RESULT_PATH"]
+            Path(env["DAEDALUS_RESULT_PATH"]).write_text(
+                json.dumps(
+                    {
+                        "output": "structured hermes output\n",
+                        "session_id": "hermes-session-1",
+                        "thread_id": "hermes-thread-1",
+                        "turn_id": "hermes-turn-1",
+                        "turn_count": 1,
+                        "tokens": {"input_tokens": 4, "output_tokens": 6, "total_tokens": 10},
+                        "rate_limits": {"requests_remaining": 77},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        class Result:
+            stdout = "stdout fallback\n"
+            stderr = ""
+            returncode = 0
+
+        return Result()
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=fake_run,
+        run_json=lambda *args, **kwargs: {},
+    )
+    result = workspace.tick()
+
+    assert result["ok"] is True
+    assert Path(result["outputPath"]).read_text(encoding="utf-8") == "structured hermes output\n"
+    assert result["metrics"]["session_id"] == "hermes-session-1"
+    assert result["metrics"]["thread_id"] == "hermes-thread-1"
+    assert result["metrics"]["turn_id"] == "hermes-turn-1"
+    assert result["metrics"]["tokens"] == {"input_tokens": 4, "output_tokens": 6, "total_tokens": 10}
+    status = workspace.build_status()
+    assert status["metrics"]["tokens"]["total_tokens"] == 10
+    assert status["metrics"]["rate_limits"] == {"requests_remaining": 77}
+
+
 def test_issue_runner_tracker_feedback_marks_local_json_done_without_continuation_retry(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 


### PR DESCRIPTION
## Summary
- add built-in hermes-agent prompt execution modes: final mode via `hermes -z` and chat mode via `hermes chat --quiet -q`
- add shared `{result_path}` / `DAEDALUS_RESULT_PATH` structured result capture for command-backed runtime stages
- allow issue-runner and change-delivery schemas to configure Hermes mode/provider/source/max-turns/toolsets/skills options
- remove the issue-runner preflight requirement that Hermes profiles must always define a custom command
- update runtime/session docs and operator skill guidance

## Notes
- Based on the official Hermes CLI docs: `hermes -z` is the clean scripted one-shot path; `hermes chat -q` is the richer one-shot chat path with `--source`, `--max-turns`, skills, and toolsets.

## Tests
- `python -m pytest -q`
