### PR TITLE
[codex] Document Daedalus positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,16 @@ flowchart LR
 
 Stable public boundaries are tracked in [docs/public-contract.md](docs/public-contract.md).
 Readiness and generic-surface guardrails are tracked in
-[docs/harness-engineering.md](docs/harness-engineering.md).
+[docs/harness-engineering.md](docs/harness-engineering.md). For the product
+boundary between Daedalus, Hermes Agent, and Hermes Kanban, see
+[docs/positioning.md](docs/positioning.md).
 
 ## Documentation
 
 | Doc | Purpose |
 |---|---|
 | [Installation](docs/operator/installation.md) | Full install, bootstrap, service, and troubleshooting path. |
+| [Positioning](docs/positioning.md) | Daedalus vs. Hermes Agent vs. Hermes Kanban, and why Kanban is an optional tracker rather than the engine. |
 | [WORKFLOW.md guide](docs/workflows/workflow-contract.md) | Workflow contract structure and examples. |
 | [Bundled workflows](docs/workflows/README.md) | Workflow comparison and templates. |
 | [Architecture](docs/architecture.md) | Engine/workflow boundary and durable runtime model. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Entry point for everything that won't fit on the [project landing page](../READM
 ## Start here
 
 - **[architecture.md](architecture.md)** — the big picture. What Daedalus is, what it isn't, how the pieces fit together.
+- **[positioning.md](positioning.md)** — Daedalus vs. Hermes Agent vs. Hermes Kanban, and where integration boundaries belong.
 - **[operator/installation.md](operator/installation.md)** — the supported install, scaffold, verify, and supervise flow.
 - **[workflows/README.md](workflows/README.md)** — the two bundled workflows, when to use each, and where their templates live.
 - **[public-contract.md](public-contract.md)** — the stability boundary for the first public release.
@@ -64,6 +65,7 @@ Day-2 commands and observability.
 docs/
 ├── README.md                this file
 ├── architecture.md          big picture
+├── positioning.md           product boundaries vs. Hermes Agent and Hermes Kanban
 ├── public-contract.md       stable public surfaces for the first release
 ├── symphony-conformance.md  current spec alignment vs. remaining gaps
 ├── harness-engineering.md   public-readiness checks and guardrails

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,87 @@
+# Daedalus vs. Hermes Agent vs. Hermes Kanban
+
+Daedalus, Hermes Agent, and Hermes Kanban all coordinate agentic work, but they
+sit at different layers. Keeping those layers separate avoids duplicate
+schedulers and makes Daedalus useful without taking over every Hermes feature.
+
+```mermaid
+flowchart TD
+    Tracker[Trackers and boards<br/>GitHub Issues, local-json, future Linear, future Hermes Kanban]
+    Daedalus[Daedalus engine<br/>ticks, leases, SQLite state, workflow reconciliation]
+    Workflow[Workflow packages<br/>issue-runner, change-delivery, future workflows]
+    Runtime[Runtimes<br/>Hermes Agent, Codex app-server, CLI agents, custom commands]
+    CodeHost[Code hosts<br/>branches, PRs, checks, reviews, merge]
+
+    Tracker --> Daedalus
+    Daedalus --> Workflow
+    Workflow --> Runtime
+    Workflow --> CodeHost
+```
+
+## Short Version
+
+| System | Primary job | Best fit |
+|---|---|---|
+| Hermes Agent | Run an agent with tools, memory, skills, models, messaging, and runtime surfaces. | The execution platform Daedalus can call into. |
+| Hermes Kanban | Durable multi-agent task board with task states, dependencies, run history, and worker claims. | Optional local-first tracker or planning board. |
+| Daedalus | Durable SDLC workflow engine that turns issues into governed workflow runs. | Software delivery automation: issue selection, runtime dispatch, PR/review/merge gates, recovery. |
+
+## Where They Overlap
+
+Hermes Kanban and Daedalus are both engine-like. Both use durable state, track
+work attempts, support claim/retry/recovery semantics, and expose operator
+surfaces. That overlap is why Kanban should not become Daedalus' internal
+scheduler. Running one scheduler inside another would create unclear ownership
+for claims, retries, blocked work, and terminal states.
+
+## What Each Does Not Own
+
+| System | Intentional limitation |
+|---|---|
+| Hermes Agent | It runs agents and exposes tools, but it should not own Daedalus workflow policy, SDLC gates, tracker reconciliation, or PR/merge semantics. |
+| Hermes Kanban | It coordinates generic tasks, but it should not own Daedalus lane leases, runtime role dispatch, GitHub PR lifecycle, CI/review gates, or workflow recovery policy. |
+| Daedalus | It automates SDLC workflows, but it should not become a general personal/team Kanban board, messaging gateway, model provider router, or universal Hermes task UI. |
+
+## Why Daedalus Is Not Duplication
+
+Hermes Kanban can say: "task X is ready and assigned to profile Y." Daedalus
+adds the SDLC-specific layer: "issue X becomes a lane, role A uses runtime B,
+thread IDs are persisted, tracker feedback is posted, a PR is created or
+updated, review gates are enforced, CI and merge state are reconciled, and
+stalled work is recovered."
+
+That SDLC layer is the reason Daedalus remains necessary even when Hermes
+Kanban exists.
+
+## Integration Stance
+
+Hermes Agent should remain a first-class runtime surface. Daedalus should call
+it through runtime adapters such as `hermes-agent` and, later, optional
+`hermes-acp`.
+
+Hermes Kanban should be integrated later as a tracker adapter, not as a
+replacement engine:
+
+```yaml
+tracker:
+  kind: hermes-kanban
+  tenant: my-project
+  assignee: daedalus
+```
+
+In that shape, Daedalus reads candidate tasks from Kanban and writes comments or
+state updates back, while Daedalus still owns workflow execution, leases,
+runtime dispatch, gates, reconciliation, and code-host side effects.
+
+## Current Priority
+
+Keep GitHub first-class for `change-delivery` because GitHub is where issues,
+branches, PRs, reviews, checks, and merge state already live. Add Hermes Kanban
+later for local demos, personal task queues, non-GitHub work, and fleet-style
+operator planning.
+
+References:
+
+- [Hermes Agent ACP integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp)
+- [Hermes Kanban overview](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban)
+- [Hermes Kanban tutorial](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban-tutorial)


### PR DESCRIPTION
## Summary

Adds a positioning document that explains the boundary between Daedalus, Hermes Agent, and Hermes Kanban.

## Changes

- Adds `docs/positioning.md` with a layer diagram, comparison table, non-ownership boundaries, and integration stance.
- Links the positioning doc from the repo README and docs index.
- Clarifies Hermes Kanban as a future optional tracker adapter, not a replacement for the Daedalus engine.

## Validation

Docs-only change; tests not run.
