### PR TITLE
[codex] Add runtime preset configuration command

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -39,6 +39,13 @@ from workflows.contract import (
     write_workflow_contract_pointer,
 )
 from workflows.validation import validate_workflow_contract
+from workflows.runtime_presets import (
+    RuntimePresetError,
+    available_runtime_presets,
+    configure_runtime_contract,
+    runtime_availability_checks,
+    runtime_binding_checks,
+)
 from workflows.shared.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -2123,6 +2130,7 @@ def build_doctor_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
             },
         )
     )
+    checks.extend(_runtime_doctor_checks(workflow_root))
 
     active_lane_id = active_lane.get("lane_id")
     stuck_dispatched_actions = daedalus.query_stuck_dispatched_actions(
@@ -2227,6 +2235,43 @@ def build_doctor_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
         "recent_shadow_actions": shadow_report.get("recent_shadow_actions"),
         "recent_failures": recent_failures,
     }
+
+
+def _runtime_doctor_checks(workflow_root: Path) -> list[dict[str, Any]]:
+    try:
+        config = load_workflow_contract(workflow_root).config
+    except Exception as exc:
+        return [
+            _make_check(
+                code="runtime_contract",
+                status="fail",
+                severity="critical",
+                summary=f"Unable to load workflow contract for runtime checks: {exc}",
+            )
+        ]
+
+    checks = []
+    for check in [*runtime_binding_checks(config), *runtime_availability_checks(config)]:
+        status = str(check.get("status") or "info")
+        severity = "info"
+        if status == "fail":
+            severity = "critical"
+        elif status == "warn":
+            severity = "warning"
+        checks.append(
+            _make_check(
+                code=str(check.get("name") or "runtime-check").replace(":", "_"),
+                status=status,
+                severity=severity,
+                summary=str(check.get("detail") or ""),
+                details={
+                    key: value
+                    for key, value in check.items()
+                    if key not in {"name", "status", "detail"}
+                },
+            )
+        )
+    return checks
 
 
 def _lazy_cmd_watch(args, parser):
@@ -2734,6 +2779,26 @@ def cmd_bootstrap_workflow(args, parser) -> str:
     return "\n".join(lines)
 
 
+def configure_runtime_preset(
+    *,
+    workflow_root: Path,
+    runtime_preset: str,
+    role: str,
+    runtime_name: str | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    try:
+        return configure_runtime_contract(
+            workflow_root=workflow_root,
+            preset_name=runtime_preset,
+            role=role,
+            runtime_name=runtime_name,
+            dry_run=dry_run,
+        )
+    except (RuntimePresetError, WorkflowContractError, FileNotFoundError, OSError) as exc:
+        raise DaedalusCommandError(str(exc)) from exc
+
+
 def cmd_migrate_filesystem(args, parser) -> str:
     """Run the filesystem migrator for the given workflow root.
 
@@ -3160,6 +3225,34 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     bootstrap_cmd.add_argument("--json", action="store_true")
     bootstrap_cmd.set_defaults(handler=cmd_bootstrap_workflow, func=run_cli_command)
 
+    configure_runtime_cmd = sub.add_parser(
+        "configure-runtime",
+        help="Bind a workflow role to a built-in runtime preset in the repo-owned WORKFLOW.md contract.",
+    )
+    configure_runtime_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    configure_runtime_cmd.add_argument("--runtime", required=True, choices=available_runtime_presets())
+    configure_runtime_cmd.add_argument(
+        "--role",
+        required=True,
+        help=(
+            "Role to bind. issue-runner: agent. change-delivery: "
+            "coder.default, coder.high-effort, internal-reviewer, coder, reviewer, or all."
+        ),
+    )
+    configure_runtime_cmd.add_argument(
+        "--runtime-name",
+        help="Optional profile name to write under runtimes: (defaults to the preset name).",
+    )
+    configure_runtime_cmd.add_argument("--dry-run", action="store_true")
+    configure_runtime_cmd.add_argument("--json", action="store_true")
+    configure_runtime_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    configure_runtime_cmd.set_defaults(func=run_cli_command)
+
     codex_cmd = sub.add_parser(
         "codex-app-server",
         help="Install and control the shared Codex app-server systemd user service.",
@@ -3328,7 +3421,7 @@ def _resolve_format(format_arg: str | None, json_flag: bool | None) -> str:
 def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     workflow_root = Path(args.workflow_root).resolve() if hasattr(args, "workflow_root") else None
     daedalus = _load_daedalus_module(workflow_root) if workflow_root is not None else None
-    eventless_commands = {"codex-app-server", "runs", "events", "validate"}
+    eventless_commands = {"codex-app-server", "runs", "events", "validate", "configure-runtime"}
     if (
         workflow_root is not None
         and daedalus is not None
@@ -3380,6 +3473,14 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
         return build_validate_report(
             workflow_root=workflow_root,
             service_mode=getattr(args, "service_mode", None),
+        )
+    if args.daedalus_command == "configure-runtime":
+        return configure_runtime_preset(
+            workflow_root=workflow_root,
+            runtime_preset=args.runtime,
+            role=args.role,
+            runtime_name=args.runtime_name,
+            dry_run=args.dry_run,
         )
     if args.daedalus_command == "runs":
         return build_runs_report(
@@ -3691,6 +3792,26 @@ def render_result(
                 path = item.get("path") if isinstance(item, dict) else None
                 message = item.get("message") if isinstance(item, dict) else str(item)
                 lines.append(f"  {path or '<root>'}: {message}")
+        return "\n".join(lines)
+    if command == "configure-runtime":
+        bindings = result.get("bindings") or []
+        availability = result.get("availability_checks") or []
+        mode = "dry-run " if result.get("dry_run") else ""
+        lines = [
+            (
+                f"{mode}configured runtime preset={result.get('runtime_preset')} "
+                f"profile={result.get('runtime_name')} workflow={result.get('workflow')}"
+            ),
+            f"contract={result.get('contract_path')}",
+            "changed_roles=" + ", ".join(result.get("changed_roles") or []),
+        ]
+        for binding in bindings:
+            lines.append(
+                f"- {binding.get('role')} -> {binding.get('runtime')} "
+                f"kind={binding.get('kind')} exists={binding.get('profile_exists')}"
+            )
+        for check in availability:
+            lines.append(f"- {check.get('status')} {check.get('name')}: {check.get('detail')}")
         return "\n".join(lines)
     if command == "runs":
         if result.get("mode") == "show":

--- a/daedalus/skills/operator/SKILL.md
+++ b/daedalus/skills/operator/SKILL.md
@@ -31,6 +31,9 @@ Inside Hermes sessions:
 /daedalus status
 /daedalus shadow-report
 /daedalus doctor
+/daedalus configure-runtime --runtime hermes-final --role agent
+/daedalus configure-runtime --runtime hermes-chat --role internal-reviewer
+/daedalus configure-runtime --runtime codex-service --role coder.default
 /daedalus active-gate-status
 /daedalus set-active-execution --enabled true
 /daedalus set-active-execution --enabled false
@@ -60,6 +63,7 @@ Inside Hermes sessions:
 - Default workflow root is detected from the current directory or `DAEDALUS_WORKFLOW_ROOT`.
 - Workflow root directories should be named `<owner>-<repo>-<workflow-type>`, and `instance.name` in `WORKFLOW.md` should match.
 - Use `--workflow-root` to point at a different test root.
+- Use `configure-runtime` to bind a workflow role to a built-in runtime preset in the repo-owned `WORKFLOW.md`; follow with `validate` and `doctor`.
 - `service-up` is the preferred post-edit command: it validates the workflow contract, initializes state when needed, installs/enables/starts the systemd user unit, and reports status.
 - `change-delivery` supports shadow and active service modes. `issue-runner` supports active mode.
 - `run-shadow` remains shadow-only: it derives and records `change-delivery` actions but does not execute active side effects.

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -41,7 +41,16 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
         runtime_cfg = runtimes.get(runtime_name) or {}
         runtime_kind = str(runtime_cfg.get("kind") or "").strip()
         if runtime_kind == "codex-app-server":
-            if not (runtime_cfg.get("command") or codex_cfg.get("command")):
+            runtime_mode = str(
+                runtime_cfg.get("mode")
+                or codex_cfg.get("mode")
+                or ("external" if runtime_cfg.get("endpoint") or codex_cfg.get("endpoint") else "managed")
+            ).strip()
+            if runtime_mode == "external" and not (runtime_cfg.get("endpoint") or codex_cfg.get("endpoint")):
+                raise RuntimeError(
+                    "external codex-app-server runtime requires endpoint on the runtime profile or codex block"
+                )
+            if runtime_mode != "external" and not (runtime_cfg.get("command") or codex_cfg.get("command")):
                 raise RuntimeError(
                     "codex-app-server runtime requires command on the runtime profile or codex block"
                 )

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -50,6 +50,7 @@ from workflows.issue_runner.tracker import (
     issue_workspace_slug,
     select_issue,
 )
+from workflows.runtime_presets import runtime_availability_checks, runtime_binding_checks
 from trackers.feedback import publish_tracker_feedback
 from trackers.github import (
     github_auth_host_from_slug,
@@ -422,9 +423,11 @@ class IssueRunnerWorkspace(WorkflowDriver):
             checks.append({"name": "agent-runtime", "status": "pass", "detail": runtime_name})
         except Exception as exc:
             checks.append({"name": "agent-runtime", "status": "fail", "detail": str(exc)})
+        checks.extend(runtime_binding_checks(self.config))
+        checks.extend(runtime_availability_checks(self.config))
 
         checks.extend(self.engine_store.doctor(event_retention=self.config.get("retention") or {}))
-        ok = all(check["status"] == "pass" for check in checks)
+        ok = all(check["status"] != "fail" for check in checks)
         return {
             "ok": ok,
             "workflow": "issue-runner",

--- a/daedalus/workflows/runtime_presets.py
+++ b/daedalus/workflows/runtime_presets.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import copy
+import shlex
+import shutil
+import socket
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from workflows.contract import (
+    load_workflow_contract,
+    render_workflow_markdown,
+)
+
+
+RUNTIME_PRESETS: dict[str, dict[str, Any]] = {
+    "hermes-final": {
+        "kind": "hermes-agent",
+        "mode": "final",
+    },
+    "hermes-chat": {
+        "kind": "hermes-agent",
+        "mode": "chat",
+        "source": "daedalus",
+    },
+    "codex-service": {
+        "kind": "codex-app-server",
+        "mode": "external",
+        "endpoint": "ws://127.0.0.1:4500",
+        "ephemeral": False,
+        "keep_alive": True,
+    },
+}
+
+
+class RuntimePresetError(RuntimeError):
+    pass
+
+
+def available_runtime_presets() -> tuple[str, ...]:
+    return tuple(sorted(RUNTIME_PRESETS))
+
+
+def runtime_preset_config(preset_name: str) -> dict[str, Any]:
+    try:
+        return copy.deepcopy(RUNTIME_PRESETS[preset_name])
+    except KeyError as exc:
+        raise RuntimePresetError(
+            f"unknown runtime preset {preset_name!r}; expected one of {list(available_runtime_presets())}"
+        ) from exc
+
+
+def configure_runtime_contract(
+    *,
+    workflow_root: Path,
+    preset_name: str,
+    role: str,
+    runtime_name: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    root = Path(workflow_root).expanduser().resolve()
+    contract = load_workflow_contract(root)
+    if contract.source_path.suffix.lower() != ".md":
+        raise RuntimePresetError(
+            f"configure-runtime edits repo-owned WORKFLOW.md contracts only; got {contract.source_path}"
+        )
+
+    config = copy.deepcopy(contract.config)
+    workflow_name = str(config.get("workflow") or "").strip()
+    if not workflow_name:
+        raise RuntimePresetError("workflow contract is missing top-level workflow")
+
+    resolved_runtime_name = (runtime_name or preset_name).strip()
+    if not resolved_runtime_name:
+        raise RuntimePresetError("--runtime-name cannot be blank")
+
+    runtime_config = runtime_preset_config(preset_name)
+    runtimes = config.setdefault("runtimes", {})
+    if not isinstance(runtimes, dict):
+        raise RuntimePresetError("top-level runtimes must be a mapping")
+    runtimes[resolved_runtime_name] = runtime_config
+
+    changed_roles = bind_runtime_role(
+        config=config,
+        workflow_name=workflow_name,
+        role=role,
+        runtime_name=resolved_runtime_name,
+    )
+
+    if not dry_run:
+        contract.source_path.write_text(
+            render_workflow_markdown(config=config, prompt_template=contract.prompt_template),
+            encoding="utf-8",
+        )
+
+    return {
+        "ok": True,
+        "action": "configure-runtime",
+        "workflow_root": str(root),
+        "contract_path": str(contract.source_path),
+        "workflow": workflow_name,
+        "runtime_preset": preset_name,
+        "runtime_name": resolved_runtime_name,
+        "runtime_config": runtime_config,
+        "role": role,
+        "changed_roles": changed_roles,
+        "bindings": runtime_role_bindings(config),
+        "checks": runtime_binding_checks(config),
+        "availability_checks": runtime_availability_checks(config),
+        "dry_run": dry_run,
+    }
+
+
+def bind_runtime_role(
+    *,
+    config: dict[str, Any],
+    workflow_name: str,
+    role: str,
+    runtime_name: str,
+) -> list[str]:
+    normalized_role = _normalize_role(role)
+    if workflow_name == "issue-runner":
+        return _bind_issue_runner_role(config=config, role=normalized_role, runtime_name=runtime_name)
+    if workflow_name == "change-delivery":
+        return _bind_change_delivery_role(config=config, role=normalized_role, runtime_name=runtime_name)
+    raise RuntimePresetError(f"configure-runtime does not know workflow {workflow_name!r}")
+
+
+def runtime_role_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
+    workflow_name = str(config.get("workflow") or "").strip()
+    runtimes = _runtime_profiles_from_config(config)
+    bindings: list[dict[str, Any]] = []
+    if workflow_name == "issue-runner":
+        agent = config.get("agent") if isinstance(config.get("agent"), dict) else {}
+        _append_binding(bindings, role="agent", runtime_name=agent.get("runtime"), runtimes=runtimes)
+        return bindings
+    if workflow_name == "change-delivery":
+        agents = config.get("agents") if isinstance(config.get("agents"), dict) else {}
+        coder = agents.get("coder") if isinstance(agents.get("coder"), dict) else {}
+        for tier_name in sorted(coder):
+            tier = coder.get(tier_name)
+            if isinstance(tier, dict):
+                _append_binding(bindings, role=f"coder.{tier_name}", runtime_name=tier.get("runtime"), runtimes=runtimes)
+        reviewer = agents.get("internal-reviewer") if isinstance(agents.get("internal-reviewer"), dict) else {}
+        _append_binding(
+            bindings,
+            role="internal-reviewer",
+            runtime_name=reviewer.get("runtime"),
+            runtimes=runtimes,
+        )
+    return bindings
+
+
+def runtime_binding_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    checks = []
+    for binding in runtime_role_bindings(config):
+        role = binding.get("role") or "runtime-role"
+        runtime_name = binding.get("runtime")
+        if not runtime_name:
+            checks.append(
+                {
+                    "name": f"runtime-binding:{role}",
+                    "status": "fail",
+                    "detail": f"{role} has no runtime profile",
+                    "role": role,
+                }
+            )
+            continue
+        if not binding.get("profile_exists"):
+            checks.append(
+                {
+                    "name": f"runtime-binding:{role}",
+                    "status": "fail",
+                    "detail": f"{role} references missing runtime profile {runtime_name!r}",
+                    "role": role,
+                    "runtime": runtime_name,
+                }
+            )
+            continue
+        checks.append(
+            {
+                "name": f"runtime-binding:{role}",
+                "status": "pass",
+                "detail": f"{role} -> {runtime_name} ({binding.get('kind')})",
+                "role": role,
+                "runtime": runtime_name,
+                "kind": binding.get("kind"),
+            }
+        )
+    return checks
+
+
+def runtime_availability_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    runtimes = _runtime_profiles_from_config(config)
+    referenced = {
+        str(binding.get("runtime"))
+        for binding in runtime_role_bindings(config)
+        if binding.get("runtime") and binding.get("profile_exists")
+    }
+    checks = []
+    for name in sorted(referenced):
+        runtime_cfg = runtimes.get(name) if isinstance(runtimes.get(name), dict) else {}
+        kind = str(runtime_cfg.get("kind") or "").strip()
+        checks.append(_runtime_availability_check(name=name, kind=kind, runtime_cfg=runtime_cfg))
+    return checks
+
+
+def _normalize_role(role: str) -> str:
+    normalized = role.strip()
+    if not normalized:
+        raise RuntimePresetError("--role cannot be blank")
+    if normalized.startswith("issue-runner."):
+        normalized = normalized.removeprefix("issue-runner.")
+    if normalized.startswith("change-delivery."):
+        normalized = normalized.removeprefix("change-delivery.")
+    return normalized
+
+
+def _runtime_profiles_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    top_level = config.get("runtimes")
+    if isinstance(top_level, dict) and top_level:
+        return top_level
+    daedalus_cfg = config.get("daedalus")
+    if isinstance(daedalus_cfg, dict) and isinstance(daedalus_cfg.get("runtimes"), dict):
+        return daedalus_cfg["runtimes"]
+    return {}
+
+
+def _bind_issue_runner_role(*, config: dict[str, Any], role: str, runtime_name: str) -> list[str]:
+    if role not in {"agent", "all"}:
+        raise RuntimePresetError("issue-runner supports --role agent or --role all")
+    agent = config.setdefault("agent", {})
+    if not isinstance(agent, dict):
+        raise RuntimePresetError("issue-runner agent must be a mapping")
+    agent["runtime"] = runtime_name
+    return ["agent"]
+
+
+def _bind_change_delivery_role(*, config: dict[str, Any], role: str, runtime_name: str) -> list[str]:
+    agents = config.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        raise RuntimePresetError("change-delivery agents must be a mapping")
+
+    changed: list[str] = []
+    if role in {"coder.default", "coder", "all"}:
+        changed.extend(_bind_coder_tiers(agents=agents, tiers=("default",), runtime_name=runtime_name))
+    if role in {"coder.high-effort", "coder", "all"}:
+        changed.extend(_bind_coder_tiers(agents=agents, tiers=("high-effort",), runtime_name=runtime_name))
+    if role in {"internal-reviewer", "reviewer", "all"}:
+        reviewer = agents.setdefault("internal-reviewer", {})
+        if not isinstance(reviewer, dict):
+            raise RuntimePresetError("agents.internal-reviewer must be a mapping")
+        reviewer["runtime"] = runtime_name
+        changed.append("internal-reviewer")
+    if changed:
+        return changed
+    raise RuntimePresetError(
+        "change-delivery supports --role coder.default, coder.high-effort, coder, "
+        "internal-reviewer, reviewer, or all"
+    )
+
+
+def _bind_coder_tiers(*, agents: dict[str, Any], tiers: tuple[str, ...], runtime_name: str) -> list[str]:
+    coder = agents.setdefault("coder", {})
+    if not isinstance(coder, dict):
+        raise RuntimePresetError("agents.coder must be a mapping")
+    changed = []
+    for tier_name in tiers:
+        tier = coder.setdefault(tier_name, {})
+        if not isinstance(tier, dict):
+            raise RuntimePresetError(f"agents.coder.{tier_name} must be a mapping")
+        tier["runtime"] = runtime_name
+        changed.append(f"coder.{tier_name}")
+    return changed
+
+
+def _append_binding(
+    bindings: list[dict[str, Any]],
+    *,
+    role: str,
+    runtime_name: Any,
+    runtimes: dict[str, Any],
+) -> None:
+    normalized_runtime = str(runtime_name or "").strip() or None
+    runtime_cfg = runtimes.get(normalized_runtime) if normalized_runtime else None
+    profile_exists = isinstance(runtime_cfg, dict)
+    bindings.append(
+        {
+            "role": role,
+            "runtime": normalized_runtime,
+            "profile_exists": profile_exists,
+            "kind": str(runtime_cfg.get("kind") or "").strip() if profile_exists else None,
+        }
+    )
+
+
+def _runtime_availability_check(*, name: str, kind: str, runtime_cfg: dict[str, Any]) -> dict[str, Any]:
+    if kind == "codex-app-server":
+        mode = str(runtime_cfg.get("mode") or ("external" if runtime_cfg.get("endpoint") else "managed")).strip()
+        if mode == "external":
+            endpoint = str(runtime_cfg.get("endpoint") or "").strip()
+            ok, detail = _probe_ws_endpoint(endpoint)
+            return {
+                "name": f"runtime-availability:{name}",
+                "status": "pass" if ok else "warn",
+                "detail": detail,
+                "runtime": name,
+                "kind": kind,
+                "mode": mode,
+            }
+        executable = _runtime_command_executable(runtime_cfg, default="codex")
+        return _executable_check(name=name, kind=kind, executable=executable, mode=mode)
+
+    if kind == "hermes-agent":
+        executable = _runtime_command_executable(runtime_cfg, default=str(runtime_cfg.get("executable") or "hermes"))
+        return _executable_check(name=name, kind=kind, executable=executable)
+    if kind == "claude-cli":
+        executable = _runtime_command_executable(runtime_cfg, default="claude")
+        return _executable_check(name=name, kind=kind, executable=executable)
+    if kind == "acpx-codex":
+        executable = _runtime_command_executable(runtime_cfg, default="acpx")
+        return _executable_check(name=name, kind=kind, executable=executable)
+    return {
+        "name": f"runtime-availability:{name}",
+        "status": "warn",
+        "detail": f"unknown runtime kind {kind!r}",
+        "runtime": name,
+        "kind": kind,
+    }
+
+
+def _runtime_command_executable(runtime_cfg: dict[str, Any], *, default: str) -> str:
+    command = runtime_cfg.get("command")
+    if isinstance(command, list) and command:
+        return str(command[0])
+    if isinstance(command, str) and command.strip():
+        parts = shlex.split(command)
+        if parts:
+            return parts[0]
+    return default
+
+
+def _executable_check(*, name: str, kind: str, executable: str, mode: str | None = None) -> dict[str, Any]:
+    path = shutil.which(executable)
+    detail = f"{executable} -> {path}" if path else f"{executable} not found on PATH"
+    return {
+        "name": f"runtime-availability:{name}",
+        "status": "pass" if path else "warn",
+        "detail": detail,
+        "runtime": name,
+        "kind": kind,
+        "mode": mode,
+        "executable": executable,
+    }
+
+
+def _probe_ws_endpoint(endpoint: str) -> tuple[bool, str]:
+    if not endpoint:
+        return False, "external codex-app-server endpoint is not configured"
+    parsed = urlparse(endpoint)
+    if parsed.scheme != "ws":
+        return False, f"external codex-app-server endpoint must use ws://, got {endpoint!r}"
+    if not parsed.hostname or not parsed.port:
+        return False, f"external codex-app-server endpoint requires host and port: {endpoint!r}"
+    try:
+        with socket.create_connection((parsed.hostname, parsed.port), timeout=0.2):
+            return True, f"{endpoint} is reachable"
+    except OSError as exc:
+        return False, f"{endpoint} is not reachable yet: {exc}"
+
+
+__all__ = [
+    "RUNTIME_PRESETS",
+    "RuntimePresetError",
+    "available_runtime_presets",
+    "configure_runtime_contract",
+    "runtime_availability_checks",
+    "runtime_binding_checks",
+    "runtime_preset_config",
+    "runtime_role_bindings",
+]

--- a/daedalus/workflows/validation.py
+++ b/daedalus/workflows/validation.py
@@ -10,6 +10,7 @@ import yaml
 
 from . import load_workflow
 from .contract import WorkflowContract, WorkflowContractError, load_workflow_contract
+from .runtime_presets import runtime_binding_checks
 
 
 SERVICE_MODES = frozenset({"active", "shadow"})
@@ -202,6 +203,7 @@ def validate_workflow_contract(
 
     checks.append(_instance_name_check(workflow_root=root, config=config))
     checks.append(_repository_path_check(workflow_root=root, config=config))
+    checks.extend(runtime_binding_checks(config))
 
     if module is not None and run_preflight:
         preflight_fn = getattr(module, "run_preflight", None)

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -81,6 +81,21 @@ agents:
 
 The preflight pass walks `runtimes.<name>.kind` and `agents.external-reviewer.kind` to confirm every referenced runtime resolves to a registered adapter before a tick dispatches.
 
+## Configure with Presets
+
+For common choices, let Daedalus edit the repo-owned workflow contract:
+
+```bash
+hermes daedalus configure-runtime --runtime hermes-final --role agent
+hermes daedalus configure-runtime --runtime hermes-chat --role internal-reviewer
+hermes daedalus configure-runtime --runtime codex-service --role coder.default
+```
+
+The command writes a named profile under `runtimes:` and updates the selected
+role under `agent:` or `agents:`. Use `--runtime-name` if you want the profile
+key to be different from the preset name. Use `--dry-run --json` to inspect the
+change without writing the file.
+
 ### `hermes-agent` runtime
 
 The `hermes-agent` runtime delegates turns to a local Hermes Agent CLI. By

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -88,6 +88,24 @@ The validator checks:
 | Repository path | Missing or non-directory `repository.local-path` |
 | Workflow preflight | Tracker/runtime references that cannot dispatch safely |
 
+## Runtime Presets
+
+Use `configure-runtime` when you want the plugin to update the YAML front matter
+for a known runtime shape instead of editing role bindings by hand:
+
+```bash
+hermes daedalus configure-runtime --runtime hermes-final --role agent
+hermes daedalus configure-runtime --runtime hermes-chat --role internal-reviewer
+hermes daedalus configure-runtime --runtime codex-service --role coder.default
+```
+
+Built-in presets are `hermes-final`, `hermes-chat`, and `codex-service`.
+`issue-runner` supports `agent`; `change-delivery` supports `coder.default`,
+`coder.high-effort`, `internal-reviewer`, `coder`, `reviewer`, and `all`.
+Run `hermes daedalus validate` and `hermes daedalus doctor` after changing a
+binding. Doctor reports each role-to-runtime binding and whether the required
+CLI or external Codex service appears reachable.
+
 ## Markdown Body
 
 The Markdown body is policy text. Workflows decide how to use it:

--- a/tests/test_runtime_presets.py
+++ b/tests/test_runtime_presets.py
@@ -1,0 +1,213 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from workflows.contract import (
+    load_workflow_contract_file,
+    render_workflow_markdown,
+    write_workflow_contract_pointer,
+)
+from workflows.runtime_presets import RuntimePresetError, configure_runtime_contract
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
+
+
+def load_module(module_name: str, relative_path: str):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_contract(path: Path, config: dict, body: str = "# Policy\n\nDo the work.") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_workflow_markdown(config=config, prompt_template=body), encoding="utf-8")
+
+
+def test_configure_runtime_binds_issue_runner_agent_and_preserves_body(tmp_path):
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    contract_path = root / "WORKFLOW.md"
+    _write_contract(
+        contract_path,
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "default"},
+            "runtimes": {"default": {"kind": "hermes-agent", "command": ["echo", "{prompt_path}"]}},
+            "storage": {"status": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+    )
+
+    result = configure_runtime_contract(
+        workflow_root=root,
+        preset_name="hermes-chat",
+        role="agent",
+        runtime_name=None,
+    )
+    contract = load_workflow_contract_file(contract_path)
+
+    assert result["changed_roles"] == ["agent"]
+    assert contract.config["agent"]["runtime"] == "hermes-chat"
+    assert contract.config["runtimes"]["hermes-chat"] == {
+        "kind": "hermes-agent",
+        "mode": "chat",
+        "source": "daedalus",
+    }
+    assert contract.prompt_template == "# Policy\n\nDo the work."
+
+
+def test_configure_runtime_uses_workflow_root_pointer_for_change_delivery(tmp_path):
+    workflow_root = tmp_path / "attmous-daedalus-change-delivery"
+    repo_root = tmp_path / "repo"
+    contract_path = repo_root / "WORKFLOW-change-delivery.md"
+    workflow_root.mkdir()
+    _write_contract(
+        contract_path,
+        {
+            "workflow": "change-delivery",
+            "schema-version": 1,
+            "instance": {"name": workflow_root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(repo_root), "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+            "tracker": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "runtimes": {
+                "coder-runtime": {"kind": "acpx-codex"},
+                "reviewer-runtime": {"kind": "claude-cli"},
+            },
+            "agents": {
+                "coder": {
+                    "default": {"name": "coder", "model": "gpt-5", "runtime": "coder-runtime"},
+                    "high-effort": {"name": "coder-hi", "model": "gpt-5.5", "runtime": "coder-runtime"},
+                },
+                "internal-reviewer": {"name": "reviewer", "model": "gpt-5", "runtime": "reviewer-runtime"},
+                "external-reviewer": {"enabled": False, "name": "external", "kind": "disabled"},
+            },
+            "gates": {},
+            "triggers": {},
+            "storage": {"ledger": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+    )
+    write_workflow_contract_pointer(workflow_root, contract_path)
+
+    result = configure_runtime_contract(
+        workflow_root=workflow_root,
+        preset_name="codex-service",
+        role="coder.default",
+        runtime_name="codex",
+    )
+    cfg = load_workflow_contract_file(contract_path).config
+
+    assert result["changed_roles"] == ["coder.default"]
+    assert cfg["agents"]["coder"]["default"]["runtime"] == "codex"
+    assert cfg["agents"]["coder"]["high-effort"]["runtime"] == "coder-runtime"
+    assert cfg["runtimes"]["codex"] == {
+        "kind": "codex-app-server",
+        "mode": "external",
+        "endpoint": "ws://127.0.0.1:4500",
+        "ephemeral": False,
+        "keep_alive": True,
+    }
+
+
+def test_configure_runtime_rejects_unknown_role(tmp_path):
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_contract(
+        root / "WORKFLOW.md",
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path)},
+            "tracker": {"kind": "local-json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "gpt-5.4"},
+            "storage": {"status": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+    )
+
+    with pytest.raises(RuntimePresetError, match="issue-runner supports"):
+        configure_runtime_contract(
+            workflow_root=root,
+            preset_name="hermes-final",
+            role="coder.default",
+            runtime_name=None,
+        )
+
+
+def test_configure_runtime_cli_outputs_json(tmp_path):
+    tools = load_module("daedalus_tools_runtime_presets_test", "daedalus_cli.py")
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_contract(
+        root / "WORKFLOW.md",
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "default"},
+            "runtimes": {"default": {"kind": "hermes-agent", "command": ["echo", "{prompt_path}"]}},
+            "storage": {"status": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+    )
+
+    output = tools.execute_raw_args(
+        f"configure-runtime --workflow-root {root} --runtime hermes-final --role agent --json"
+    )
+    payload = json.loads(output)
+
+    assert payload["workflow"] == "issue-runner"
+    assert payload["runtime_name"] == "hermes-final"
+    assert payload["bindings"][0]["runtime"] == "hermes-final"
+
+
+def test_issue_runner_preflight_accepts_external_codex_service_without_command(tmp_path):
+    from workflows.issue_runner.preflight import run_preflight
+
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    repo = tmp_path / "repo"
+    root.mkdir()
+    repo.mkdir()
+    (root / "config").mkdir()
+    (root / "config" / "issues.json").write_text(
+        json.dumps({"issues": [{"id": "ISSUE-1", "title": "One", "state": "todo"}]}),
+        encoding="utf-8",
+    )
+
+    result = run_preflight(
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(repo), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "codex-service"},
+            "runtimes": {
+                "codex-service": {
+                    "kind": "codex-app-server",
+                    "mode": "external",
+                    "endpoint": "ws://127.0.0.1:4500",
+                    "ephemeral": False,
+                    "keep_alive": True,
+                }
+            },
+            "storage": {"status": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+        workflow_root=root,
+    )
+
+    assert result.ok is True


### PR DESCRIPTION
## Summary

Adds a runtime preset configuration path so operators can bind workflow roles to known runtime shapes without hand-editing every YAML field.

## Changes

- Adds `hermes daedalus configure-runtime` with presets for `hermes-final`, `hermes-chat`, and external `codex-service`.
- Adds shared runtime preset/binding helpers used by CLI, validation, and doctor output.
- Validates role-to-runtime references and reports runtime availability checks in doctor surfaces.
- Allows issue-runner external Codex app-server profiles to preflight without a local `command`.
- Documents preset usage in the workflow contract and runtimes docs.

## Validation

- `pytest -q` -> 848 passed, 9 skipped
