### PR TITLE
[codex] Fix local review repair parity

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1266,20 +1266,20 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
         and repair_brief.get("forHeadSha") == current_head_sha
         and (repair_brief.get("mustFix") or repair_brief.get("shouldFix"))
     )
-    last_codex_cloud_handoff = session_control.get("lastCodexCloudRepairHandoff") or {}
-    last_claude_handoff = session_control.get("lastClaudeRepairHandoff") or {}
+    last_external_review_handoff = session_control.get("lastExternalReviewRepairHandoff") or {}
+    last_internal_review_handoff = session_control.get("lastInternalReviewRepairHandoff") or {}
     internal_review_completed_at = (internal_review or {}).get("completed_at")
     local_repair_handoff_already_sent = bool(
-        last_claude_handoff.get("sessionName") == actor_row.get("backend_identity")
-        and last_claude_handoff.get("headSha") == current_head_sha
+        last_internal_review_handoff.get("sessionName") == actor_row.get("backend_identity")
+        and last_internal_review_handoff.get("headSha") == current_head_sha
         and internal_review
-        and last_claude_handoff.get("reviewedAt") == internal_review_completed_at
+        and last_internal_review_handoff.get("reviewedAt") == internal_review_completed_at
     )
     repair_handoff_already_sent = bool(
-        last_codex_cloud_handoff.get("sessionName") == actor_row.get("backend_identity")
-        and last_codex_cloud_handoff.get("headSha") == current_head_sha
+        last_external_review_handoff.get("sessionName") == actor_row.get("backend_identity")
+        and last_external_review_handoff.get("headSha") == current_head_sha
         and external_review
-        and last_codex_cloud_handoff.get("reviewedAt") == external_review.get("completed_at")
+        and last_external_review_handoff.get("reviewedAt") == external_review.get("completed_at")
     )
     if (
         workflow_state in {"implementing_local", "implementing"}

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1267,6 +1267,14 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
         and (repair_brief.get("mustFix") or repair_brief.get("shouldFix"))
     )
     last_codex_cloud_handoff = session_control.get("lastCodexCloudRepairHandoff") or {}
+    last_claude_handoff = session_control.get("lastClaudeRepairHandoff") or {}
+    internal_review_completed_at = (internal_review or {}).get("completed_at")
+    local_repair_handoff_already_sent = bool(
+        last_claude_handoff.get("sessionName") == actor_row.get("backend_identity")
+        and last_claude_handoff.get("headSha") == current_head_sha
+        and internal_review
+        and last_claude_handoff.get("reviewedAt") == internal_review_completed_at
+    )
     repair_handoff_already_sent = bool(
         last_codex_cloud_handoff.get("sessionName") == actor_row.get("backend_identity")
         and last_codex_cloud_handoff.get("headSha") == current_head_sha
@@ -1302,6 +1310,28 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
             "issue_number": lane_row.get("issue_number"),
             "target_head_sha": current_head_sha,
             "reason": "implementation-in-progress",
+        }]
+    if (
+        workflow_state in {"claude_prepublish_findings", "rework_required"}
+        and not active_pr_number
+        and internal_review
+        and internal_review.get("status") == "completed"
+        and internal_review.get("verdict") in {"PASS_WITH_FINDINGS", "REWORK"}
+        and current_head_sha
+        and internal_review.get("reviewed_head_sha") == current_head_sha
+        and internal_review.get("review_scope") == "local-prepublish"
+        and has_actionable_repair_brief
+        and actor_row.get("runtime_status") == "healthy"
+        and actor_row.get("session_action_recommendation") in {"continue-session", "poke-session"}
+        and actor_row.get("backend_identity")
+        and not local_repair_handoff_already_sent
+    ):
+        return [{
+            "action_type": "dispatch_repair_handoff",
+            "lane_id": lane_row.get("lane_id"),
+            "issue_number": lane_row.get("issue_number"),
+            "target_head_sha": current_head_sha,
+            "reason": "local-review-findings-need-repair",
         }]
     if (
         workflow_state in {"claude_prepublish_findings", "rework_required"}
@@ -1472,6 +1502,17 @@ def persist_shadow_actions(*, workflow_root: Path, lane_id: str, now_iso: str | 
                         "mode": "shadow",
                     },
                 })
+            else:
+                existing = conn.execute(
+                    """
+                    SELECT action_id
+                    FROM lane_actions
+                    WHERE idempotency_key=?
+                    """,
+                    (idempotency_key,),
+                ).fetchone()
+                if existing:
+                    persisted.append({**action, "action_id": dict(existing)["action_id"]})
         conn.commit()
     finally:
         conn.close()

--- a/daedalus/workflows/change_delivery/reviews.py
+++ b/daedalus/workflows/change_delivery/reviews.py
@@ -1027,7 +1027,7 @@ def build_external_review_repair_handoff_payload(
 ) -> dict[str, Any]:
     review = external_review or {}
     return {
-        "action": "codex-cloud-repair-handoff",
+        "action": "external-review-repair-handoff",
         "sessionName": session_action.get("sessionName"),
         "issueNumber": (issue or {}).get("number"),
         "issueTitle": (issue or {}).get("title"),
@@ -1055,7 +1055,7 @@ def record_external_review_repair_handoff(
     if path is None:
         return None
     state = load_optional_json_fn(path) or {"schemaVersion": 1}
-    state.setdefault("sessionControl", {})["lastCodexCloudRepairHandoff"] = payload
+    state.setdefault("sessionControl", {})["lastExternalReviewRepairHandoff"] = payload
     write_json_fn(path, state)
     return state
 
@@ -1072,7 +1072,7 @@ def build_claude_repair_handoff_payload(
 ) -> dict[str, Any]:
     review = internal_review or {}
     return {
-        "action": "claude-repair-handoff",
+        "action": "internal-review-repair-handoff",
         "sessionName": session_action.get("sessionName"),
         "issueNumber": (issue or {}).get("number"),
         "issueTitle": (issue or {}).get("title"),
@@ -1100,7 +1100,7 @@ def record_claude_repair_handoff(
     if path is None:
         return None
     state = load_optional_json_fn(path) or {"schemaVersion": 1}
-    state.setdefault("sessionControl", {})["lastClaudeRepairHandoff"] = payload
+    state.setdefault("sessionControl", {})["lastInternalReviewRepairHandoff"] = payload
     write_json_fn(path, state)
     return state
 
@@ -1237,7 +1237,7 @@ def should_dispatch_claude_repair_handoff(
         return {"shouldDispatch": False, "reason": "repair-brief-head-mismatch"}
     if not ((repair_brief or {}).get("mustFix") or (repair_brief or {}).get("shouldFix")):
         return {"shouldDispatch": False, "reason": "repair-brief-empty"}
-    last_handoff = ((lane_state or {}).get("sessionControl") or {}).get("lastClaudeRepairHandoff") or {}
+    last_handoff = ((lane_state or {}).get("sessionControl") or {}).get("lastInternalReviewRepairHandoff") or {}
     if (
         last_handoff.get("sessionName") == session_action.get("sessionName")
         and last_handoff.get("headSha") == current_head_sha
@@ -1278,7 +1278,7 @@ def should_dispatch_external_review_repair_handoff(
         return {"shouldDispatch": False, "reason": "repair-brief-head-mismatch"}
     if not ((repair_brief or {}).get("mustFix") or (repair_brief or {}).get("shouldFix")):
         return {"shouldDispatch": False, "reason": "repair-brief-empty"}
-    last_handoff = ((lane_state or {}).get("sessionControl") or {}).get("lastCodexCloudRepairHandoff") or {}
+    last_handoff = ((lane_state or {}).get("sessionControl") or {}).get("lastExternalReviewRepairHandoff") or {}
     if (
         last_handoff.get("sessionName") == session_action.get("sessionName")
         and last_handoff.get("headSha") == current_head_sha
@@ -1405,8 +1405,8 @@ def maybe_dispatch_repair_handoff(
         )
         ledger["internalReviewRepairHandoff"] = repair_payload
         audit_fn(
-            "claude-repair-handoff-dispatched",
-            "Sent Claude pre-publish repair brief back into the active Codex session",
+            "internal-review-repair-handoff-dispatched",
+            "Sent pre-publish review repair brief back into the active implementer session",
             issueNumber=repair_payload.get("issueNumber"),
             sessionName=repair_payload.get("sessionName"),
             headSha=repair_payload.get("headSha"),
@@ -1416,7 +1416,7 @@ def maybe_dispatch_repair_handoff(
         )
         return {
             "dispatched": True,
-            "mode": "claude_repair_handoff",
+            "mode": "internal_review_repair_handoff",
             "issueNumber": repair_payload.get("issueNumber"),
             "sessionName": repair_payload.get("sessionName"),
             "headSha": repair_payload.get("headSha"),
@@ -1466,8 +1466,8 @@ def maybe_dispatch_repair_handoff(
         )
         ledger["externalReviewRepairHandoff"] = repair_payload
         audit_fn(
-            "codex-cloud-repair-handoff-dispatched",
-            "Sent Codex Cloud repair brief back into the active Codex session",
+            "external-review-repair-handoff-dispatched",
+            "Sent external review repair brief back into the active implementer session",
             issueNumber=repair_payload.get("issueNumber"),
             sessionName=repair_payload.get("sessionName"),
             headSha=repair_payload.get("headSha"),
@@ -1477,7 +1477,7 @@ def maybe_dispatch_repair_handoff(
         )
         return {
             "dispatched": True,
-            "mode": "codex_cloud_repair_handoff",
+            "mode": "external_review_repair_handoff",
             "issueNumber": repair_payload.get("issueNumber"),
             "sessionName": repair_payload.get("sessionName"),
             "headSha": repair_payload.get("headSha"),
@@ -1487,8 +1487,8 @@ def maybe_dispatch_repair_handoff(
     return {
         "dispatched": False,
         "reason": "repair-handoff-not-needed",
-        "claudeReason": claude_decision.get("reason"),
-        "codexCloudReason": codex_cloud_decision.get("reason"),
+        "internalReviewReason": claude_decision.get("reason"),
+        "externalReviewReason": codex_cloud_decision.get("reason"),
     }, False
 
 

--- a/daedalus/workflows/change_delivery/workflow.py
+++ b/daedalus/workflows/change_delivery/workflow.py
@@ -183,8 +183,8 @@ def derive_next_action(
     ).get("shouldDispatch"):
         return {
             "type": "dispatch_codex_turn",
-            "mode": "claude_repair_handoff",
-            "reason": "claude-findings-need-repair",
+            "mode": "internal_review_repair_handoff",
+            "reason": "internal-review-findings-need-repair",
             "issueNumber": active_lane.get("number"),
             "sessionName": session_action.get("sessionName"),
             "headSha": local_head_sha,
@@ -201,8 +201,8 @@ def derive_next_action(
     ).get("shouldDispatch"):
         return {
             "type": "dispatch_codex_turn",
-            "mode": "codex_cloud_repair_handoff",
-            "reason": "codex-cloud-findings-need-repair",
+            "mode": "external_review_repair_handoff",
+            "reason": "external-review-findings-need-repair",
             "issueNumber": active_lane.get("number"),
             "sessionName": session_action.get("sessionName"),
             "headSha": current_postpublish_head,
@@ -224,7 +224,7 @@ def derive_next_action(
         return {
             "type": "dispatch_codex_turn",
             "mode": "postpublish_repair",
-            "reason": "codex-cloud-findings-need-repair",
+            "reason": "external-review-findings-need-repair",
             "issueNumber": active_lane.get("number"),
             "sessionName": session_action.get("sessionName"),
             "headSha": current_postpublish_head,

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -401,7 +401,7 @@ def test_derive_shadow_actions_skips_duplicate_local_review_repair_handoff(runti
             "metadata_json": json.dumps(
                 {
                     "sessionControl": {
-                        "lastClaudeRepairHandoff": {
+                        "lastInternalReviewRepairHandoff": {
                             "sessionName": "lane-221",
                             "headSha": "abc123",
                             "reviewedAt": "2026-04-22T00:05:00Z",

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -323,6 +323,217 @@ def test_derive_shadow_actions_requests_internal_review_without_review_row(runti
     ]
 
 
+def test_derive_shadow_actions_dispatches_local_review_repair_handoff_when_session_routable(runtime_module):
+    actions = runtime_module.derive_shadow_actions_for_lane(
+        lane_row={
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "workflow_state": "claude_prepublish_findings",
+            "active_pr_number": None,
+            "current_head_sha": "abc123",
+            "repair_brief_json": json.dumps(
+                {
+                    "forHeadSha": "abc123",
+                    "mustFix": [{"summary": "Fix validation"}],
+                    "shouldFix": [],
+                }
+            ),
+        },
+        reviews=[
+            {
+                "reviewer_scope": "internal",
+                "status": "completed",
+                "verdict": "PASS_WITH_FINDINGS",
+                "review_scope": "local-prepublish",
+                "reviewed_head_sha": "abc123",
+                "completed_at": "2026-04-22T00:05:00Z",
+            }
+        ],
+        actor_row={
+            "backend_identity": "lane-221",
+            "runtime_status": "healthy",
+            "session_action_recommendation": "continue-session",
+            "metadata_json": json.dumps({"sessionControl": {}}),
+        },
+    )
+
+    assert actions == [
+        {
+            "action_type": "dispatch_repair_handoff",
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "target_head_sha": "abc123",
+            "reason": "local-review-findings-need-repair",
+        }
+    ]
+
+
+def test_derive_shadow_actions_skips_duplicate_local_review_repair_handoff(runtime_module):
+    actions = runtime_module.derive_shadow_actions_for_lane(
+        lane_row={
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "workflow_state": "claude_prepublish_findings",
+            "active_pr_number": None,
+            "current_head_sha": "abc123",
+            "repair_brief_json": json.dumps(
+                {
+                    "forHeadSha": "abc123",
+                    "mustFix": [{"summary": "Fix validation"}],
+                    "shouldFix": [],
+                }
+            ),
+        },
+        reviews=[
+            {
+                "reviewer_scope": "internal",
+                "status": "completed",
+                "verdict": "PASS_WITH_FINDINGS",
+                "review_scope": "local-prepublish",
+                "reviewed_head_sha": "abc123",
+                "completed_at": "2026-04-22T00:05:00Z",
+            }
+        ],
+        actor_row={
+            "backend_identity": "lane-221",
+            "runtime_status": "healthy",
+            "session_action_recommendation": "continue-session",
+            "metadata_json": json.dumps(
+                {
+                    "sessionControl": {
+                        "lastClaudeRepairHandoff": {
+                            "sessionName": "lane-221",
+                            "headSha": "abc123",
+                            "reviewedAt": "2026-04-22T00:05:00Z",
+                        }
+                    }
+                }
+            ),
+        },
+    )
+
+    assert actions == []
+
+
+def test_persist_shadow_actions_returns_existing_action_on_idempotency_conflict(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    paths = runtime_module._runtime_paths(workflow_root)
+    now_iso = "2026-04-22T00:00:00Z"
+    repair_brief = {
+        "forHeadSha": "abc123",
+        "mustFix": [{"summary": "Fix validation"}],
+        "shouldFix": [],
+    }
+    conn = runtime_module._connect(paths["db_path"])
+    try:
+        conn.execute(
+            """
+            INSERT INTO lanes (
+              lane_id, issue_number, issue_url, issue_title, repo_path, actor_backend,
+              lane_status, workflow_state, review_state, merge_state, current_head_sha,
+              repair_brief_json, active_actor_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "lane:221",
+                221,
+                "https://example.com/issues/221",
+                "Issue 221",
+                "/tmp/repo",
+                "acpx-codex",
+                "active",
+                "claude_prepublish_findings",
+                "findings_open",
+                "blocked",
+                "abc123",
+                json.dumps(repair_brief),
+                "actor:lane:221:coder",
+                now_iso,
+                now_iso,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO lane_actors (
+              actor_id, lane_id, actor_role, actor_name, backend_type, backend_identity,
+              model_name, runtime_status, session_action_recommendation, last_seen_at,
+              last_used_at, can_continue, can_nudge, restart_count, failure_count,
+              metadata_json, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "actor:lane:221:coder",
+                "lane:221",
+                "Internal_Coder_Agent",
+                "Internal_Coder_Agent",
+                "acpx-codex",
+                "lane-221",
+                "gpt-5.3-codex",
+                "healthy",
+                "continue-session",
+                now_iso,
+                now_iso,
+                1,
+                0,
+                0,
+                0,
+                json.dumps({"sessionControl": {}}),
+                now_iso,
+                now_iso,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO lane_reviews (
+              review_id, lane_id, reviewer_scope, reviewer_role, reviewer_name,
+              backend_type, status, verdict, reviewed_head_sha, review_scope,
+              completed_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "review:lane:221:internal",
+                "lane:221",
+                "internal",
+                "Internal_Reviewer_Agent",
+                "Internal_Reviewer_Agent",
+                "internalReview",
+                "completed",
+                "PASS_WITH_FINDINGS",
+                "abc123",
+                "local-prepublish",
+                "2026-04-22T00:05:00Z",
+                now_iso,
+                now_iso,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    first = runtime_module.persist_shadow_actions(
+        workflow_root=workflow_root,
+        lane_id="lane:221",
+        now_iso="2026-04-22T00:06:00Z",
+    )
+    second = runtime_module.persist_shadow_actions(
+        workflow_root=workflow_root,
+        lane_id="lane:221",
+        now_iso="2026-04-22T00:07:00Z",
+    )
+
+    assert first[0]["action_type"] == "dispatch_repair_handoff"
+    assert second == first
+    conn = runtime_module._connect(paths["db_path"])
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM lane_actions WHERE action_mode='shadow' AND action_type='dispatch_repair_handoff'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
 def test_execute_requested_action_records_ambiguous_failure_without_name_error(runtime_module, tmp_path):
     workflow_root = tmp_path / "workflow"
     paths = runtime_module._runtime_paths(workflow_root)

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -125,7 +125,7 @@ def test_should_dispatch_claude_repair_handoff_rejects_duplicate_handoff_for_sam
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     result = reviews_module.should_dispatch_claude_repair_handoff(
-        lane_state={"sessionControl": {"lastClaudeRepairHandoff": {"sessionName": "lane-224", "headSha": "head123", "reviewedAt": "2026-04-22T01:00:00Z"}}},
+        lane_state={"sessionControl": {"lastInternalReviewRepairHandoff": {"sessionName": "lane-224", "headSha": "head123", "reviewedAt": "2026-04-22T01:00:00Z"}}},
         session_action={"action": "continue-session", "sessionName": "lane-224"},
         internal_review={
             "reviewScope": "local-prepublish",
@@ -553,11 +553,11 @@ def test_repair_handoff_payload_builders_shape_claude_and_codex_payloads():
         now_iso="2026-04-23T00:21:00Z",
     )
 
-    assert claude_payload["action"] == "claude-repair-handoff"
+    assert claude_payload["action"] == "internal-review-repair-handoff"
     assert claude_payload["mustFixCount"] == 1
     assert claude_payload["shouldFixCount"] == 2
     assert claude_payload["headSha"] == "abc123"
-    assert codex_payload["action"] == "codex-cloud-repair-handoff"
+    assert codex_payload["action"] == "external-review-repair-handoff"
     assert codex_payload["mustFixCount"] == 0
     assert codex_payload["shouldFixCount"] == 1
     assert codex_payload["headSha"] == "def456"
@@ -591,8 +591,8 @@ def test_record_repair_handoff_helpers_store_payload_under_session_control(tmp_p
         write_json_fn=fake_write,
     )
 
-    assert claude_state["sessionControl"]["lastClaudeRepairHandoff"]["headSha"] == "abc123"
-    assert codex_state["sessionControl"]["lastCodexCloudRepairHandoff"]["headSha"] == "def456"
+    assert claude_state["sessionControl"]["lastInternalReviewRepairHandoff"]["headSha"] == "abc123"
+    assert codex_state["sessionControl"]["lastExternalReviewRepairHandoff"]["headSha"] == "def456"
     assert seen["loaded"] == [lane_state_path, lane_state_path]
     assert seen["written"][0][0] == lane_state_path
     assert seen["written"][1][0] == lane_state_path
@@ -970,11 +970,11 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
 
     assert changed is True
     assert result["dispatched"] is True
-    assert result["mode"] == "claude_repair_handoff"
+    assert result["mode"] == "internal_review_repair_handoff"
     assert result["issueNumber"] == 224
     assert ledger["internalReviewRepairHandoff"]["sessionName"] == "lane-224"
     assert captured["run_acpx"]["session_name"] == "lane-224"
-    assert captured["audit"][0]["action"] == "claude-repair-handoff-dispatched"
+    assert captured["audit"][0]["action"] == "internal-review-repair-handoff-dispatched"
     # Record helper actually wrote .lane-state.json
     assert (worktree / ".lane-state.json").exists()
 
@@ -1024,10 +1024,10 @@ def test_maybe_dispatch_repair_handoff_dispatches_codex_cloud_branch_when_routab
 
     assert changed is True
     assert result["dispatched"] is True
-    assert result["mode"] == "codex_cloud_repair_handoff"
+    assert result["mode"] == "external_review_repair_handoff"
     assert result["issueNumber"] == 224
     assert ledger["externalReviewRepairHandoff"]["sessionName"] == "lane-224"
-    assert captured["audit"][0]["action"] == "codex-cloud-repair-handoff-dispatched"
+    assert captured["audit"][0]["action"] == "external-review-repair-handoff-dispatched"
 
 
 def test_maybe_dispatch_repair_handoff_returns_noop_when_no_dispatch_branch_is_routable(tmp_path):

--- a/tests/test_workflows_code_review_workflow.py
+++ b/tests/test_workflows_code_review_workflow.py
@@ -178,7 +178,7 @@ def test_derive_next_action_dispatches_retry_turn_when_failure_budget_is_reached
     assert result["reason"] == "failure-retry-budget-reached"
 
 
-def test_derive_next_action_dispatches_claude_repair_handoff_when_review_is_actionable_and_session_is_routable():
+def test_derive_next_action_dispatches_internal_review_repair_handoff_when_review_is_actionable_and_session_is_routable():
     workflow_module = load_module("daedalus_workflows_change_delivery_workflow_test", "workflows/change_delivery/workflow.py")
 
     result = workflow_module.derive_next_action(
@@ -210,11 +210,11 @@ def test_derive_next_action_dispatches_claude_repair_handoff_when_review_is_acti
     )
 
     assert result["type"] == "dispatch_codex_turn"
-    assert result["mode"] == "claude_repair_handoff"
-    assert result["reason"] == "claude-findings-need-repair"
+    assert result["mode"] == "internal_review_repair_handoff"
+    assert result["reason"] == "internal-review-findings-need-repair"
 
 
-def test_derive_next_action_dispatches_codex_cloud_repair_handoff_when_review_is_actionable_and_session_is_routable():
+def test_derive_next_action_dispatches_external_review_repair_handoff_when_review_is_actionable_and_session_is_routable():
     workflow_module = load_module("daedalus_workflows_change_delivery_workflow_test", "workflows/change_delivery/workflow.py")
 
     result = workflow_module.derive_next_action(
@@ -246,8 +246,8 @@ def test_derive_next_action_dispatches_codex_cloud_repair_handoff_when_review_is
     )
 
     assert result["type"] == "dispatch_codex_turn"
-    assert result["mode"] == "codex_cloud_repair_handoff"
-    assert result["reason"] == "codex-cloud-findings-need-repair"
+    assert result["mode"] == "external_review_repair_handoff"
+    assert result["reason"] == "external-review-findings-need-repair"
 
 
 def test_derive_next_action_dispatches_postpublish_repair_when_codex_findings_require_restart():
@@ -282,7 +282,7 @@ def test_derive_next_action_dispatches_postpublish_repair_when_codex_findings_re
 
     assert result["type"] == "dispatch_codex_turn"
     assert result["mode"] == "postpublish_repair"
-    assert result["reason"] == "codex-cloud-findings-need-repair"
+    assert result["reason"] == "external-review-findings-need-repair"
 
 
 def test_derive_next_action_falls_back_to_wrapper_value_for_unhandled_cases():


### PR DESCRIPTION
## Summary
- derive `dispatch_repair_handoff` for local pre-publish review findings when the implementer session is healthy and routable
- keep shadow parity compatible when a derived shadow action already exists by returning the existing idempotent action
- adapt repair-handoff dedupe state to the new review-neutral model: `lastInternalReviewRepairHandoff` / `lastExternalReviewRepairHandoff`
- add regression coverage for local review repair handoff derivation, duplicate handoff suppression, and persisted shadow action conflicts

## Validation
- `pytest -q` -> `873 passed, 7 skipped`
- `pytest -q tests/test_runtime_tools_alerts.py tests/test_workflows_code_review_reviews.py tests/test_workflows_code_review_workflow.py tests/test_workflows_code_review_workspace.py` -> `106 passed`

## Notes
Rebased on `main` after PR #87 and force-with-lease pushed the branch. The PR now targets the repo-owned `WORKFLOW.md` / actor-stage-gate contract model and avoids adding new Claude/Codex-specific repair-handoff state keys.