### PR TITLE
[codex] Add operator readiness recommendations

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -39,6 +39,7 @@ from workflows.contract import (
     write_workflow_contract_pointer,
 )
 from workflows.validation import validate_workflow_contract
+from workflows.readiness import build_readiness_recommendations
 from workflows.runtime_presets import (
     RuntimePresetError,
     available_runtime_presets,
@@ -499,6 +500,10 @@ def _validation_failure_summary(report: dict[str, Any]) -> str:
             lines.append(f"  {path}: {message}")
     if len(failures) > 8:
         lines.append(f"- ... {len(failures) - 8} more failing checks")
+    recommendations = report.get("recommendations") or []
+    if recommendations:
+        lines.append("next steps:")
+        lines.extend(f"- {item}" for item in recommendations[:5])
     return "\n".join(lines)
 
 
@@ -521,6 +526,7 @@ def _validate_workflow_contract_preflight_for_service(
         "source_path": report.get("source_path"),
         "checks": report.get("checks") or [],
         "warnings": report.get("warnings") or [],
+        "recommendations": report.get("recommendations") or [],
     }
 
 
@@ -2226,6 +2232,11 @@ def build_doctor_report(*, workflow_root: Path, recent_actions_limit: int = 5) -
         "report_generated_at": shadow_report.get("report_generated_at"),
         "overall_status": overall_status,
         "checks": checks,
+        "recommendations": build_readiness_recommendations(
+            checks,
+            workflow="change-delivery",
+            workflow_root=workflow_root,
+        ),
         "runtime": runtime,
         "heartbeat": heartbeat,
         "owner_summary": shadow_report.get("owner_summary"),
@@ -3792,6 +3803,10 @@ def render_result(
                 path = item.get("path") if isinstance(item, dict) else None
                 message = item.get("message") if isinstance(item, dict) else str(item)
                 lines.append(f"  {path or '<root>'}: {message}")
+        recommendations = result.get("recommendations") or []
+        if recommendations:
+            lines.append("next steps:")
+            lines.extend(f"- {item}" for item in recommendations[:8])
         return "\n".join(lines)
     if command == "configure-runtime":
         bindings = result.get("bindings") or []

--- a/daedalus/formatters.py
+++ b/daedalus/formatters.py
@@ -457,18 +457,30 @@ def format_doctor(
                     status=row_status,
                 )
             )
+        sections = [
+            Section(
+                name=None,
+                rows=[
+                    Row(label="workflow", value=str(result.get("workflow") or EMPTY_VALUE)),
+                    Row(label="overall", value="PASS" if ok else "FAIL", status="pass" if ok else "fail"),
+                ],
+            ),
+            Section(name="checks", rows=rows),
+        ]
+        recommendations = result.get("recommendations") or []
+        if recommendations:
+            sections.append(
+                Section(
+                    name="next steps",
+                    rows=[
+                        Row(label=str(index), value=str(item))
+                        for index, item in enumerate(recommendations, start=1)
+                    ],
+                )
+            )
         return format_panel(
             title="Issue runner doctor",
-            sections=[
-                Section(
-                    name=None,
-                    rows=[
-                        Row(label="workflow", value=str(result.get("workflow") or EMPTY_VALUE)),
-                        Row(label="overall", value="PASS" if ok else "FAIL", status="pass" if ok else "fail"),
-                    ],
-                ),
-                Section(name="checks", rows=rows),
-            ],
+            sections=sections,
             use_color=use_color,
         )
 
@@ -516,10 +528,22 @@ def format_doctor(
         )],
     )
     checks_section = Section(name="checks", rows=rows)
+    sections = [summary_section, checks_section]
+    recommendations = result.get("recommendations") or []
+    if recommendations:
+        sections.append(
+            Section(
+                name="next steps",
+                rows=[
+                    Row(label=str(index), value=str(item))
+                    for index, item in enumerate(recommendations, start=1)
+                ],
+            )
+        )
 
     return format_panel(
         title="Daedalus doctor",
-        sections=[summary_section, checks_section],
+        sections=sections,
         use_color=use_color,
     )
 

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -50,6 +50,7 @@ from workflows.issue_runner.tracker import (
     issue_workspace_slug,
     select_issue,
 )
+from workflows.readiness import build_readiness_recommendations
 from workflows.runtime_presets import runtime_availability_checks, runtime_binding_checks
 from trackers.feedback import publish_tracker_feedback
 from trackers.github import (
@@ -432,6 +433,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
             "ok": ok,
             "workflow": "issue-runner",
             "checks": checks,
+            "recommendations": build_readiness_recommendations(
+                checks,
+                workflow="issue-runner",
+                workflow_root=self.path,
+                source_path=self.contract_path,
+            ),
             "updatedAt": _now_iso(),
         }
 

--- a/daedalus/workflows/readiness.py
+++ b/daedalus/workflows/readiness.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def build_readiness_recommendations(
+    checks: list[dict[str, Any]],
+    *,
+    workflow: str | None = None,
+    workflow_root: str | Path | None = None,
+    source_path: str | Path | None = None,
+) -> list[str]:
+    """Return concise operator next steps for failing/warning checks."""
+
+    del workflow_root
+    recommendations: list[str] = []
+    source = str(source_path) if source_path else "WORKFLOW.md"
+    for check in checks:
+        status = str(check.get("status") or "").lower()
+        if status not in {"fail", "warn"}:
+            continue
+        name = _check_name(check)
+        detail = str(check.get("detail") or check.get("summary") or "")
+
+        if name == "contract-file":
+            _append_once(
+                recommendations,
+                "Run `hermes daedalus bootstrap` from the target repo, or pass `--workflow-root` for an existing workflow instance.",
+            )
+        elif name == "contract-format":
+            _append_once(
+                recommendations,
+                "Move legacy YAML config to a repo-owned `WORKFLOW.md` contract before publishing the workflow.",
+            )
+        elif name == "workflow-field":
+            _append_once(recommendations, f"Add top-level `workflow:` to {source}.")
+        elif name == "workflow-package":
+            _append_once(
+                recommendations,
+                "Use a bundled workflow (`issue-runner` or `change-delivery`) or reinstall the Daedalus plugin.",
+            )
+        elif name == "schema":
+            _append_once(
+                recommendations,
+                f"Edit the YAML front matter in {source} and fix the listed schema paths.",
+            )
+        elif name == "schema-version":
+            _append_once(
+                recommendations,
+                "Set `schema-version` to a version supported by this plugin, or update the installed Daedalus plugin.",
+            )
+        elif name == "service-mode":
+            _append_once(
+                recommendations,
+                _service_mode_recommendation(workflow=workflow, detail=detail),
+            )
+        elif name == "instance-name":
+            _append_once(
+                recommendations,
+                "Make `instance.name` match the workflow root directory name, or rerun `hermes daedalus bootstrap`.",
+            )
+        elif name == "repository-path":
+            _append_once(
+                recommendations,
+                "Set `repository.local-path` to an existing local checkout path.",
+            )
+        elif name == "workflow-preflight":
+            _append_once(recommendations, _preflight_recommendation(check=check, workflow=workflow))
+        elif name.startswith("runtime-binding"):
+            _append_once(recommendations, _runtime_binding_recommendation(workflow=workflow))
+        elif name.startswith("runtime-availability"):
+            _append_once(recommendations, _runtime_availability_recommendation(detail))
+        elif name == "github-auth":
+            _append_once(
+                recommendations,
+                "Run `gh auth status` and `gh auth login` for the configured GitHub host.",
+            )
+        elif name == "github-repo":
+            _append_once(
+                recommendations,
+                "Check `tracker.github_slug`, `code-host.github_slug`, and local GitHub access with `gh repo view`.",
+            )
+        elif name == "tracker":
+            _append_once(
+                recommendations,
+                "Run `hermes daedalus validate --format json` and fix the tracker configuration before starting the service.",
+            )
+        elif name == "workspace-root":
+            _append_once(
+                recommendations,
+                "Create the configured workspace root or fix filesystem permissions for the workflow user.",
+            )
+        elif name == "service_supervision":
+            _append_once(
+                recommendations,
+                "Run `hermes daedalus service-up` to install, enable, and start the supervised user service.",
+            )
+        elif name == "stuck_dispatched_actions":
+            _append_once(
+                recommendations,
+                "Run `hermes daedalus doctor --format json` and inspect stuck dispatched actions before restarting active execution.",
+            )
+        elif name == "active_execution_failures":
+            _append_once(
+                recommendations,
+                "Inspect recent failures with `hermes daedalus doctor --format json`; retry or repair the recorded recovery action.",
+            )
+        elif name in {"engine_event_retention", "engine-event-retention"}:
+            _append_once(
+                recommendations,
+                "Configure or apply event retention with `hermes daedalus events stats` and `hermes daedalus events prune`.",
+            )
+        elif status == "fail":
+            _append_once(
+                recommendations,
+                f"Fix failing check `{name}`: {detail or 'see JSON output for details'}.",
+            )
+    return recommendations
+
+
+def _check_name(check: dict[str, Any]) -> str:
+    raw = str(check.get("name") or check.get("code") or "check").strip()
+    return raw.replace("_", "-") if raw.startswith("runtime_") else raw
+
+
+def _append_once(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def _service_mode_recommendation(*, workflow: str | None, detail: str) -> str:
+    if workflow == "issue-runner" or "issue-runner" in detail:
+        return "Use `hermes daedalus service-up --service-mode active`; `issue-runner` does not support shadow mode."
+    return "Use `--service-mode active` for execution or `--service-mode shadow` only for change-delivery parity checks."
+
+
+def _preflight_recommendation(*, check: dict[str, Any], workflow: str | None) -> str:
+    detail = str(check.get("error_detail") or check.get("detail") or "")
+    lowered = detail.lower()
+    if "agent.runtime" in lowered or "runtime" in lowered:
+        return _runtime_binding_recommendation(workflow=workflow)
+    if "tracker.path" in lowered or "issues.json" in lowered:
+        return "Create the configured local-json tracker file, or rerun `hermes daedalus bootstrap` to seed `config/issues.json`."
+    if "github" in lowered or "gh " in lowered:
+        return "Run `gh auth status`, verify `tracker.github_slug`, then rerun `hermes daedalus validate`."
+    return "Fix the workflow preflight detail shown above, then rerun `hermes daedalus validate`."
+
+
+def _runtime_binding_recommendation(*, workflow: str | None) -> str:
+    if workflow == "issue-runner":
+        return "Run `hermes daedalus configure-runtime --runtime hermes-final --role agent`, or define the referenced runtime profile manually."
+    if workflow == "change-delivery":
+        return "Run `hermes daedalus configure-runtime --runtime hermes-final --role coder.default`, or define the referenced runtime profile manually."
+    return "Run `hermes daedalus configure-runtime` for the affected role, or define the referenced runtime profile manually."
+
+
+def _runtime_availability_recommendation(detail: str) -> str:
+    lowered = detail.lower()
+    if "127.0.0.1:4500" in lowered or "codex-app-server" in lowered or "ws://" in lowered:
+        return "Start or diagnose the shared Codex listener with `hermes daedalus codex-app-server up` and `hermes daedalus codex-app-server doctor`."
+    if "hermes" in lowered:
+        return "Install Hermes Agent on PATH, or set `runtimes.<name>.executable` / `command` to the correct Hermes binary."
+    if "gh" in lowered:
+        return "Install GitHub CLI and authenticate with `gh auth login`."
+    return "Install the required runtime CLI on PATH or edit the runtime profile command."
+
+
+__all__ = ["build_readiness_recommendations"]

--- a/daedalus/workflows/validation.py
+++ b/daedalus/workflows/validation.py
@@ -10,6 +10,7 @@ import yaml
 
 from . import load_workflow
 from .contract import WorkflowContract, WorkflowContractError, load_workflow_contract
+from .readiness import build_readiness_recommendations
 from .runtime_presets import runtime_binding_checks
 
 
@@ -246,6 +247,12 @@ def _validation_report(
 ) -> dict[str, Any]:
     failures = [check for check in checks if check.get("status") == "fail"]
     warnings = [check for check in checks if check.get("status") == "warn"]
+    recommendations = build_readiness_recommendations(
+        checks,
+        workflow=workflow_name,
+        workflow_root=workflow_root,
+        source_path=source_path,
+    )
     return {
         "ok": not failures,
         "workflow_root": str(workflow_root),
@@ -255,4 +262,5 @@ def _validation_report(
         "checks": checks,
         "failures": failures,
         "warnings": warnings,
+        "recommendations": recommendations,
     }

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -155,17 +155,36 @@ The YAML front matter is the structured config. The Markdown body below it is
 the workflow policy contract. `change-delivery` composes it into its role
 prompts; `issue-runner` renders it as the issue prompt template.
 
+For common runtime choices, use the preset command instead of hand-editing the
+runtime block:
+
+```bash
+# default issue-runner role
+hermes daedalus configure-runtime --runtime hermes-final --role agent
+
+# change-delivery coder role backed by the shared Codex listener
+hermes daedalus configure-runtime --runtime codex-service --role coder.default
+```
+
+`configure-runtime` edits the repo-owned `WORKFLOW.md` contract, writes the
+runtime profile under `runtimes:`, and updates the selected role binding. It
+does not start external services.
+
 ## Bring it up
 
 ```bash
 hermes daedalus validate
+hermes daedalus doctor
 hermes daedalus service-up
 ```
 
 Run `validate` after editing `WORKFLOW.md`. It checks the contract file,
 workflow schema, schema version, instance naming, repository path, service mode,
-and workflow preflight rules. `service-up` runs the same validation again before
-it installs or starts the user service.
+runtime role bindings, and workflow preflight rules. `doctor` adds host/runtime
+readiness checks such as missing CLIs, unreachable Codex app-server, GitHub auth,
+and workspace access. Both commands include `next steps` recommendations when
+they find a problem. `service-up` runs validation again before it installs or
+starts the user service.
 
 `service-up` runs the supported post-edit path in one command:
 

--- a/tests/test_formatters_doctor.py
+++ b/tests/test_formatters_doctor.py
@@ -108,3 +108,20 @@ def test_doctor_issue_runner_renders_named_checks():
     assert "unknown runtime profile" in out
     assert "✓" in out
     assert "✗" in out
+
+
+def test_doctor_renders_recommendations():
+    fmt = _fmt()
+    result = {
+        "overall_status": "fail",
+        "checks": [
+            {"code": "runtime_binding_agent", "status": "fail", "summary": "agent references missing runtime"},
+        ],
+        "recommendations": [
+            "Run `hermes daedalus configure-runtime --runtime hermes-final --role agent`."
+        ],
+    }
+    out = fmt.format_doctor(result, use_color=False)
+
+    assert "next steps" in out
+    assert "configure-runtime" in out

--- a/tests/test_readiness_recommendations.py
+++ b/tests/test_readiness_recommendations.py
@@ -1,0 +1,50 @@
+from workflows.readiness import build_readiness_recommendations
+
+
+def test_readiness_recommends_configure_runtime_for_issue_runner_binding_failure():
+    recommendations = build_readiness_recommendations(
+        [
+            {
+                "name": "runtime-binding:agent",
+                "status": "fail",
+                "detail": "agent references missing runtime profile 'codex'",
+            }
+        ],
+        workflow="issue-runner",
+        source_path="/repo/WORKFLOW.md",
+    )
+
+    assert recommendations == [
+        "Run `hermes daedalus configure-runtime --runtime hermes-final --role agent`, or define the referenced runtime profile manually."
+    ]
+
+
+def test_readiness_recommends_codex_service_doctor_for_external_listener_warning():
+    recommendations = build_readiness_recommendations(
+        [
+            {
+                "name": "runtime-availability:codex-service",
+                "status": "warn",
+                "detail": "ws://127.0.0.1:4500 is not reachable yet: connection refused",
+            }
+        ],
+        workflow="change-delivery",
+    )
+
+    assert recommendations == [
+        "Start or diagnose the shared Codex listener with `hermes daedalus codex-app-server up` and `hermes daedalus codex-app-server doctor`."
+    ]
+
+
+def test_readiness_deduplicates_recommendations():
+    recommendations = build_readiness_recommendations(
+        [
+            {"name": "github-auth", "status": "fail", "detail": "missing auth"},
+            {"name": "github-auth", "status": "fail", "detail": "still missing auth"},
+        ],
+        workflow="issue-runner",
+    )
+
+    assert recommendations == [
+        "Run `gh auth status` and `gh auth login` for the configured GitHub host."
+    ]

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -90,6 +90,9 @@ def test_validate_command_reports_schema_and_semantic_failures(tmp_path):
     assert any(item["path"] == "storage" for item in checks["schema"]["items"])
     assert checks["instance-name"]["status"] == "fail"
     assert checks["repository-path"]["status"] == "fail"
+    assert payload["recommendations"]
+    assert any("YAML front matter" in item for item in payload["recommendations"])
+    assert any("repository.local-path" in item for item in payload["recommendations"])
 
 
 def test_validate_command_text_keeps_actionable_failures(tmp_path):
@@ -105,6 +108,8 @@ def test_validate_command_text_keeps_actionable_failures(tmp_path):
     assert "workflow contract valid=False" in output
     assert "FAIL schema" in output
     assert "storage" in output
+    assert "next steps:" in output
+    assert "YAML front matter" in output
 
 
 def test_service_up_refuses_invalid_contract_before_install(tmp_path):
@@ -126,3 +131,4 @@ def test_service_up_refuses_invalid_contract_before_install(tmp_path):
 
     assert "workflow contract validation failed" in str(exc.value)
     assert "schema" in str(exc.value)
+    assert "next steps:" in str(exc.value)


### PR DESCRIPTION
## Summary

Adds shared readiness recommendations so `validate`, `doctor`, and `service-up` failures tell operators what to fix next.

## Changes

- Adds `workflows/readiness.py` to map failing/warning checks to concise next steps.
- Includes recommendations in validation reports and service-up preflight failures.
- Renders doctor next steps for both `issue-runner` and `change-delivery`.
- Updates install docs to show the happy-path readiness loop: `configure-runtime` → `validate` → `doctor` → `service-up`.
- Adds tests for recommendation mapping, validation output, service-up failure text, and doctor formatting.

## Validation

- `pytest -q` -> 852 passed, 9 skipped
