### PR TITLE
[codex] Filter codex app-server events by active turn

### DIFF
--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -951,6 +951,8 @@ class CodexAppServerRuntime:
         params = message.get("params")
         if not isinstance(params, dict):
             params = {}
+        if not self._message_matches_active_run(method, params, state=state):
+            return False
         state.last_event = method
 
         if method in {"protocol/error", "error"}:
@@ -1009,9 +1011,66 @@ class CodexAppServerRuntime:
             self._notify_progress(state)
             return True
         elif self._is_request_notification(method):
-            state.last_message = f"unsupported app-server request: {method}"
+            pass
         self._notify_progress(state)
         return False
+
+    def _message_matches_active_run(self, method: str, params: dict[str, Any], *, state: _RunState) -> bool:
+        thread_id = self._message_thread_id(params)
+        turn_id = self._message_turn_id(params)
+
+        if thread_id and state.thread_id and thread_id != state.thread_id:
+            return False
+        if turn_id and state.turn_id and turn_id != state.turn_id:
+            return False
+        if thread_id and state.thread_id is None:
+            return method == "thread/started"
+        if turn_id and state.turn_id is None:
+            return method == "turn/started"
+        return True
+
+    def _message_thread_id(self, params: dict[str, Any]) -> str | None:
+        return self._first_message_id(
+            params,
+            direct_keys=("threadId", "thread_id"),
+            id_object_key="thread",
+            nested_keys=("item",),
+        )
+
+    def _message_turn_id(self, params: dict[str, Any]) -> str | None:
+        return self._first_message_id(
+            params,
+            direct_keys=("turnId", "turn_id"),
+            id_object_key="turn",
+            nested_keys=("item",),
+        )
+
+    def _first_message_id(
+        self,
+        params: dict[str, Any],
+        *,
+        direct_keys: tuple[str, ...],
+        id_object_key: str,
+        nested_keys: tuple[str, ...],
+    ) -> str | None:
+        for key in direct_keys:
+            value = params.get(key)
+            if value not in (None, ""):
+                return str(value)
+        nested = params.get(id_object_key)
+        if isinstance(nested, dict):
+            value = nested.get("id")
+            if value not in (None, ""):
+                return str(value)
+        for key in nested_keys:
+            nested = params.get(key)
+            if not isinstance(nested, dict):
+                continue
+            for direct_key in direct_keys:
+                value = nested.get(direct_key)
+                if value not in (None, ""):
+                    return str(value)
+        return None
 
     def _is_request_notification(self, method: str) -> bool:
         return method.startswith("item/") or method.startswith("mcpServer/")

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -512,6 +512,92 @@ def test_codex_app_server_runtime_speaks_jsonrpc_and_maps_metrics(tmp_path):
     }
 
 
+def test_codex_app_server_runtime_filters_events_by_active_thread_and_turn():
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime, _RunState
+
+    runtime = CodexAppServerRuntime({"command": [sys.executable, "-c", ""]}, run=None)
+    state = _RunState(session_id="thread-current", thread_id="thread-current", turn_id="turn-current")
+
+    assert (
+        runtime._consume_message(
+            {"method": "error", "params": {"threadId": "thread-stale", "turnId": "turn-stale", "message": "timed out"}},
+            state=state,
+        )
+        is False
+    )
+    assert state.last_event is None
+
+    assert (
+        runtime._consume_message(
+            {
+                "method": "turn/completed",
+                "params": {"threadId": "thread-current", "turn": {"id": "turn-stale", "status": "completed"}},
+            },
+            state=state,
+        )
+        is False
+    )
+    assert state.last_event is None
+
+    assert (
+        runtime._consume_message(
+            {
+                "method": "thread/tokenUsage/updated",
+                "params": {
+                    "threadId": "thread-current",
+                    "turnId": "turn-stale",
+                    "tokenUsage": {"last": {"inputTokens": 99, "outputTokens": 99, "totalTokens": 198}},
+                },
+            },
+            state=state,
+        )
+        is False
+    )
+    assert state.tokens == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+    assert (
+        runtime._consume_message(
+            {
+                "method": "turn/completed",
+                "params": {"threadId": "thread-current", "turn": {"id": "turn-current", "status": "completed"}},
+            },
+            state=state,
+        )
+        is True
+    )
+    assert state.last_event == "turn/completed"
+
+    with pytest.raises(CodexAppServerError, match="current failure"):
+        runtime._consume_message(
+            {
+                "method": "error",
+                "params": {"threadId": "thread-current", "turnId": "turn-current", "message": "current failure"},
+            },
+            state=state,
+        )
+
+
+def test_codex_app_server_runtime_tracks_item_notifications_without_unsupported_message():
+    from runtimes.codex_app_server import CodexAppServerRuntime, _RunState
+
+    runtime = CodexAppServerRuntime({"command": [sys.executable, "-c", ""]}, run=None)
+    state = _RunState(session_id="thread-current", thread_id="thread-current", turn_id="turn-current")
+
+    assert (
+        runtime._consume_message(
+            {
+                "method": "item/started",
+                "params": {"threadId": "thread-current", "turnId": "turn-current", "itemId": "item-current"},
+            },
+            state=state,
+        )
+        is False
+    )
+
+    assert state.last_event == "item/started"
+    assert state.last_message is None
+
+
 def test_codex_app_server_runtime_resumes_existing_thread(tmp_path):
     from runtimes.codex_app_server import CodexAppServerRuntime
 


### PR DESCRIPTION
## Summary

Filter codex-app-server notifications before they can mutate the active runtime state. The runtime now ignores events whose `threadId` or `turnId` belongs to another app-server thread or a stale turn, preventing stale websocket broadcasts from completing or failing the current lane.

## Root Cause

`CodexAppServerRuntime._consume_message` processed every websocket notification as if it belonged to the active turn. A stale `error`, `turn/completed`, or token usage update from another thread could mark the active implementation run failed or complete even while the real app-server turn kept running.

## Changes

- Added thread/turn correlation for app-server messages before updating run state.
- Kept canonical item/mcp notifications as normal progress events instead of recording them as unsupported request messages.
- Added focused tests for foreign errors, stale same-thread turn completions, stale token usage, and item notifications.

## Validation

- `python3 -m pytest tests/test_runtimes_codex_app_server.py`
- `python3 -m pytest tests/test_runtime_stage_dispatcher.py tests/test_workflows_code_review_actions.py tests/test_workflows_code_review_workspace.py`
- `python3 -m pytest`