### PR TITLE
[codex] Fix active workflow smoke blockers

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -48,6 +48,7 @@ from workflows.runtime_presets import (
     runtime_binding_checks,
 )
 from workflows.runtime_matrix import build_runtime_matrix_report
+from workflows.change_delivery.storage import ensure_change_delivery_state_files
 from workflows.shared.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -2717,6 +2718,9 @@ def scaffold_workflow_root(
         encoding="utf-8",
     )
     write_workflow_contract_pointer(root, contract_path)
+    state_files_result: dict[str, Any] | None = None
+    if workflow_name == "change-delivery":
+        state_files_result = ensure_change_delivery_state_files(root, config)
     if workflow_name == "issue-runner":
         issues_template = PLUGIN_DIR / "workflows" / "issue_runner" / "issues.template.json"
         issues_path = root / "config" / "issues.json"
@@ -2738,6 +2742,7 @@ def scaffold_workflow_root(
         "workflow_contract_pointer_path": str(workflow_contract_pointer_path(root)),
         "renamed_contract_paths": renamed_contract_paths,
         "renamed_contract_source_paths": renamed_contract_source_paths,
+        "state_files": state_files_result,
     }
 
 

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -40,6 +40,7 @@ from workflows.change_delivery.event_taxonomy import (
     canonicalize as canonicalize_event_type,
 )
 from workflows.change_delivery.status import build_status as build_workflow_status
+from workflows.change_delivery.storage import ensure_change_delivery_state_files
 import sys
 
 def _load_migration_module():
@@ -316,6 +317,12 @@ def init_daedalus_db(*, workflow_root: Path, project_key: str) -> dict[str, Any]
     # 1. Filesystem-level migration (renames relay-era files if present).
     #    Done before opening the DB so we don't open a stale empty file.
     _load_migration_module().migrate_filesystem_state(workflow_root)
+
+    try:
+        contract = load_workflow_contract(workflow_root)
+        state_files = ensure_change_delivery_state_files(workflow_root, contract.config)
+    except (FileNotFoundError, WorkflowContractError, OSError, UnicodeDecodeError):
+        state_files = ensure_change_delivery_state_files(workflow_root)
 
     # 2. Resolve canonical paths and open the DB.
     paths = runtime_paths(workflow_root)
@@ -607,7 +614,7 @@ def init_daedalus_db(*, workflow_root: Path, project_key: str) -> dict[str, Any]
             ),
         )
         conn.commit()
-        return {"ok": True, "db_path": str(db_path), "project_key": project_key}
+        return {"ok": True, "db_path": str(db_path), "project_key": project_key, "state_files": state_files}
     finally:
         conn.close()
 
@@ -1004,8 +1011,10 @@ def _merge_state_from_status(legacy_status: dict[str, Any]) -> str:
 
 def _required_review_flags(legacy_status: dict[str, Any]) -> tuple[int, int]:
     reviews = legacy_status.get("reviews") or {}
-    internal_required = 1 if (reviews.get("claudeCode") or {}).get("required") else 0
-    external_required = 1 if (reviews.get("codexCloud") or {}).get("required") else 0
+    internal_review = reviews.get("internalReview") or {}
+    external_review = reviews.get("externalReview") or {}
+    internal_required = 1 if internal_review.get("required") else 0
+    external_required = 1 if external_review.get("required") else 0
     return internal_required, external_required
 
 
@@ -1145,11 +1154,11 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
                 }, sort_keys=True), now_iso, now_iso,
             ),
         )
-        for reviewer_scope, legacy_key, reviewer_role in (
-            ("internal", "claudeCode", "Internal_Reviewer_Agent"),
-            ("external", "codexCloud", "External_Reviewer_Agent"),
+        for reviewer_scope, review_key, reviewer_role in (
+            ("internal", "internalReview", "Internal_Reviewer_Agent"),
+            ("external", "externalReview", "External_Reviewer_Agent"),
         ):
-            review = reviews.get(legacy_key) or {}
+            review = reviews.get(review_key) or {}
             if not review:
                 continue
             review_id = f"review:{lane_id}:{reviewer_scope}"
@@ -1186,7 +1195,7 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
                     reviewer_scope,
                     reviewer_role,
                     review.get("agentName") or reviewer_role,
-                    legacy_key,
+                    review_key,
                     review.get("model"),
                     review.get("status") or "not_started",
                     review.get("verdict"),
@@ -1200,7 +1209,13 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
                     review.get("summary"),
                     review.get("requestedAt"),
                     review.get("updatedAt") if review.get("status") == "completed" else None,
-                    json.dumps({"source": "legacy-status-ingest", "legacyKey": legacy_key}, sort_keys=True),
+                    json.dumps(
+                        {
+                            "source": "legacy-status-ingest",
+                            "reviewKey": review_key,
+                        },
+                        sort_keys=True,
+                    ),
                     now_iso,
                     now_iso,
                 ),
@@ -1324,8 +1339,7 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
         workflow_state == "awaiting_claude_prepublish"
         and not active_pr_number
         and lane_row.get("required_internal_review")
-        and internal_review
-        and internal_review.get("status") == "pending"
+        and (internal_review is None or internal_review.get("status") in {None, "", "pending", "not_started"})
         and current_head_sha
     ):
         return [{
@@ -2357,7 +2371,7 @@ def _semantic_completion_events_for_action(
     impl_status = (post_legacy_status or {}).get("implementation") or {}
     open_pr_status = (post_legacy_status or {}).get("openPr") or {}
     reviews = (post_legacy_status or {}).get("reviews") or {}
-    internal_review = reviews.get("claudeCode") or {}
+    internal_review = reviews.get("internalReview") or {}
     events: list[dict[str, Any]] = []
     if action_type in {"dispatch_implementation_turn", "dispatch_repair_handoff", "restart_actor_session"} and result.get("dispatched"):
         local_head_sha = impl_status.get("localHeadSha") or lane_after.get("current_head_sha") or lane_before.get("current_head_sha")
@@ -2923,6 +2937,7 @@ def _analyze_ambiguous_failure(
     failure_class: str,
     failure_summary: str,
     now_iso: str,
+    project_key: str,
     failure_analyst: Any | None,
 ) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
     analysis_input = _build_failure_analysis_input(
@@ -2942,7 +2957,7 @@ def _analyze_ambiguous_failure(
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
-            "project_key": _project_key_for(workflow_root),
+            "project_key": project_key,
             "lane_id": action.get("lane_id"),
             "issue_number": None,
             "head_sha": action.get("target_head_sha"),
@@ -2988,7 +3003,7 @@ def _analyze_ambiguous_failure(
             "event_version": 1,
             "created_at": now_iso,
             "producer": "Workflow_Orchestrator",
-            "project_key": _project_key_for(workflow_root),
+            "project_key": project_key,
             "lane_id": action.get("lane_id"),
             "issue_number": None,
             "head_sha": action.get("target_head_sha"),
@@ -3291,6 +3306,7 @@ def execute_requested_action(
                     failure_class=raw_failure_class,
                     failure_summary=failure_summary,
                     now_iso=now_iso,
+                    project_key=_project_key_for(workflow_root),
                     failure_analyst=failure_analyst,
                 )
                 recovery["metadata"] = {

--- a/daedalus/runtimes/claude_cli.py
+++ b/daedalus/runtimes/claude_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import time
 from pathlib import Path
 
@@ -20,6 +21,26 @@ class ClaudeCliRuntime:
 
     def last_activity_ts(self) -> float | None:
         return self._last_activity
+
+    def _run_process(self, command: list[str], *, worktree: Path, env: dict | None = None):
+        kwargs = {"cwd": worktree, "timeout": self._timeout}
+        if env is not None:
+            kwargs["env"] = env
+        try:
+            signature = inspect.signature(self._run)
+        except (TypeError, ValueError):
+            supported_kwargs = kwargs
+        else:
+            accepts_var_kwargs = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD
+                for param in signature.parameters.values()
+            )
+            supported_kwargs = (
+                kwargs
+                if accepts_var_kwargs
+                else {key: value for key, value in kwargs.items() if key in signature.parameters}
+            )
+        return self._run(command, **supported_kwargs)
 
     def ensure_session(
         self,
@@ -51,7 +72,7 @@ class ClaudeCliRuntime:
             prompt,
         ]
         self._record_activity()
-        completed = self._run(cmd, cwd=worktree, timeout=self._timeout)
+        completed = self._run_process(cmd, worktree=worktree)
         self._record_activity()
         return getattr(completed, "stdout", "") or ""
 
@@ -75,6 +96,6 @@ class ClaudeCliRuntime:
         env: dict | None = None,
     ) -> str:
         self._record_activity()
-        completed = self._run(command_argv, cwd=worktree, timeout=self._timeout, env=env)
+        completed = self._run_process(command_argv, worktree=worktree, env=env)
         self._record_activity()
         return getattr(completed, "stdout", "") or ""

--- a/daedalus/workflows/change_delivery/migrations.py
+++ b/daedalus/workflows/change_delivery/migrations.py
@@ -9,8 +9,8 @@ Cloud). Phases A-C made runtimes/reviewers/webhooks pluggable; this
 migration removes the last operator-visible coupling to provider names.
 
 `migrate_persisted_ledger(path)` runs idempotently on workspace setup.
-`get_review(reviews_dict, new_key)` reads new key with legacy fallback
-so an unmigrated ledger still works for one release.
+`get_review(reviews_dict, new_key)` reads canonical keys only; old keys are
+removed by migration instead of remaining valid runtime input.
 """
 from __future__ import annotations
 

--- a/daedalus/workflows/change_delivery/storage.py
+++ b/daedalus/workflows/change_delivery/storage.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _resolve_storage_path(workflow_root: Path, value: Any, default: str) -> Path:
+    raw = str(value or default).strip() or default
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    return (Path(workflow_root).resolve() / path).resolve()
+
+
+def change_delivery_storage_paths(
+    workflow_root: Path,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    storage = (config or {}).get("storage") or {}
+    return {
+        "ledger": _resolve_storage_path(workflow_root, storage.get("ledger"), "memory/workflow-status.json"),
+        "health": _resolve_storage_path(workflow_root, storage.get("health"), "memory/workflow-health.json"),
+        "audit_log": _resolve_storage_path(workflow_root, storage.get("audit-log"), "memory/workflow-audit.jsonl"),
+        "scheduler": _resolve_storage_path(workflow_root, storage.get("scheduler"), "memory/workflow-scheduler.json"),
+    }
+
+
+def default_idle_ledger(*, now_iso: str | None = None) -> dict[str, Any]:
+    now_iso = now_iso or _now_iso()
+    return {
+        "schemaVersion": 6,
+        "activeLane": None,
+        "workflowIdle": True,
+        "workflowState": "idle",
+        "reviewState": "idle",
+        "reviewLoopState": "idle",
+        "branch": None,
+        "openActiveLanePr": None,
+        "blockedReason": None,
+        "approval": {
+            "status": "not-approved",
+            "approvedAt": None,
+            "approvedHeadSha": None,
+            "pendingReason": None,
+        },
+        "reviews": {},
+        "repairBrief": None,
+        "updatedAt": now_iso,
+    }
+
+
+def default_health_payload(*, now_iso: str | None = None) -> dict[str, Any]:
+    now_iso = now_iso or _now_iso()
+    return {
+        "workflow": "change-delivery",
+        "health": "unknown",
+        "ledger": {
+            "workflowState": "idle",
+            "reviewState": "idle",
+            "workflowIdle": True,
+        },
+        "updatedAt": now_iso,
+    }
+
+
+def default_scheduler_payload(*, now_iso: str | None = None) -> dict[str, Any]:
+    now_iso = now_iso or _now_iso()
+    return {
+        "workflow": "change-delivery",
+        "updatedAt": now_iso,
+        "running": [],
+        "retry_queue": [],
+        "codex_threads": {},
+        "codex_totals": {},
+    }
+
+
+def _write_json_if_missing(path: Path, payload: dict[str, Any]) -> bool:
+    if path.exists():
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return True
+
+
+def ensure_change_delivery_state_files(
+    workflow_root: Path,
+    config: dict[str, Any] | None = None,
+    *,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    now_iso = now_iso or _now_iso()
+    paths = change_delivery_storage_paths(workflow_root, config)
+    created = {
+        "ledger": _write_json_if_missing(paths["ledger"], default_idle_ledger(now_iso=now_iso)),
+        "health": _write_json_if_missing(paths["health"], default_health_payload(now_iso=now_iso)),
+        "scheduler": _write_json_if_missing(paths["scheduler"], default_scheduler_payload(now_iso=now_iso)),
+        "audit_log": False,
+    }
+    audit_log = paths["audit_log"]
+    if not audit_log.exists():
+        audit_log.parent.mkdir(parents=True, exist_ok=True)
+        audit_log.touch()
+        created["audit_log"] = True
+    return {
+        "ok": True,
+        "paths": {key: str(path) for key, path in paths.items()},
+        "created": created,
+    }

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -17,6 +17,7 @@ from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
 from engine.storage import write_text_atomic as _write_text
 from workflows.change_delivery.migrations import get_ledger_field
+from workflows.change_delivery.storage import ensure_change_delivery_state_files
 from workflows.change_delivery.runtimes import build_runtimes
 from workflows.shared.paths import runtime_paths
 from code_hosts import build_code_host_client
@@ -428,6 +429,15 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     hermes_cron_jobs_path = Path(config.get("hermesCronJobsPath") or (Path.home() / ".hermes/cron/jobs.json"))
     ledger_path = Path(config["ledgerPath"])
     from workflows.change_delivery.migrations import migrate_persisted_ledger
+    fallback_storage_config = {
+        "storage": {
+            "ledger": str(ledger_path),
+            "health": str(config["healthPath"]),
+            "audit-log": str(config["auditLogPath"]),
+            "scheduler": str(config.get("schedulerPath") or (workspace_root / "memory/workflow-scheduler.json")),
+        }
+    }
+    ensure_change_delivery_state_files(workspace_root, yaml_cfg or fallback_storage_config)
     migrate_persisted_ledger(ledger_path)
     health_path = Path(config["healthPath"])
     audit_log_path = Path(config["auditLogPath"])
@@ -527,7 +537,10 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         return hermes_cron_jobs_path if engine_owner == "hermes" else cron_jobs_path
 
     def load_jobs() -> dict[str, Any]:
-        return _load_json(_jobs_store_path())
+        try:
+            return _load_json(_jobs_store_path())
+        except FileNotFoundError:
+            return {"jobs": []}
 
     def load_ledger() -> dict[str, Any]:
         return _load_json(ledger_path)

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -102,6 +102,26 @@ def test_init_daedalus_db_migrates_execution_control_to_clean_schema(runtime_mod
     assert json.loads(row[3]) == {"source": "legacy"}
 
 
+def test_init_daedalus_db_seeds_change_delivery_state_files(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+
+    result = runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+
+    ledger_path = workflow_root / "memory" / "workflow-status.json"
+    health_path = workflow_root / "memory" / "workflow-health.json"
+    audit_path = workflow_root / "memory" / "workflow-audit.jsonl"
+    scheduler_path = workflow_root / "memory" / "workflow-scheduler.json"
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    scheduler = json.loads(scheduler_path.read_text(encoding="utf-8"))
+
+    assert result["state_files"]["created"]["ledger"] is True
+    assert ledger["workflowState"] == "idle"
+    assert ledger["workflowIdle"] is True
+    assert json.loads(health_path.read_text(encoding="utf-8"))["workflow"] == "change-delivery"
+    assert audit_path.read_text(encoding="utf-8") == ""
+    assert scheduler["workflow"] == "change-delivery"
+
+
 def test_ingest_legacy_status_preserves_active_action_operator_attention(runtime_module, tmp_path):
     workflow_root = tmp_path / "workflow"
     paths = runtime_module._runtime_paths(workflow_root)
@@ -160,6 +180,236 @@ def test_ingest_legacy_status_preserves_active_action_operator_attention(runtime
 
     assert required == 1
     assert reason == "active-action-failed:dispatch_implementation_turn"
+
+
+def test_ingest_legacy_status_uses_canonical_internal_review_for_active_request(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    legacy_status = {
+        "activeLane": {"number": 221, "url": "https://example.com/issues/221", "title": "Issue 221", "labels": []},
+        "repo": "/tmp/repo",
+        "implementation": {
+            "worktree": "/tmp/issue-221",
+            "branch": "codex/issue-221-test",
+            "localHeadSha": "abc123",
+            "laneState": {"implementation": {}, "pr": {"lastPublishedHeadSha": None}},
+            "activeSessionHealth": {"healthy": False, "lastUsedAt": None},
+            "sessionActionRecommendation": {"action": "restart-session"},
+        },
+        "reviews": {
+            "internalReview": {
+                "required": True,
+                "status": "pending",
+                "reviewScope": "local-prepublish",
+                "requestedHeadSha": "abc123",
+                "model": "claude-sonnet-4-6",
+            },
+            "externalReview": {"required": False, "status": "not_started"},
+        },
+        "ledger": {"workflowState": "awaiting_claude_prepublish", "reviewState": "awaiting_claude_prepublish", "repairBrief": None},
+        "derivedReviewLoopState": "awaiting_reviews",
+        "derivedMergeBlocked": False,
+        "derivedMergeBlockers": [],
+        "openPr": None,
+        "activeLaneError": None,
+        "staleLaneReasons": [],
+        "nextAction": {"type": "run_internal_review", "reason": "prepublish-claude-required"},
+    }
+
+    runtime_module.ingest_legacy_status(
+        workflow_root=workflow_root,
+        legacy_status=legacy_status,
+        now_iso="2026-04-22T00:01:00Z",
+    )
+    actions = runtime_module.request_active_actions_for_lane(
+        workflow_root=workflow_root,
+        lane_id="lane:221",
+        now_iso="2026-04-22T00:02:00Z",
+    )
+
+    conn = sqlite3.connect(paths["db_path"])
+    try:
+        lane_required = conn.execute(
+            "SELECT required_internal_review FROM lanes WHERE lane_id=?",
+            ("lane:221",),
+        ).fetchone()[0]
+        review_row = conn.execute(
+            "SELECT status, backend_type, requested_head_sha FROM lane_reviews WHERE review_id=?",
+            ("review:lane:221:internal",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert lane_required == 1
+    assert review_row == ("pending", "internalReview", "abc123")
+    assert actions[0]["action_type"] == "request_internal_review"
+
+
+def test_ingest_legacy_status_ignores_old_review_status_keys(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    legacy_status = {
+        "activeLane": {"number": 221, "url": "https://example.com/issues/221", "title": "Issue 221", "labels": []},
+        "repo": "/tmp/repo",
+        "implementation": {
+            "worktree": "/tmp/issue-221",
+            "branch": "codex/issue-221-test",
+            "localHeadSha": "abc123",
+            "laneState": {"implementation": {}, "pr": {"lastPublishedHeadSha": None}},
+            "activeSessionHealth": {"healthy": False, "lastUsedAt": None},
+            "sessionActionRecommendation": {"action": "restart-session"},
+        },
+        "reviews": {
+            "claudeCode": {"required": True, "status": "pending", "requestedHeadSha": "abc123"},
+            "codexCloud": {"required": True, "status": "pending", "requestedHeadSha": "abc123"},
+        },
+        "ledger": {"workflowState": "awaiting_claude_prepublish", "reviewState": "awaiting_claude_prepublish", "repairBrief": None},
+        "derivedReviewLoopState": "awaiting_reviews",
+        "derivedMergeBlocked": False,
+        "derivedMergeBlockers": [],
+        "openPr": None,
+        "activeLaneError": None,
+        "staleLaneReasons": [],
+        "nextAction": {"type": "run_internal_review", "reason": "prepublish-claude-required"},
+    }
+
+    runtime_module.ingest_legacy_status(
+        workflow_root=workflow_root,
+        legacy_status=legacy_status,
+        now_iso="2026-04-22T00:01:00Z",
+    )
+
+    conn = sqlite3.connect(paths["db_path"])
+    try:
+        required_flags = conn.execute(
+            "SELECT required_internal_review, required_external_review FROM lanes WHERE lane_id=?",
+            ("lane:221",),
+        ).fetchone()
+        review_count = conn.execute(
+            "SELECT COUNT(*) FROM lane_reviews WHERE lane_id=?",
+            ("lane:221",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert required_flags == (0, 0)
+    assert review_count == 0
+
+
+def test_derive_shadow_actions_requests_internal_review_without_review_row(runtime_module):
+    actions = runtime_module.derive_shadow_actions_for_lane(
+        lane_row={
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "workflow_state": "awaiting_claude_prepublish",
+            "required_internal_review": 1,
+            "active_pr_number": None,
+            "current_head_sha": "abc123",
+        },
+        reviews=[],
+        actor_row={},
+    )
+
+    assert actions == [
+        {
+            "action_type": "request_internal_review",
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "target_head_sha": "abc123",
+            "reason": "internal-review-pending",
+        }
+    ]
+
+
+def test_execute_requested_action_records_ambiguous_failure_without_name_error(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    now_iso = "2026-04-22T00:00:00Z"
+    conn = runtime_module._connect(paths["db_path"])
+    try:
+        conn.execute(
+            """
+            INSERT INTO lanes (
+              lane_id, issue_number, issue_url, issue_title, repo_path, actor_backend,
+              lane_status, workflow_state, review_state, merge_state, active_actor_id,
+              current_head_sha, required_internal_review, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "lane:221",
+                221,
+                "https://example.com/issues/221",
+                "Issue 221",
+                "/tmp/repo",
+                "acpx-codex",
+                "active",
+                "awaiting_claude_prepublish",
+                "awaiting_reviews",
+                "not_ready",
+                "actor:1",
+                "abc123",
+                1,
+                now_iso,
+                now_iso,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO lane_actions (
+              action_id, lane_id, action_type, action_reason, action_mode, requested_by,
+              target_head_sha, idempotency_key, status, requested_at, request_payload_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "act:review:1",
+                "lane:221",
+                "request_internal_review",
+                "internal-review-pending",
+                "active",
+                "Workflow_Orchestrator",
+                "abc123",
+                "active:request_internal_review:lane:221:abc123",
+                "requested",
+                now_iso,
+                json.dumps({"action_type": "request_internal_review"}, sort_keys=True),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    def fail_review():
+        raise RuntimeError("review failed")
+
+    result = runtime_module.execute_requested_action(
+        workflow_root=workflow_root,
+        action_id="act:review:1",
+        now_iso="2026-04-22T00:01:00Z",
+        action_runners={"request_internal_review": fail_review},
+    )
+
+    assert result["executed"] is False
+    assert result["reason"] == "execution-failed"
+    assert result["error"] == "review failed"
+
+    conn = sqlite3.connect(paths["db_path"])
+    try:
+        failure_row = conn.execute(
+            "SELECT failure_class, analyst_recommended_action FROM failures WHERE failure_id=?",
+            ("failure:act:review:1",),
+        ).fetchone()
+    finally:
+        conn.close()
+    events = [json.loads(line) for line in paths["event_log_path"].read_text(encoding="utf-8").splitlines()]
+    analysis_requested = [
+        event for event in events if event.get("event_type") == "daedalus.error_analysis_requested"
+    ]
+
+    assert failure_row == ("request_internal_review_blocked", "mark_operator_attention")
+    assert analysis_requested[-1]["project_key"] == "workflow-example"
 
 
 def test_request_active_actions_event_payload_uses_retry_count(runtime_module, tmp_path, monkeypatch):

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 from pathlib import Path
 
@@ -73,6 +74,16 @@ def test_bootstrap_workflow_infers_repo_root_slug_and_default_root(tmp_path, mon
     assert cfg["code-host"]["github_slug"] == "attmous/daedalus"
     assert pointer_path.read_text(encoding="utf-8").strip() == str(expected_root)
     assert state_pointer_path.read_text(encoding="utf-8").strip() == str(contract_path.resolve())
+    assert result["state_files"]["created"]["ledger"] is True
+    assert result["state_files"]["created"]["health"] is True
+    assert result["state_files"]["created"]["scheduler"] is True
+    assert result["state_files"]["created"]["audit_log"] is True
+    ledger = json.loads((expected_root / "memory" / "workflow-status.json").read_text(encoding="utf-8"))
+    assert ledger["workflowState"] == "idle"
+    assert ledger["workflowIdle"] is True
+    assert (expected_root / "memory" / "workflow-health.json").exists()
+    assert (expected_root / "memory" / "workflow-audit.jsonl").exists()
+    assert (expected_root / "memory" / "workflow-scheduler.json").exists()
 
 
 def test_bootstrap_workflow_accepts_explicit_slug_for_non_github_remote(tmp_path):

--- a/tests/test_workflows_code_review_runtimes_claude_cli.py
+++ b/tests/test_workflows_code_review_runtimes_claude_cli.py
@@ -66,3 +66,53 @@ def test_run_prompt_invokes_claude_cli_with_model(tmp_path):
     # The prompt must be passed through somehow (either as a positional arg
     # at the end or via --print)
     assert "review this" in cmd
+
+
+def test_run_prompt_supports_workspace_runner_without_timeout_kwarg(tmp_path):
+    from workflows.change_delivery.runtimes.claude_cli import ClaudeCliRuntime
+
+    calls = []
+
+    def fake_run(cmd, cwd=None):
+        calls.append((cmd, cwd))
+
+        class R:
+            stdout = "ok"
+
+        return R()
+
+    runtime = ClaudeCliRuntime(
+        {"kind": "claude-cli", "max-turns-per-invocation": 24, "timeout-seconds": 1200},
+        run=fake_run,
+    )
+
+    assert runtime.run_prompt(
+        worktree=tmp_path,
+        session_name="inter-review-agent:abc",
+        prompt="review this",
+        model="claude-sonnet-4-6",
+    ) == "ok"
+    assert calls[0][1] == tmp_path
+
+
+def test_run_command_supports_workspace_runner_without_env_or_timeout_kwargs(tmp_path):
+    from workflows.change_delivery.runtimes.claude_cli import ClaudeCliRuntime
+
+    calls = []
+
+    def fake_run(cmd, cwd=None):
+        calls.append((cmd, cwd))
+
+        class R:
+            stdout = "ok"
+
+        return R()
+
+    runtime = ClaudeCliRuntime({"kind": "claude-cli"}, run=fake_run)
+
+    assert runtime.run_command(
+        worktree=tmp_path,
+        command_argv=["claude", "--print", "hi"],
+        env={"DAEDALUS_RUNTIME_KIND": "claude-cli"},
+    ) == "ok"
+    assert calls == [(["claude", "--print", "hi"], tmp_path)]

--- a/workflows/__main__.py
+++ b/workflows/__main__.py
@@ -10,6 +10,7 @@ if _PLUGIN_ROOT_STR not in sys.path:
 
 from daedalus.workflows.__main__ import *  # noqa: F401,F403
 from daedalus.workflows.__main__ import main as _main
+from daedalus.workflows.__main__ import _resolve_workflow_root
 
 
 if __name__ == "__main__":

--- a/workflows/change_delivery/__init__.py
+++ b/workflows/change_delivery/__init__.py
@@ -1,6 +1,8 @@
 """Repo-root change-delivery workflow wrapper for official Hermes plugin installs."""
 
+import importlib
 import sys
+import types
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[2]
@@ -14,3 +16,12 @@ if _real_dir_str not in __path__:
     __path__.append(_real_dir_str)
 
 from daedalus.workflows.change_delivery import *  # noqa: F401,F403
+
+
+class _ServerProxy(types.ModuleType):
+    def __getattr__(self, name):
+        real_server = importlib.import_module("daedalus.workflows.change_delivery.server")
+        return getattr(real_server, name)
+
+
+server = sys.modules.setdefault(__name__ + ".server", _ServerProxy(__name__ + ".server"))


### PR DESCRIPTION
## Summary

Fixes the blockers surfaced by the `daedalus-playground` active workflow smoke test:

- seed change-delivery ledger, health, audit, and scheduler files during bootstrap/init/workspace load
- promote the first eligible GitHub issue to `active-lane` during active startup so a fresh bootstrap can start the engine against real work
- ingest canonical `internalReview` / `externalReview` review status keys without accepting old review-key names at runtime
- allow the Claude CLI runtime to use workspace runners that do not accept `timeout` or `env` kwargs
- pass project identity explicitly through active-action failure analysis so failure handling does not raise `NameError`
- repair repo-root workflow wrapper exports found while running the full suite

## Validation

- playground smoke: removed `active-lane` from `attmous/daedalus-playground#1`, fresh bootstrapped, ran active service loop, confirmed startup re-added `active-lane` and ingested `lane:1`
- `python3 -m py_compile daedalus/daedalus_cli.py daedalus/workflows/change_delivery/actions.py daedalus/workflows/change_delivery/workspace.py`
- `python3 -m pytest tests/test_workflows_code_review_actions.py tests/test_tools_bootstrap_workflow.py tests/test_public_onboarding_smoke.py tests/test_runtime_tools_alerts.py -q`
- `python3 -m pytest -q` (`872 passed, 10 skipped`)