### PR TITLE
[codex] Promote eligible lane during active startup

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -563,6 +563,42 @@ def _load_issue_runner_workspace(workflow_root: Path):
     return load_workspace_from_config(workspace_root=workflow_root)
 
 
+def _load_change_delivery_workspace(workflow_root: Path):
+    try:
+        from workflows.change_delivery.workspace import load_workspace_from_config
+    except ImportError:
+        path = PLUGIN_DIR / "workflows" / "change_delivery" / "workspace.py"
+        spec = importlib.util.spec_from_file_location("daedalus_change_delivery_workspace_for_tools", path)
+        if spec is None or spec.loader is None:
+            raise DaedalusCommandError(f"unable to load change-delivery workspace module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        load_workspace_from_config = module.load_workspace_from_config
+    return load_workspace_from_config(workspace_root=workflow_root)
+
+
+def _ensure_change_delivery_active_lane_for_start(workflow_root: Path) -> dict[str, Any]:
+    try:
+        workspace = _load_change_delivery_workspace(workflow_root)
+        ensure_active_lane = getattr(workspace, "ensure_active_lane")
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "workspace-load-failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    try:
+        return ensure_active_lane()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "active-lane-selection-failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
 def _build_issue_runner_status(workflow_root: Path) -> dict[str, Any]:
     return _load_issue_runner_workspace(workflow_root).build_status()
 
@@ -782,6 +818,11 @@ def service_loop(
         daedalus = _load_daedalus_module(workflow_root)
         resolved_project_key = project_key or daedalus._project_key_for(workflow_root)
         resolved_instance_id = instance_id or _instance_id_for(service_mode=service_mode, workspace=workflow_root.name)
+        lane_selection = (
+            _ensure_change_delivery_active_lane_for_start(workflow_root)
+            if service_mode == "active"
+            else None
+        )
         if service_mode == "shadow":
             return daedalus.run_shadow_loop(
                 workflow_root=workflow_root,
@@ -790,13 +831,15 @@ def service_loop(
                 interval_seconds=interval_seconds,
                 max_iterations=max_iterations,
             )
-        return daedalus.run_active_loop(
+        result = daedalus.run_active_loop(
             workflow_root=workflow_root,
             project_key=resolved_project_key,
             instance_id=resolved_instance_id,
             interval_seconds=interval_seconds,
             max_iterations=max_iterations,
         )
+        result["lane_selection"] = lane_selection
+        return result
     if workflow_name == "issue-runner":
         workspace = _load_issue_runner_workspace(workflow_root)
         payload = workspace.run_loop(
@@ -835,6 +878,7 @@ def service_up(
             "skipped": True,
             "reason": "workflow-managed runtime does not require daedalus.db bootstrap",
         }
+    lane_selection_result = None
 
     install_result = install_supervised_service(
         workflow_root=workflow_root,
@@ -864,6 +908,9 @@ def service_up(
             f"{enable_result.get('stderr') or enable_result.get('stdout') or enable_result.get('returncode')}"
         )
 
+    if workflow_name == "change-delivery" and service_mode == "active":
+        lane_selection_result = _ensure_change_delivery_active_lane_for_start(workflow_root)
+
     start_result = service_control(
         "start",
         workflow_root=workflow_root,
@@ -887,6 +934,7 @@ def service_up(
         "project_key": project_key,
         "service_mode": service_mode,
         "init": init_result,
+        "lane_selection": lane_selection_result,
         "preflight": preflight_result,
         "service_install": install_result,
         "service_enable": enable_result,
@@ -3732,18 +3780,32 @@ def execute_namespace(args: argparse.Namespace) -> dict[str, Any]:
             "gate": daedalus.evaluate_active_execution_gate(workflow_root=workflow_root, legacy_status=legacy_status),
         }
     if args.daedalus_command == "iterate-active":
-        return daedalus.run_active_iteration(
+        lane_selection = (
+            _ensure_change_delivery_active_lane_for_start(workflow_root)
+            if _workflow_name_for_root(workflow_root) == "change-delivery"
+            else None
+        )
+        result = daedalus.run_active_iteration(
             workflow_root=workflow_root,
             instance_id=args.instance_id,
         )
+        result["lane_selection"] = lane_selection
+        return result
     if args.daedalus_command == "run-active":
-        return daedalus.run_active_loop(
+        lane_selection = (
+            _ensure_change_delivery_active_lane_for_start(workflow_root)
+            if _workflow_name_for_root(workflow_root) == "change-delivery"
+            else None
+        )
+        result = daedalus.run_active_loop(
             workflow_root=workflow_root,
             project_key=resolved_project_key,
             instance_id=args.instance_id,
             interval_seconds=args.interval_seconds,
             max_iterations=args.max_iterations,
         )
+        result["lane_selection"] = lane_selection
+        return result
     if args.daedalus_command == "request-active-actions":
         return daedalus.request_active_actions_for_lane(
             workflow_root=workflow_root,

--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -190,6 +190,124 @@ def run_merge_and_promote(
     }
 
 
+def run_ensure_active_lane(
+    *,
+    build_status_fn: Callable[[], dict[str, Any]],
+    reconcile_fn: Callable[..., dict[str, Any]],
+    audit_fn: Callable[..., Any],
+    issue_add_label_fn: Callable[[Any, str], Any],
+    issue_comment_fn: Callable[[Any, str], Any],
+    pick_next_lane_issue_fn: Callable[[], dict[str, Any] | None],
+    active_lane_label: str,
+) -> dict[str, Any]:
+    """Promote the first eligible issue when a fresh workflow has no active lane."""
+    try:
+        status = build_status_fn()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "status-build-failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    active_lane = status.get("activeLane")
+    if active_lane:
+        return {
+            "ok": True,
+            "promoted": False,
+            "reason": "active-lane-present",
+            "issueNumber": active_lane.get("number"),
+        }
+    active_lane_error = status.get("activeLaneError")
+    if active_lane_error:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": active_lane_error.get("error") or "active-lane-error",
+            "activeLaneError": active_lane_error,
+        }
+    try:
+        next_issue = pick_next_lane_issue_fn()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "lane-selection-failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    if not next_issue:
+        return {"ok": True, "promoted": False, "reason": "no-eligible-issue"}
+
+    issue_number = next_issue.get("number")
+    if issue_number in (None, ""):
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "eligible-issue-missing-number",
+            "issue": next_issue,
+        }
+    try:
+        label_added = bool(issue_add_label_fn(issue_number, active_lane_label))
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "active-lane-label-failed",
+            "issueNumber": issue_number,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    if not label_added:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "active-lane-label-not-applied",
+            "issueNumber": issue_number,
+        }
+
+    comment_posted = False
+    try:
+        comment_posted = bool(
+            issue_comment_fn(
+                issue_number,
+                "Promoted to active lane during Daedalus startup.",
+            )
+        )
+    except Exception:
+        comment_posted = False
+
+    audit_fn(
+        "bootstrap-active-lane",
+        "Promoted eligible issue to active lane during Daedalus startup",
+        issueNumber=issue_number,
+        activeLaneLabel=active_lane_label,
+    )
+    try:
+        after = reconcile_fn(fix_watchers=True)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": True,
+            "reason": "reconcile-after-promotion-failed",
+            "issueNumber": issue_number,
+            "commentPosted": comment_posted,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "ok": True,
+        "promoted": True,
+        "reason": "promoted",
+        "issueNumber": issue_number,
+        "issueTitle": next_issue.get("title"),
+        "issueUrl": next_issue.get("url"),
+        "commentPosted": comment_posted,
+        "after": {
+            "health": after.get("health"),
+            "activeLane": (after.get("activeLane") or {}).get("number"),
+            "nextAction": (after.get("nextAction") or {}).get("type"),
+        },
+    }
+
+
 def run_dispatch_lane_turn(
     *,
     status: dict[str, Any],

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -1115,6 +1115,17 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             issue_number, comment, repo_path=ns.REPO_PATH, run=ns._run,
         )
 
+    def ensure_active_lane():
+        return ns._load_adapter_actions_module().run_ensure_active_lane(
+            build_status_fn=ns.build_status,
+            reconcile_fn=ns.reconcile,
+            audit_fn=ns.audit,
+            issue_add_label_fn=ns._issue_add_label,
+            issue_comment_fn=ns._issue_comment,
+            pick_next_lane_issue_fn=ns._pick_next_lane_issue,
+            active_lane_label=ns.ACTIVE_LANE_LABEL,
+        )
+
     def publish_ready_pr():
         return ns._load_adapter_actions_module().publish_ready_pr(ns.WORKSPACE)
 

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -284,6 +285,67 @@ def test_bootstrap_promotion_refuses_existing_named_target_even_with_force(tmp_p
     assert (repo_root / "WORKFLOW.md").exists()
     assert target_path.read_text(encoding="utf-8") == target_text
     assert not (repo_root / "WORKFLOW-issue-runner.md").exists()
+
+
+def test_change_delivery_service_up_promotes_eligible_lane_before_start(tmp_path, monkeypatch):
+    tools = _tools()
+    workflow_root = tmp_path / "workflow"
+    workflow_root.mkdir()
+    calls: list[tuple] = []
+
+    fake_daedalus = SimpleNamespace(
+        init_daedalus_db=lambda **kwargs: calls.append(("init", kwargs)) or {"ok": True},
+    )
+
+    monkeypatch.setattr(tools, "_validate_workflow_contract_preflight_for_service", lambda **_kwargs: {"ok": True, "workflow": "change-delivery"})
+    monkeypatch.setattr(tools, "_load_daedalus_module", lambda _workflow_root: fake_daedalus)
+    monkeypatch.setattr(tools, "_ensure_change_delivery_active_lane_for_start", lambda _workflow_root: calls.append(("lane", str(_workflow_root))) or {"ok": True, "promoted": True, "issueNumber": 7})
+    monkeypatch.setattr(tools, "install_supervised_service", lambda **kwargs: calls.append(("install", kwargs)) or {"installed": True, "unit_path": str(tmp_path / "unit.service")})
+    monkeypatch.setattr(tools, "service_control", lambda action, **kwargs: calls.append((action, kwargs)) or {"ok": True})
+    monkeypatch.setattr(tools, "service_status", lambda **kwargs: calls.append(("status", kwargs)) or {"service_name": "daedalus-active@test.service"})
+
+    result = tools.service_up(
+        workflow_root=workflow_root,
+        project_key="project",
+        instance_id="instance",
+        interval_seconds=30,
+        service_mode="active",
+    )
+
+    assert result["ok"] is True
+    assert result["lane_selection"] == {"ok": True, "promoted": True, "issueNumber": 7}
+    call_names = [call[0] for call in calls]
+    assert call_names.index("enable") < call_names.index("lane") < call_names.index("start")
+
+
+def test_change_delivery_active_service_loop_promotes_lane_before_running(tmp_path, monkeypatch):
+    tools = _tools()
+    workflow_root = tmp_path / "workflow"
+    workflow_root.mkdir()
+    calls: list[str] = []
+
+    fake_daedalus = SimpleNamespace(
+        _project_key_for=lambda _workflow_root: "project",
+        run_active_loop=lambda **kwargs: calls.append("run-active") or {"loop_status": "completed", "kwargs": kwargs},
+        run_shadow_loop=lambda **kwargs: calls.append("run-shadow") or {"loop_status": "completed", "kwargs": kwargs},
+    )
+
+    monkeypatch.setattr(tools, "_assert_service_mode_supported", lambda **_kwargs: "change-delivery")
+    monkeypatch.setattr(tools, "_load_daedalus_module", lambda _workflow_root: fake_daedalus)
+    monkeypatch.setattr(tools, "_ensure_change_delivery_active_lane_for_start", lambda _workflow_root: calls.append("lane") or {"ok": True, "promoted": True, "issueNumber": 8})
+
+    result = tools.service_loop(
+        workflow_root=workflow_root,
+        project_key=None,
+        instance_id="instance",
+        interval_seconds=1,
+        max_iterations=1,
+        service_mode="active",
+    )
+
+    assert result["loop_status"] == "completed"
+    assert result["lane_selection"] == {"ok": True, "promoted": True, "issueNumber": 8}
+    assert calls == ["lane", "run-active"]
 
 
 def test_bootstrap_workflow_requires_git_repo(tmp_path):

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -249,6 +249,83 @@ def test_run_merge_and_promote_promotes_next_lane_after_merge():
     assert ("add", 225, "P0") in calls["issue"]
 
 
+def test_run_ensure_active_lane_promotes_first_eligible_issue():
+    actions_module = load_module("daedalus_workflows_change_delivery_actions_eal", "workflows/change_delivery/actions.py")
+    calls: list[tuple] = []
+
+    def fake_reconcile(*, fix_watchers=False):
+        calls.append(("reconcile", fix_watchers))
+        return {
+            "health": "healthy",
+            "activeLane": {"number": 225},
+            "nextAction": {"type": "dispatch_codex_turn"},
+        }
+
+    result = actions_module.run_ensure_active_lane(
+        build_status_fn=lambda: {"activeLane": None, "activeLaneError": None},
+        reconcile_fn=fake_reconcile,
+        audit_fn=lambda action, summary, **extra: calls.append(("audit", action, extra)),
+        issue_add_label_fn=lambda issue_number, label: calls.append(("add", issue_number, label)) or True,
+        issue_comment_fn=lambda issue_number, body: calls.append(("comment", issue_number, body)) or True,
+        pick_next_lane_issue_fn=lambda: {"number": 225, "title": "Next lane", "url": "https://example.test/issues/225"},
+        active_lane_label="active-lane",
+    )
+
+    assert result["ok"] is True
+    assert result["promoted"] is True
+    assert result["issueNumber"] == 225
+    assert result["after"] == {"health": "healthy", "activeLane": 225, "nextAction": "dispatch_codex_turn"}
+    assert ("add", 225, "active-lane") in calls
+    assert any(call[0] == "comment" and call[1] == 225 for call in calls)
+    assert ("reconcile", True) in calls
+
+
+def test_run_ensure_active_lane_skips_when_active_lane_already_exists():
+    actions_module = load_module("daedalus_workflows_change_delivery_actions_eal_skip", "workflows/change_delivery/actions.py")
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("selection should not run when an active lane already exists")
+
+    result = actions_module.run_ensure_active_lane(
+        build_status_fn=lambda: {"activeLane": {"number": 224}},
+        reconcile_fn=should_not_run,
+        audit_fn=should_not_run,
+        issue_add_label_fn=should_not_run,
+        issue_comment_fn=should_not_run,
+        pick_next_lane_issue_fn=should_not_run,
+        active_lane_label="active-lane",
+    )
+
+    assert result == {
+        "ok": True,
+        "promoted": False,
+        "reason": "active-lane-present",
+        "issueNumber": 224,
+    }
+
+
+def test_run_ensure_active_lane_reports_selection_failure_without_raising():
+    actions_module = load_module("daedalus_workflows_change_delivery_actions_eal_fail", "workflows/change_delivery/actions.py")
+
+    def broken_selection():
+        raise RuntimeError("gh unavailable")
+
+    result = actions_module.run_ensure_active_lane(
+        build_status_fn=lambda: {"activeLane": None},
+        reconcile_fn=lambda **_kwargs: {},
+        audit_fn=lambda *args, **kwargs: None,
+        issue_add_label_fn=lambda *_args: True,
+        issue_comment_fn=lambda *_args: True,
+        pick_next_lane_issue_fn=broken_selection,
+        active_lane_label="active-lane",
+    )
+
+    assert result["ok"] is False
+    assert result["promoted"] is False
+    assert result["reason"] == "lane-selection-failed"
+    assert "gh unavailable" in result["error"]
+
+
 def _dispatch_deps(tmp_path: Path):
     worktree = tmp_path / "worktree"
     worktree.mkdir()


### PR DESCRIPTION
## Summary

Fixes the fresh-bootstrap gap found in `daedalus-playground`:

- add a change-delivery startup action that promotes the first eligible GitHub issue to `active-lane` when no active lane exists
- run that promotion before active `service-up`, active `service-loop`, `run-active`, and `iterate-active` start engine work
- keep promotion non-fatal when GitHub selection is unavailable, while returning the selection result in command JSON
- add regression coverage for promotion, no-op, failure handling, and active startup ordering

## Validation

- playground smoke: removed `active-lane` from `attmous/daedalus-playground#1`, fresh bootstrapped, ran active service loop, confirmed startup re-added `active-lane` and ingested `lane:1`
- `python3 -m py_compile daedalus/daedalus_cli.py daedalus/workflows/change_delivery/actions.py daedalus/workflows/change_delivery/workspace.py`
- `python3 -m pytest tests/test_workflows_code_review_actions.py tests/test_tools_bootstrap_workflow.py tests/test_public_onboarding_smoke.py tests/test_runtime_tools_alerts.py -q`
- `python3 -m pytest -q` (`872 passed, 10 skipped`)
