### PR TITLE
[codex] Add runtime matrix smoke command

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -47,6 +47,7 @@ from workflows.runtime_presets import (
     runtime_availability_checks,
     runtime_binding_checks,
 )
+from workflows.runtime_matrix import build_runtime_matrix_report
 from workflows.shared.paths import (
     derive_workflow_instance_name,
     plugin_runtime_path,
@@ -3264,6 +3265,23 @@ def configure_subcommands(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     )
     configure_runtime_cmd.set_defaults(func=run_cli_command)
 
+    runtime_matrix_cmd = sub.add_parser(
+        "runtime-matrix",
+        help="Show workflow role-to-runtime bindings and optionally execute a tiny runtime-stage smoke.",
+    )
+    runtime_matrix_cmd.add_argument("--workflow-root", default=default_workflow_root_str)
+    runtime_matrix_cmd.add_argument("--role", action="append", help="Limit to a workflow role. Can be repeated.")
+    runtime_matrix_cmd.add_argument("--runtime", action="append", help="Limit to a runtime profile. Can be repeated.")
+    runtime_matrix_cmd.add_argument("--execute", action="store_true", help="Run a tiny prompt through each selected role runtime.")
+    runtime_matrix_cmd.add_argument("--json", action="store_true")
+    runtime_matrix_cmd.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (text|json). --json flag is a back-compat alias for --format json.",
+    )
+    runtime_matrix_cmd.set_defaults(func=run_cli_command)
+
     codex_cmd = sub.add_parser(
         "codex-app-server",
         help="Install and control the shared Codex app-server systemd user service.",
@@ -3432,7 +3450,7 @@ def _resolve_format(format_arg: str | None, json_flag: bool | None) -> str:
 def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
     workflow_root = Path(args.workflow_root).resolve() if hasattr(args, "workflow_root") else None
     daedalus = _load_daedalus_module(workflow_root) if workflow_root is not None else None
-    eventless_commands = {"codex-app-server", "runs", "events", "validate", "configure-runtime"}
+    eventless_commands = {"codex-app-server", "runs", "events", "validate", "configure-runtime", "runtime-matrix"}
     if (
         workflow_root is not None
         and daedalus is not None
@@ -3492,6 +3510,13 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
             role=args.role,
             runtime_name=args.runtime_name,
             dry_run=args.dry_run,
+        )
+    if args.daedalus_command == "runtime-matrix":
+        return build_runtime_matrix_report(
+            workflow_root=workflow_root,
+            execute=args.execute,
+            roles=args.role,
+            runtimes=args.runtime,
         )
     if args.daedalus_command == "runs":
         return build_runs_report(
@@ -3827,6 +3852,35 @@ def render_result(
             )
         for check in availability:
             lines.append(f"- {check.get('status')} {check.get('name')}: {check.get('detail')}")
+        return "\n".join(lines)
+    if command == "runtime-matrix":
+        lines = [
+            (
+                f"runtime matrix ok={result.get('ok')} workflow={result.get('workflow')} "
+                f"execute={result.get('execute')}"
+            ),
+            f"contract={result.get('contract_path')}",
+        ]
+        missing = result.get("missing") or {}
+        if missing.get("roles") or missing.get("runtimes"):
+            lines.append(f"missing roles={missing.get('roles') or []} runtimes={missing.get('runtimes') or []}")
+        for item in result.get("matrix") or []:
+            binding = item.get("binding") or {}
+            availability = item.get("availability") or {}
+            smoke = item.get("smoke") or {}
+            detail = (
+                f"- {item.get('role')} -> {item.get('runtime')} kind={item.get('kind')} "
+                f"binding={binding.get('status')} availability={availability.get('status')}"
+            )
+            if smoke:
+                detail += f" smoke={'pass' if smoke.get('ok') else 'fail'}"
+            lines.append(detail)
+            if availability.get("detail"):
+                lines.append(f"  availability: {availability.get('detail')}")
+            if smoke.get("error"):
+                lines.append(f"  smoke error: {smoke.get('error')}")
+            elif smoke.get("output_preview"):
+                lines.append(f"  output: {smoke.get('output_preview')}")
         return "\n".join(lines)
     if command == "runs":
         if result.get("mode") == "show":

--- a/daedalus/workflows/runtime_matrix.py
+++ b/daedalus/workflows/runtime_matrix.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from runtimes import build_runtimes
+from runtimes.stages import prompt_result_from_stage, run_runtime_stage
+from workflows.contract import load_workflow_contract
+from workflows.runtime_presets import (
+    runtime_availability_checks,
+    runtime_binding_checks,
+    runtime_role_bindings,
+)
+
+
+_SAFE_PATH_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def build_runtime_matrix_report(
+    *,
+    workflow_root: Path,
+    execute: bool = False,
+    roles: list[str] | None = None,
+    runtimes: list[str] | None = None,
+    run=None,
+    run_json=None,
+) -> dict[str, Any]:
+    """Build the runtime-role matrix for a workflow contract.
+
+    When ``execute`` is true, each selected role gets a tiny runtime-stage smoke.
+    This exercises the same shared stage boundary used by workflow dispatch; it
+    does not call workflow-specific code paths or mutate tracker state.
+    """
+    root = Path(workflow_root).expanduser().resolve()
+    contract = load_workflow_contract(root)
+    config = dict(contract.config)
+    workflow_name = str(config.get("workflow") or "").strip()
+    runtime_profiles = _runtime_profiles_from_config(config)
+    role_filter = _normalized_filter(roles)
+    runtime_filter = _normalized_filter(runtimes)
+
+    binding_checks = runtime_binding_checks(config)
+    availability_checks = runtime_availability_checks(config)
+    bindings = runtime_role_bindings(config)
+    selected_bindings = [
+        binding
+        for binding in bindings
+        if (not role_filter or str(binding.get("role") or "") in role_filter)
+        and (not runtime_filter or str(binding.get("runtime") or "") in runtime_filter)
+    ]
+
+    matrix = [
+        _matrix_item(
+            binding=binding,
+            binding_checks=binding_checks,
+            availability_checks=availability_checks,
+        )
+        for binding in selected_bindings
+    ]
+
+    missing_roles = sorted(role_filter - {str(binding.get("role") or "") for binding in bindings})
+    missing_runtimes = sorted(runtime_filter - {str(binding.get("runtime") or "") for binding in bindings})
+
+    if execute:
+        _execute_matrix_smokes(
+            matrix=matrix,
+            config=config,
+            runtime_profiles=runtime_profiles,
+            workflow_root=root,
+            run=run,
+            run_json=run_json,
+        )
+
+    selected_binding_check_names = {
+        f"runtime-binding:{item.get('role')}"
+        for item in matrix
+        if item.get("role")
+    }
+    failures = [
+        check
+        for check in binding_checks
+        if check.get("name") in selected_binding_check_names
+        and str(check.get("status") or "") == "fail"
+    ]
+    if execute:
+        failures.extend(
+            {
+                "name": f"runtime-smoke:{item.get('role')}",
+                "status": "fail",
+                "detail": (item.get("smoke") or {}).get("error"),
+            }
+            for item in matrix
+            if not (item.get("smoke") or {}).get("ok")
+        )
+    return {
+        "ok": not failures and not missing_roles and not missing_runtimes,
+        "workflow": workflow_name,
+        "workflow_root": str(root),
+        "contract_path": str(contract.source_path),
+        "execute": execute,
+        "filters": {
+            "roles": sorted(role_filter),
+            "runtimes": sorted(runtime_filter),
+        },
+        "missing": {
+            "roles": missing_roles,
+            "runtimes": missing_runtimes,
+        },
+        "runtime_profiles": {
+            name: {"kind": str((cfg or {}).get("kind") or "")}
+            for name, cfg in sorted(runtime_profiles.items())
+            if isinstance(cfg, dict)
+        },
+        "bindings": bindings,
+        "binding_checks": binding_checks,
+        "availability_checks": availability_checks,
+        "matrix": matrix,
+        "failures": failures,
+    }
+
+
+def _execute_matrix_smokes(
+    *,
+    matrix: list[dict[str, Any]],
+    config: dict[str, Any],
+    runtime_profiles: dict[str, Any],
+    workflow_root: Path,
+    run,
+    run_json,
+) -> None:
+    selected_runtime_names = {str(item.get("runtime") or "") for item in matrix if item.get("runtime")}
+    selected_runtime_profiles = {
+        name: cfg
+        for name, cfg in runtime_profiles.items()
+        if name in selected_runtime_names
+    }
+    runtimes = build_runtimes(
+        selected_runtime_profiles,
+        run=run or _subprocess_run,
+        run_json=run_json or _subprocess_run_json,
+    )
+    for item in matrix:
+        role = str(item.get("role") or "")
+        runtime_name = str(item.get("runtime") or "")
+        if not item.get("profile_exists"):
+            item["smoke"] = {"ok": False, "error": f"missing runtime profile {runtime_name!r}"}
+            continue
+        runtime = runtimes.get(runtime_name)
+        runtime_cfg = runtime_profiles.get(runtime_name) if isinstance(runtime_profiles.get(runtime_name), dict) else {}
+        if runtime is None or not isinstance(runtime_cfg, dict):
+            item["smoke"] = {"ok": False, "error": f"unable to build runtime profile {runtime_name!r}"}
+            continue
+        agent_cfg = _agent_cfg_for_role(config, role)
+        if agent_cfg is None:
+            item["smoke"] = {"ok": False, "error": f"unable to resolve agent config for role {role!r}"}
+            continue
+        worktree = workflow_root / "runtime" / "matrix-smoke" / _safe_name(role)
+        worktree.mkdir(parents=True, exist_ok=True)
+        prompt = (
+            f"Daedalus runtime matrix smoke.\n"
+            f"Workflow: {config.get('workflow')}\n"
+            f"Role: {role}\n"
+            "Return a short signoff.\n"
+        )
+        try:
+            result = run_runtime_stage(
+                runtime=runtime,
+                runtime_cfg=runtime_cfg,
+                agent_cfg=agent_cfg,
+                stage_name=f"runtime-matrix-{_safe_name(role)}",
+                worktree=worktree,
+                session_name=f"runtime-matrix-{_safe_name(role)}",
+                prompt=prompt,
+                placeholders={
+                    "role": role,
+                    "workflow": str(config.get("workflow") or ""),
+                    "runtime": runtime_name,
+                    "workflow_root": str(workflow_root),
+                },
+            )
+            metrics = prompt_result_from_stage(result)
+            item["smoke"] = {
+                "ok": True,
+                "used_command": result.used_command,
+                "output_preview": (result.output or "").strip()[:500],
+                "prompt_path": str(result.prompt_path) if result.prompt_path else None,
+                "result_path": str(result.result_path) if result.result_path else None,
+                "session_id": metrics.session_id,
+                "thread_id": metrics.thread_id,
+                "turn_id": metrics.turn_id,
+                "last_event": metrics.last_event,
+                "tokens": metrics.tokens or {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "rate_limits": metrics.rate_limits,
+            }
+        except Exception as exc:
+            item["smoke"] = {
+                "ok": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+
+def _matrix_item(
+    *,
+    binding: dict[str, Any],
+    binding_checks: list[dict[str, Any]],
+    availability_checks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    role = str(binding.get("role") or "")
+    runtime_name = str(binding.get("runtime") or "")
+    binding_check = _find_check(binding_checks, f"runtime-binding:{role}")
+    availability_check = _find_check(availability_checks, f"runtime-availability:{runtime_name}")
+    return {
+        "role": role,
+        "runtime": runtime_name or None,
+        "kind": binding.get("kind"),
+        "profile_exists": bool(binding.get("profile_exists")),
+        "binding": binding_check,
+        "availability": availability_check,
+    }
+
+
+def _find_check(checks: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    return next((check for check in checks if check.get("name") == name), None)
+
+
+def _runtime_profiles_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    top_level = config.get("runtimes")
+    if isinstance(top_level, dict):
+        return top_level
+    daedalus_cfg = config.get("daedalus")
+    if isinstance(daedalus_cfg, dict) and isinstance(daedalus_cfg.get("runtimes"), dict):
+        return daedalus_cfg["runtimes"]
+    return {}
+
+
+def _agent_cfg_for_role(config: dict[str, Any], role: str) -> dict[str, Any] | None:
+    if str(config.get("workflow") or "") == "issue-runner":
+        agent = config.get("agent")
+        return agent if isinstance(agent, dict) and role == "agent" else None
+
+    if str(config.get("workflow") or "") != "change-delivery":
+        return None
+    agents = config.get("agents")
+    if not isinstance(agents, dict):
+        return None
+    if role.startswith("coder."):
+        coder = agents.get("coder")
+        if not isinstance(coder, dict):
+            return None
+        tier = coder.get(role.split(".", 1)[1])
+        return tier if isinstance(tier, dict) else None
+    reviewer = agents.get(role)
+    return reviewer if isinstance(reviewer, dict) else None
+
+
+def _normalized_filter(values: list[str] | None) -> set[str]:
+    return {str(value).strip() for value in (values or []) if str(value).strip()}
+
+
+def _safe_name(value: str) -> str:
+    return _SAFE_PATH_RE.sub("-", value).strip("-") or "runtime"
+
+
+def _subprocess_run(command, *, cwd=None, timeout=None, env=None, **kwargs):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        timeout=timeout,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _subprocess_run_json(command, *, cwd=None, timeout=None, env=None, **kwargs):
+    completed = _subprocess_run(command, cwd=cwd, timeout=timeout, env=env)
+    return json.loads(completed.stdout or "null")

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -96,6 +96,30 @@ role under `agent:` or `agents:`. Use `--runtime-name` if you want the profile
 key to be different from the preset name. Use `--dry-run --json` to inspect the
 change without writing the file.
 
+## Runtime Matrix Check
+
+After editing runtime bindings, inspect the workflow's role matrix:
+
+```bash
+hermes daedalus runtime-matrix
+hermes daedalus runtime-matrix --format json
+```
+
+This reports every runtime-backed role, the selected profile, adapter kind,
+binding health, and host availability. To exercise the shared stage boundary
+with a tiny prompt, run:
+
+```bash
+hermes daedalus runtime-matrix --execute
+hermes daedalus runtime-matrix --role agent --execute
+hermes daedalus runtime-matrix --runtime codex-service --execute --format json
+```
+
+`--execute` does not mutate trackers or code hosts. It only creates a temporary
+worktree under the workflow root and dispatches one minimal prompt through the
+configured runtime profile. For `codex-service`, start the shared Codex listener
+first with `hermes daedalus codex-app-server up`.
+
 ### `hermes-agent` runtime
 
 The `hermes-agent` runtime delegates turns to a local Hermes Agent CLI. By

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -170,6 +170,17 @@ hermes daedalus configure-runtime --runtime codex-service --role coder.default
 runtime profile under `runtimes:`, and updates the selected role binding. It
 does not start external services.
 
+To inspect the resulting role-to-runtime matrix:
+
+```bash
+hermes daedalus runtime-matrix
+hermes daedalus runtime-matrix --execute
+```
+
+Use `--execute` only after the referenced local CLIs or shared Codex service are
+available. It runs a tiny runtime-stage prompt without touching trackers or code
+hosts.
+
 ## Bring it up
 
 ```bash

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -19,6 +19,7 @@ workflow exposes the richer `change-delivery` command surface.
 | `/daedalus status` | Runtime row + lane count + paths (DB, event log) |
 | `/daedalus doctor` | Full health check across all subsystems |
 | `/daedalus validate` | Validate `WORKFLOW.md`, schema, service mode, and workflow preflight |
+| `/daedalus runtime-matrix` | Show workflow role-to-runtime bindings and optional tiny runtime-stage smoke results |
 | `/daedalus events` | Query the durable engine event ledger |
 | `/daedalus events stats` | Count durable events by type/severity and show retention posture |
 | `/daedalus events prune` | Apply explicit or `WORKFLOW.md` event retention immediately |

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -104,7 +104,9 @@ Built-in presets are `hermes-final`, `hermes-chat`, and `codex-service`.
 `coder.high-effort`, `internal-reviewer`, `coder`, `reviewer`, and `all`.
 Run `hermes daedalus validate` and `hermes daedalus doctor` after changing a
 binding. Doctor reports each role-to-runtime binding and whether the required
-CLI or external Codex service appears reachable.
+CLI or external Codex service appears reachable. Use
+`hermes daedalus runtime-matrix --execute` when you want to run a tiny prompt
+through the configured role runtimes without touching trackers or code hosts.
 
 ## Markdown Body
 

--- a/scripts/smoke_live.py
+++ b/scripts/smoke_live.py
@@ -55,6 +55,21 @@ SMOKES: tuple[Smoke, ...] = (
         required_env=("DAEDALUS_REAL_CODEX_APP_SERVER",),
     ),
     Smoke(
+        name="runtime-matrix-codex",
+        description="Runtime-matrix issue-runner smoke against the shared Codex service profile.",
+        command=(
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_runtime_matrix.py",
+            "-k",
+            "real_codex_service_issue_runner_smoke",
+            "-q",
+            "-s",
+        ),
+        required_env=("DAEDALUS_REAL_CODEX_APP_SERVER",),
+    ),
+    Smoke(
         name="change-delivery-codex",
         description="Self-contained change-delivery GitHub issue plus Codex app-server lane dispatch smoke.",
         command=(

--- a/tests/test_runtime_matrix.py
+++ b/tests/test_runtime_matrix.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from workflows.contract import render_workflow_markdown
+from workflows.runtime_matrix import build_runtime_matrix_report
+
+
+def _runtime_smoke_command() -> list[str]:
+    code = (
+        "import json, os, pathlib; "
+        "prompt = pathlib.Path(os.environ['DAEDALUS_PROMPT_PATH']).read_text(encoding='utf-8'); "
+        "pathlib.Path(os.environ['DAEDALUS_RESULT_PATH']).write_text(json.dumps({"
+        "'output': 'matrix-ok:' + os.environ['DAEDALUS_SESSION_NAME'], "
+        "'last_event': 'turn/completed', "
+        "'last_message': prompt.splitlines()[0], "
+        "'turn_count': 1, "
+        "'tokens': {'input_tokens': 1, 'output_tokens': 1, 'total_tokens': 2}"
+        "}), encoding='utf-8'); "
+        "print('stdout fallback')"
+    )
+    return [sys.executable, "-c", code]
+
+
+def _write_contract(root: Path, config: dict, prompt: str = "Policy body.") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=config, prompt_template=prompt),
+        encoding="utf-8",
+    )
+
+
+def test_runtime_matrix_executes_issue_runner_command_runtime(tmp_path):
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    _write_contract(
+        root,
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "local-smoke", "runtime": "hermes-command"},
+            "runtimes": {
+                "hermes-command": {
+                    "kind": "hermes-agent",
+                    "command": _runtime_smoke_command(),
+                }
+            },
+        },
+    )
+
+    report = build_runtime_matrix_report(workflow_root=root, execute=True)
+
+    assert report["ok"] is True
+    assert report["workflow"] == "issue-runner"
+    assert report["matrix"][0]["role"] == "agent"
+    assert report["matrix"][0]["runtime"] == "hermes-command"
+    assert report["matrix"][0]["kind"] == "hermes-agent"
+    assert report["matrix"][0]["smoke"]["ok"] is True
+    assert report["matrix"][0]["smoke"]["used_command"] is True
+    assert report["matrix"][0]["smoke"]["output_preview"] == "matrix-ok:runtime-matrix-agent"
+    assert report["matrix"][0]["smoke"]["tokens"]["total_tokens"] == 2
+
+
+def test_runtime_matrix_reports_change_delivery_role_bindings(tmp_path):
+    root = tmp_path / "attmous-daedalus-change-delivery"
+    _write_contract(
+        root,
+        {
+            "workflow": "change-delivery",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+            "tracker": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "runtimes": {
+                "hermes-final": {"kind": "hermes-agent", "mode": "final"},
+                "codex-service": {
+                    "kind": "codex-app-server",
+                    "mode": "external",
+                    "endpoint": "ws://127.0.0.1:4500",
+                    "ephemeral": False,
+                    "keep_alive": True,
+                },
+            },
+            "agents": {
+                "coder": {
+                    "default": {"name": "coder", "model": "gpt-5", "runtime": "codex-service"},
+                    "high-effort": {"name": "coder-hi", "model": "gpt-5.5", "runtime": "hermes-final"},
+                },
+                "internal-reviewer": {"name": "reviewer", "model": "gpt-5", "runtime": "codex-service"},
+            },
+        },
+    )
+
+    report = build_runtime_matrix_report(workflow_root=root)
+    roles = {item["role"]: item for item in report["matrix"]}
+
+    assert report["ok"] is True
+    assert set(roles) == {"coder.default", "coder.high-effort", "internal-reviewer"}
+    assert roles["coder.default"]["kind"] == "codex-app-server"
+    assert roles["coder.high-effort"]["kind"] == "hermes-agent"
+    assert roles["internal-reviewer"]["runtime"] == "codex-service"
+    assert all(check["status"] == "pass" for check in report["binding_checks"])
+
+
+def test_runtime_matrix_cli_executes_selected_role(tmp_path):
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parents[1] / "daedalus"
+    spec = importlib.util.spec_from_file_location("daedalus_cli_runtime_matrix_test", repo_root / "daedalus_cli.py")
+    tools = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(tools)
+
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    _write_contract(
+        root,
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {"name": "runner", "model": "local-smoke", "runtime": "hermes-command"},
+            "runtimes": {"hermes-command": {"kind": "hermes-agent", "command": _runtime_smoke_command()}},
+        },
+    )
+
+    output = tools.execute_raw_args(f"runtime-matrix --workflow-root {root} --role agent --execute --json")
+    payload = json.loads(output)
+
+    assert payload["ok"] is True
+    assert payload["matrix"][0]["smoke"]["output_preview"] == "matrix-ok:runtime-matrix-agent"
+
+
+def test_runtime_matrix_role_filter_ignores_unselected_broken_role(tmp_path):
+    root = tmp_path / "attmous-daedalus-change-delivery"
+    _write_contract(
+        root,
+        {
+            "workflow": "change-delivery",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+            "tracker": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
+            "runtimes": {
+                "hermes-command": {"kind": "hermes-agent", "command": _runtime_smoke_command()},
+            },
+            "agents": {
+                "coder": {
+                    "default": {"name": "coder", "model": "gpt-5", "runtime": "hermes-command"},
+                    "high-effort": {"name": "coder-hi", "model": "gpt-5.5", "runtime": "missing-runtime"},
+                },
+                "internal-reviewer": {"name": "reviewer", "model": "gpt-5", "runtime": "missing-runtime"},
+            },
+        },
+    )
+
+    report = build_runtime_matrix_report(
+        workflow_root=root,
+        execute=True,
+        roles=["coder.default"],
+    )
+
+    assert report["ok"] is True
+    assert [item["role"] for item in report["matrix"]] == ["coder.default"]
+    assert report["matrix"][0]["smoke"]["ok"] is True
+
+
+@pytest.mark.skipif(
+    os.environ.get("DAEDALUS_REAL_CODEX_APP_SERVER") != "1",
+    reason="set DAEDALUS_REAL_CODEX_APP_SERVER=1 to run the real Codex runtime-matrix smoke",
+)
+def test_runtime_matrix_real_codex_service_issue_runner_smoke(tmp_path):
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    _write_contract(
+        root,
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path), "slug": "attmous/daedalus"},
+            "tracker": {"kind": "local-json", "path": "config/issues.json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {
+                "name": "runner",
+                "model": os.environ.get("DAEDALUS_REAL_CODEX_MODEL", ""),
+                "runtime": "codex-service",
+            },
+            "runtimes": {
+                "codex-service": {
+                    "kind": "codex-app-server",
+                    "mode": "external",
+                    "endpoint": os.environ.get("DAEDALUS_REAL_CODEX_ENDPOINT", "ws://127.0.0.1:4500"),
+                    "approval_policy": "never",
+                    "thread_sandbox": "workspace-write",
+                    "turn_sandbox_policy": "workspace-write",
+                    "turn_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_TURN_TIMEOUT_MS", "180000")),
+                    "read_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_READ_TIMEOUT_MS", "5000")),
+                    "stall_timeout_ms": int(os.environ.get("DAEDALUS_REAL_CODEX_STALL_TIMEOUT_MS", "60000")),
+                    "ephemeral": False,
+                    "keep_alive": True,
+                }
+            },
+        },
+    )
+
+    report = build_runtime_matrix_report(workflow_root=root, execute=True, roles=["agent"])
+
+    assert report["ok"] is True
+    smoke = report["matrix"][0]["smoke"]
+    assert smoke["ok"] is True
+    assert smoke["thread_id"]
+    assert smoke["last_event"] == "turn/completed"


### PR DESCRIPTION
## Summary

Adds a shared runtime matrix report for workflow contracts. Operators can now run `hermes daedalus runtime-matrix` to inspect role-to-runtime bindings and `hermes daedalus runtime-matrix --execute` to run a tiny runtime-stage prompt through selected configured roles without touching trackers or code hosts.

This directly supports the runtime-agnostic strategy across `issue-runner` and `change-delivery`: roles bind to shared runtime profiles, while Daedalus verifies the binding, availability, and optional execution path through the common stage dispatcher.

## Details

- Adds `workflows.runtime_matrix.build_runtime_matrix_report`.
- Adds `/daedalus runtime-matrix` with `--role`, `--runtime`, `--execute`, and JSON/text output.
- Adds an opt-in `runtime-matrix-codex` live smoke for the shared Codex service profile.
- Documents the operator path in runtime, installation, slash-command, and workflow contract docs.

## Validation

- `pytest -q tests/test_runtime_matrix.py tests/test_public_cli_docs_drift.py tests/test_live_smoke_harness.py`
- `pytest -q tests/test_runtime_presets.py tests/test_runtime_stage_dispatcher.py tests/test_runtime_agnostic_phase_a.py tests/test_workflows_issue_runner_workspace.py tests/test_workflows_code_review_actions.py tests/test_workflows_code_review_reviews.py`
- `pytest -q`

Full suite result: `860 passed, 10 skipped`.