### PR TITLE
[codex] Add tracker feedback upsert smoke coverage

### DIFF
--- a/daedalus/trackers/__init__.py
+++ b/daedalus/trackers/__init__.py
@@ -40,6 +40,7 @@ class TrackerClient(Protocol):
         summary: str,
         state: str | None = None,
         metadata: dict[str, Any] | None = None,
+        comment_mode: str | None = None,
     ) -> dict[str, Any]: ...
 
 

--- a/daedalus/trackers/feedback.py
+++ b/daedalus/trackers/feedback.py
@@ -29,6 +29,14 @@ def feedback_enabled(config: dict[str, Any]) -> bool:
     return bool(cfg.get("enabled", False))
 
 
+def comment_mode(config: dict[str, Any]) -> str:
+    cfg = feedback_config(config)
+    mode = str(cfg.get("comment-mode") or cfg.get("comment_mode") or "append").strip().lower()
+    if mode in {"append", "upsert"}:
+        return mode
+    return "append"
+
+
 def event_included(config: dict[str, Any], event: str) -> bool:
     cfg = feedback_config(config)
     include = cfg.get("include")
@@ -105,4 +113,5 @@ def publish_tracker_feedback(
         summary=summary,
         state=target_state,
         metadata=metadata or {},
+        comment_mode=comment_mode(workflow_config),
     )

--- a/daedalus/trackers/github.py
+++ b/daedalus/trackers/github.py
@@ -13,6 +13,7 @@ _GITHUB_SLUG_RE = re.compile(
     r"^(?:(?P<host>[A-Za-z0-9.-]+(?::[0-9]+)?)/)?"
     r"(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)$"
 )
+_MARKER_VALUE_RE = re.compile(r"[^A-Za-z0-9_.:/-]+")
 
 
 def _github_slug_match(raw: str) -> re.Match[str] | None:
@@ -43,6 +44,27 @@ def github_name_with_owner_from_slug(slug: str | None) -> str | None:
     if not match:
         raise _github_slug_config_error()
     return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def _github_repo_parts_from_slug(slug: str | None) -> tuple[str, str, str] | None:
+    raw = str(slug or "").strip()
+    if not raw:
+        return None
+    match = _github_slug_match(raw)
+    if not match:
+        raise _github_slug_config_error()
+    return (
+        match.group("host") or "github.com",
+        match.group("owner"),
+        match.group("repo"),
+    )
+
+
+def _feedback_marker(*, event: str, metadata: dict[str, Any] | None) -> str:
+    workflow = str((metadata or {}).get("workflow") or "daedalus").strip() or "daedalus"
+    workflow = _MARKER_VALUE_RE.sub("_", workflow)
+    event_key = _MARKER_VALUE_RE.sub("_", str(event or "").strip() or "event")
+    return f"<!-- daedalus-feedback:{workflow}:{event_key} -->"
 
 
 def github_auth_success_accounts(
@@ -281,6 +303,92 @@ class GithubTrackerClient:
             return command
         return [*command, "--repo", self._repo_slug]
 
+    def _repo_api_parts(self) -> tuple[str, str, str]:
+        parts = _github_repo_parts_from_slug(self._repo_slug)
+        if parts is not None:
+            return parts
+        payload = self.repo_view_payload()
+        name_with_owner = str(payload.get("nameWithOwner") or "").strip()
+        fallback = _github_repo_parts_from_slug(name_with_owner)
+        if fallback is None:
+            raise TrackerConfigError("unable to resolve GitHub repository for feedback upsert")
+        return fallback
+
+    def _api_command(self, endpoint: str, *args: str) -> list[str]:
+        host, _owner, _repo = self._repo_api_parts()
+        command = ["gh", "api", endpoint, *args]
+        if host:
+            command.extend(["--hostname", host])
+        return command
+
+    def _issue_comments(self, issue_number: str) -> list[dict[str, Any]]:
+        _host, owner, repo = self._repo_api_parts()
+        payload = self._run_json(
+            self._api_command(
+                f"repos/{owner}/{repo}/issues/{issue_number}/comments",
+                "--paginate",
+                "--slurp",
+            ),
+            cwd=self._repo_path,
+        )
+        if not isinstance(payload, list):
+            raise RuntimeError("expected GitHub issue comments JSON list payload")
+        comments: list[dict[str, Any]] = []
+        for item in payload:
+            if isinstance(item, list):
+                comments.extend(comment for comment in item if isinstance(comment, dict))
+            elif isinstance(item, dict):
+                comments.append(item)
+        return comments
+
+    def _post_issue_comment(self, issue_number: str, body: str) -> str | None:
+        completed = self._run(
+            self._with_repo(["gh", "issue", "comment", issue_number, "--body", body]),
+            cwd=self._repo_path,
+        )
+        return (completed.stdout or "").strip() or None
+
+    def _upsert_issue_comment(self, issue_number: str, *, event: str, body: str, metadata: dict[str, Any] | None) -> dict[str, Any]:
+        marker = _feedback_marker(event=event, metadata=metadata)
+        body_with_marker = body if marker in body else body.rstrip() + "\n\n" + marker + "\n"
+        existing = next(
+            (
+                comment
+                for comment in self._issue_comments(issue_number)
+                if marker in str(comment.get("body") or "")
+            ),
+            None,
+        )
+        if existing is None:
+            return {
+                "action": "created",
+                "url": self._post_issue_comment(issue_number, body_with_marker),
+            }
+
+        comment_id = str(existing.get("id") or "").strip()
+        if not comment_id:
+            return {
+                "action": "created",
+                "url": self._post_issue_comment(issue_number, body_with_marker),
+            }
+        _host, owner, repo = self._repo_api_parts()
+        completed = self._run(
+            self._api_command(
+                f"repos/{owner}/{repo}/issues/comments/{comment_id}",
+                "--method",
+                "PATCH",
+                "-f",
+                f"body={body_with_marker}",
+                "--jq",
+                ".html_url",
+            ),
+            cwd=self._repo_path,
+        )
+        return {
+            "action": "updated",
+            "url": (completed.stdout or "").strip() or existing.get("html_url") or existing.get("url"),
+        }
+
     def list_issue_payloads(
         self,
         *,
@@ -434,14 +542,24 @@ class GithubTrackerClient:
         summary: str,
         state: str | None = None,
         metadata: dict[str, Any] | None = None,
+        comment_mode: str | None = None,
     ) -> dict[str, Any]:
         issue_number = _coerce_issue_number(issue_id)
         if issue_number is None:
             raise TrackerConfigError("issue_id is required when posting GitHub feedback")
-        completed = self._run(
-            self._with_repo(["gh", "issue", "comment", issue_number, "--body", body]),
-            cwd=self._repo_path,
-        )
+        mode = str(comment_mode or "append").strip().lower()
+        if mode == "upsert":
+            comment_result = self._upsert_issue_comment(
+                issue_number,
+                event=event,
+                body=body,
+                metadata=metadata,
+            )
+        else:
+            comment_result = {
+                "action": "created",
+                "url": self._post_issue_comment(issue_number, body),
+            }
         applied_state = None
         requested_state = str(state or "").strip().lower()
         if requested_state:
@@ -467,5 +585,7 @@ class GithubTrackerClient:
             "state": applied_state,
             "requested_state": state,
             "unsupported_state": requested_state if requested_state and applied_state is None else None,
-            "url": (completed.stdout or "").strip() or None,
+            "comment_mode": "upsert" if mode == "upsert" else "append",
+            "comment_action": comment_result["action"],
+            "url": comment_result["url"],
         }

--- a/daedalus/trackers/local_json.py
+++ b/daedalus/trackers/local_json.py
@@ -89,6 +89,7 @@ class LocalJsonTrackerClient:
         summary: str,
         state: str | None = None,
         metadata: dict[str, Any] | None = None,
+        comment_mode: str | None = None,
     ) -> dict[str, Any]:
         path = resolve_tracker_path(workflow_root=self._workflow_root, tracker_cfg=self._tracker_cfg)
         target_id = str(issue_id or "").strip()
@@ -116,7 +117,28 @@ class LocalJsonTrackerClient:
                 if state:
                     raw_issue["state"] = state
                     comment["state"] = state
-                comments.append(comment)
+                action = "created"
+                mode = str(comment_mode or "append").strip().lower()
+                if mode == "upsert":
+                    workflow = str((metadata or {}).get("workflow") or "").strip()
+                    for index, existing in enumerate(comments):
+                        if not isinstance(existing, dict) or existing.get("event") != event:
+                            continue
+                        existing_metadata = existing.get("metadata")
+                        existing_workflow = (
+                            str(existing_metadata.get("workflow") or "").strip()
+                            if isinstance(existing_metadata, dict)
+                            else ""
+                        )
+                        if workflow and existing_workflow and workflow != existing_workflow:
+                            continue
+                        comments[index] = comment
+                        action = "updated"
+                        break
+                    else:
+                        comments.append(comment)
+                else:
+                    comments.append(comment)
                 raw_issue["comments"] = comments
                 raw_issue["updated_at"] = now_iso
                 _write_issue_payload(path, payload)
@@ -126,6 +148,8 @@ class LocalJsonTrackerClient:
                     "issue_id": target_id,
                     "event": event,
                     "state": state,
+                    "comment_mode": "upsert" if mode == "upsert" else "append",
+                    "comment_action": action,
                     "comment_count": len(comments),
                 }
 

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -328,7 +328,7 @@ definitions:
       enabled: {type: boolean}
       comment-mode:
         type: string
-        enum: [append]
+        enum: [append, upsert]
       include:
         type: array
         items: {type: string}

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -235,7 +235,7 @@ definitions:
       enabled: {type: boolean}
       comment-mode:
         type: string
-        enum: [append]
+        enum: [append, upsert]
       include:
         type: array
         items: {type: string}

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -48,7 +48,7 @@ comment objects and can update local issue state.
 ```yaml
 tracker-feedback:
   enabled: true
-  comment-mode: append
+  comment-mode: append  # use upsert to keep one current comment per event
   include:
     - dispatch-implementation-turn
     - internal-review-completed

--- a/docs/concepts/tracker-feedback.md
+++ b/docs/concepts/tracker-feedback.md
@@ -16,7 +16,7 @@ It is the shared replacement for workflow-specific GitHub comment settings.
 ```yaml
 tracker-feedback:
   enabled: true
-  comment-mode: append
+  comment-mode: append  # append | upsert
   include:
     - issue.selected
     - issue.running
@@ -32,12 +32,17 @@ tracker-feedback:
 `internal-review-completed`, `publish-ready-pr`, `push-pr-update`,
 `merge-and-promote`, and operator-attention events.
 
+`comment-mode: append` writes a new tracker comment for every included event.
+`comment-mode: upsert` keeps one current Daedalus comment per workflow event
+and updates it on later runs; the durable audit trail still lives in Daedalus
+SQLite/events.
+
 ## Tracker Behavior
 
 | Tracker | Feedback behavior |
 |---|---|
-| GitHub | Posts issue comments through `gh issue comment`; applies configured `open`/`closed` state updates and ignores other tracker states. |
-| `local-json` | Appends `comments[]`, updates `updated_at`, and applies configured state changes. |
+| GitHub | Posts issue comments through `gh issue comment`, or updates marked comments when `comment-mode: upsert`; applies configured `open`/`closed` state updates and ignores other tracker states. |
+| `local-json` | Appends or upserts `comments[]`, updates `updated_at`, and applies configured state changes. |
 | Linear | Adapter exists for reads; feedback publishing is deferred. |
 
 ## Failure Handling

--- a/docs/operator/github-smoke.md
+++ b/docs/operator/github-smoke.md
@@ -2,9 +2,9 @@
 
 Use this only against a repository where temporary issues and comments are
 acceptable. The test creates one labeled issue, lets `issue-runner` select and
-dispatch it, forces one runtime failure, verifies retry recovery, writes tracker
-feedback comments, closes the issue through `tracker-feedback`, and verifies
-terminal cleanup.
+dispatch it, forces one runtime failure, verifies retry recovery, writes
+upserted tracker feedback comments, closes the issue through
+`tracker-feedback`, and verifies terminal cleanup.
 
 ## Prerequisites
 
@@ -45,6 +45,8 @@ to be a git checkout.
 - a supervised worker dispatches from the selected issue
 - tracker feedback writes issue comments for selected, dispatched, running,
   failed, retry scheduled, and completed stages
+- `tracker-feedback.comment-mode: upsert` avoids duplicate Daedalus comments
+  when selected/running stages repeat during retry recovery
 - scheduler state records failure retry/backoff and clears it after recovery
 - `tracker-feedback.state-updates.on-completed: closed` closes the GitHub issue
 - terminal GitHub state clears retry state and removes the issue workspace

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -213,6 +213,21 @@ flags during `install` or `up`, for example `--ws-token-file
 /absolute/path/to/token`. See [Codex app-server operations](codex-app-server.md)
 for external-mode diagnostics and troubleshooting.
 
+## Run the local demo issue
+
+The default `issue-runner` bootstrap seeds `config/issues.json` with one safe
+local issue. Before wiring GitHub or another tracker, run the service loop once
+in the foreground:
+
+```bash
+hermes daedalus service-loop --max-iterations 2 --interval-seconds 1 --json
+hermes daedalus status --format json
+```
+
+This exercises the same engine path as the user service: it selects the local
+issue, dispatches the configured runtime, appends tracker feedback comments,
+and marks the issue `done` after a successful run.
+
 ## Manual low-level path
 
 If you want to inspect or script each step separately, the lower-level commands

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -98,7 +98,7 @@ Feedback configuration is tracker-neutral. GitHub receives issue comments.
 ```yaml
 tracker-feedback:
   enabled: true
-  comment-mode: append
+  comment-mode: append  # append | upsert
   include: [issue.selected, issue.running, issue.completed, issue.failed, issue.retry_scheduled]
   state-updates:
     enabled: true
@@ -106,6 +106,9 @@ tracker-feedback:
     on-completed: done
     on-failed: todo
 ```
+
+Use `comment-mode: upsert` for public tracker issues where you want one current
+Daedalus status comment per event instead of an append-only issue timeline.
 
 `issue-runner` composes the shared `trackers/` clients with workflow-specific
 eligibility, ordering, retry, and workspace policy.

--- a/tests/test_github_issue_runner_smoke.py
+++ b/tests/test_github_issue_runner_smoke.py
@@ -136,7 +136,7 @@ def test_live_github_issue_runner_feedback_retry_recovery_and_cleanup(tmp_path):
             },
             "tracker-feedback": {
                 "enabled": True,
-                "comment-mode": "append",
+                "comment-mode": "upsert",
                 "include": [
                     "issue.selected",
                     "issue.dispatched",
@@ -219,6 +219,7 @@ def test_live_github_issue_runner_feedback_retry_recovery_and_cleanup(tmp_path):
             "issue.completed",
         ]:
             assert any(f"Daedalus update: {event}" in body for body in comment_bodies), event
+            assert sum(f"daedalus-feedback:issue-runner:{event}" in body for body in comment_bodies) == 1
 
         cleanup_result = None
         for _ in range(10):

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -76,6 +76,57 @@ def test_public_onboarding_path_install_bootstrap_defaults_to_issue_runner_and_s
     assert status_payload["contractPath"] == str(repo / "WORKFLOW.md")
     assert status_payload["tracker"]["kind"] == "local-json"
     assert status_payload["tracker"]["issueCount"] >= 1
+    assert status_payload["tracker"]["eligibleCount"] == 1
+
+    validate_payload = json.loads(tools.execute_raw_args("validate --json"))
+    assert validate_payload["ok"] is True
+    assert validate_payload["workflow"] == "issue-runner"
+
+    doctor_payload = json.loads(tools.execute_raw_args("doctor --json"))
+    assert doctor_payload["ok"] is True
+    assert doctor_payload["workflow"] == "issue-runner"
+
+    service_loop_out = tools.execute_raw_args("service-loop --max-iterations 2 --interval-seconds 1 --json")
+    service_loop_payload = json.loads(service_loop_out)
+    assert service_loop_payload["workflow"] == "issue-runner"
+    assert service_loop_payload["service_mode"] == "active"
+    assert service_loop_payload["loop_status"] == "completed"
+    assert service_loop_payload["iterations"] == 2
+    assert service_loop_payload["last_result"]["ok"] is True
+
+    issues_payload = json.loads((workflow_root / "config" / "issues.json").read_text(encoding="utf-8"))
+    issue = issues_payload["issues"][0]
+    assert issue["id"] == "ISSUE-1"
+    assert issue["state"] == "done"
+    feedback_events = [comment["event"] for comment in issue["comments"]]
+    assert feedback_events[0] == "issue.selected"
+    assert set(feedback_events) == {
+        "issue.selected",
+        "issue.dispatched",
+        "issue.running",
+        "issue.completed",
+    }
+    assert feedback_events[-1] == "issue.completed"
+    completed_comment = issue["comments"][-1]
+    assert completed_comment["state"] == "done"
+    assert "completed this issue run successfully" in completed_comment["summary"]
+
+    completed_status = json.loads(tools.execute_raw_args("status --format json"))
+    assert completed_status["tracker"]["eligibleCount"] == 0
+    assert completed_status["selectedIssue"] is None
+    assert completed_status["lastRun"]["ok"] is True
+    assert completed_status["lastRun"]["issue"]["id"] == "ISSUE-1"
+    assert completed_status["lastRun"]["results"][0]["runtimeKind"] == "hermes-agent"
+
+    runs_payload = json.loads(tools.execute_raw_args("runs --json"))
+    assert runs_payload["workflow"] == "issue-runner"
+    assert runs_payload["counts"]["running"] == 0
+    assert any(run["status"] == "completed" for run in runs_payload["runs"])
+
+    events_payload = json.loads(tools.execute_raw_args("events --type issue_runner.tick.completed --json"))
+    assert events_payload["workflow"] == "issue-runner"
+    assert events_payload["counts"]["shown"] >= 1
+    assert events_payload["events"][0]["work_id"] == "ISSUE-1"
 
     assert ["systemctl", "--user", "daemon-reload"] in captured_commands
     assert ["systemctl", "--user", "enable", "daedalus-active@attmous-daedalus-issue-runner.service"] in captured_commands

--- a/tests/test_trackers_feedback.py
+++ b/tests/test_trackers_feedback.py
@@ -2,6 +2,35 @@ import json
 import subprocess
 
 
+def test_publish_tracker_feedback_passes_configured_comment_mode():
+    from trackers.feedback import publish_tracker_feedback
+
+    calls = []
+
+    class Tracker:
+        def post_feedback(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "event": kwargs["event"], "comment_mode": kwargs["comment_mode"]}
+
+    result = publish_tracker_feedback(
+        tracker_client=Tracker(),
+        workflow_config={
+            "tracker-feedback": {
+                "enabled": True,
+                "comment-mode": "upsert",
+                "include": ["issue.running"],
+            }
+        },
+        issue={"id": "ISSUE-1"},
+        event="issue.running",
+        summary="Runtime started.",
+        metadata={"workflow": "issue-runner"},
+    )
+
+    assert result["comment_mode"] == "upsert"
+    assert calls[0]["comment_mode"] == "upsert"
+
+
 def test_local_json_feedback_appends_comment_and_updates_state(tmp_path):
     from trackers.local_json import LocalJsonTrackerClient
 
@@ -75,6 +104,60 @@ def test_local_json_feedback_preserves_top_level_list_shape(tmp_path):
     assert payload[0]["comments"][0]["event"] == "issue.completed"
 
 
+def test_local_json_feedback_upserts_comment_by_workflow_and_event(tmp_path):
+    from trackers.local_json import LocalJsonTrackerClient
+
+    issues_path = tmp_path / "config" / "issues.json"
+    issues_path.parent.mkdir()
+    issues_path.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "id": "ISSUE-1",
+                        "identifier": "ISSUE-1",
+                        "title": "Demo",
+                        "state": "todo",
+                        "comments": [
+                            {
+                                "at": "2026-04-30T00:00:00Z",
+                                "event": "issue.running",
+                                "summary": "Old summary.",
+                                "body": "Old body.",
+                                "metadata": {"workflow": "issue-runner"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    client = LocalJsonTrackerClient(
+        workflow_root=tmp_path,
+        tracker_cfg={"kind": "local-json", "path": "config/issues.json"},
+    )
+
+    result = client.post_feedback(
+        issue_id="ISSUE-1",
+        event="issue.running",
+        body="New body.",
+        summary="New summary.",
+        state="in-progress",
+        metadata={"workflow": "issue-runner", "run_id": "run-2"},
+        comment_mode="upsert",
+    )
+
+    assert result["comment_mode"] == "upsert"
+    assert result["comment_action"] == "updated"
+    payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    issue = payload["issues"][0]
+    assert issue["state"] == "in-progress"
+    assert len(issue["comments"]) == 1
+    assert issue["comments"][0]["summary"] == "New summary."
+    assert issue["comments"][0]["metadata"]["run_id"] == "run-2"
+
+
 def test_github_feedback_posts_issue_comment_with_repo_slug(tmp_path, monkeypatch):
     from trackers import github as github_tracker
 
@@ -125,4 +208,139 @@ def test_github_feedback_posts_issue_comment_with_repo_slug(tmp_path, monkeypatc
             "capture_output": True,
             "text": True,
         }
+    ]
+
+
+def test_github_feedback_upsert_creates_marked_comment(tmp_path, monkeypatch):
+    from trackers import github as github_tracker
+
+    calls = []
+
+    def fake_run_json(command, *, cwd=None):
+        calls.append({"kind": "json", "command": command, "cwd": cwd})
+        return [[]]
+
+    def fake_run(command, *, cwd=None, check=None, capture_output=None, text=None):
+        calls.append({"kind": "run", "command": command, "cwd": cwd})
+        return subprocess.CompletedProcess(command, 0, stdout="https://github.example/comment/1\n", stderr="")
+
+    client = github_tracker.GithubTrackerClient(
+        workflow_root=tmp_path,
+        tracker_cfg={"kind": "github", "github_slug": "attmous/daedalus"},
+        run=fake_run,
+        run_json=fake_run_json,
+    )
+
+    result = client.post_feedback(
+        issue_id="42",
+        event="issue.running",
+        body="Runtime started.",
+        summary="Runtime started.",
+        metadata={"workflow": "issue-runner"},
+        comment_mode="upsert",
+    )
+
+    assert result["comment_mode"] == "upsert"
+    assert result["comment_action"] == "created"
+    assert calls[0]["command"] == [
+        "gh",
+        "api",
+        "repos/attmous/daedalus/issues/42/comments",
+        "--paginate",
+        "--slurp",
+        "--hostname",
+        "github.com",
+    ]
+    created_body = calls[1]["command"][5]
+    assert "Runtime started." in created_body
+    assert "<!-- daedalus-feedback:issue-runner:issue.running -->" in created_body
+
+
+def test_github_feedback_upsert_updates_existing_marked_comment_and_applies_state(tmp_path):
+    from workflows.issue_runner.tracker import build_tracker_client
+
+    commands = []
+
+    class Completed:
+        stdout = "https://github.example/comment/1\n"
+        stderr = ""
+        returncode = 0
+
+    def fake_run_json(command, cwd=None):
+        commands.append(("json", command, cwd))
+        return [
+            [
+                {
+                    "id": 123,
+                    "body": "Old body.\n\n<!-- daedalus-feedback:issue-runner:issue.completed -->\n",
+                    "html_url": "https://github.example/comment/old",
+                }
+            ]
+        ]
+
+    def fake_run(command, cwd=None):
+        commands.append(("run", command, cwd))
+        return Completed()
+
+    client = build_tracker_client(
+        workflow_root=tmp_path,
+        tracker_cfg={
+            "kind": "github",
+            "github_slug": "attmous/daedalus",
+            "active_states": ["open"],
+            "terminal_states": ["closed"],
+        },
+        run=fake_run,
+        run_json=fake_run_json,
+    )
+
+    result = client.post_feedback(
+        issue_id="42",
+        event="issue.completed",
+        body="Completed by Daedalus.",
+        summary="Completed by Daedalus.",
+        state="closed",
+        metadata={"workflow": "issue-runner"},
+        comment_mode="upsert",
+    )
+
+    assert result["ok"] is True
+    assert result["state"] == "closed"
+    assert result["comment_action"] == "updated"
+    assert commands == [
+        (
+            "json",
+            [
+                "gh",
+                "api",
+                "repos/attmous/daedalus/issues/42/comments",
+                "--paginate",
+                "--slurp",
+                "--hostname",
+                "github.com",
+            ],
+            None,
+        ),
+        (
+            "run",
+            [
+                "gh",
+                "api",
+                "repos/attmous/daedalus/issues/comments/123",
+                "--method",
+                "PATCH",
+                "-f",
+                "body=Completed by Daedalus.\n\n<!-- daedalus-feedback:issue-runner:issue.completed -->\n",
+                "--jq",
+                ".html_url",
+                "--hostname",
+                "github.com",
+            ],
+            None,
+        ),
+        (
+            "run",
+            ["gh", "issue", "close", "42", "--repo", "attmous/daedalus"],
+            None,
+        ),
     ]


### PR DESCRIPTION
## Summary

Adds shared `tracker-feedback.comment-mode` handling with `append` and `upsert` modes. GitHub feedback can now update marked Daedalus comments through `gh api`, while `local-json` can upsert matching workflow/event comments for parity.

This also tightens the public smoke path: the default local `issue-runner` onboarding smoke now runs the seeded issue through the service loop to `done`, and the opt-in GitHub smoke verifies upserted comments during retry recovery.

## Validation

- `pytest -q tests/test_trackers_feedback.py tests/test_github_issue_runner_smoke.py tests/test_public_onboarding_smoke.py`
- `pytest -q`

Full suite result: `856 passed, 9 skipped`. The real GitHub smoke remains opt-in unless `DAEDALUS_GITHUB_SMOKE_REPO` is set.