### PR TITLE
[codex] Make change-delivery provider-neutral

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1312,7 +1312,7 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
             "reason": "implementation-in-progress",
         }]
     if (
-        workflow_state in {"claude_prepublish_findings", "rework_required"}
+        workflow_state in {"pre_publish_review_findings", "rework_required"}
         and not active_pr_number
         and internal_review
         and internal_review.get("status") == "completed"
@@ -1334,7 +1334,7 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
             "reason": "local-review-findings-need-repair",
         }]
     if (
-        workflow_state in {"claude_prepublish_findings", "rework_required"}
+        workflow_state in {"pre_publish_review_findings", "rework_required"}
         and not active_pr_number
         and internal_review
         and internal_review.get("status") == "completed"
@@ -1366,7 +1366,7 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
             "reason": "local-repair-head-ahead-of-published-pr",
         }]
     if (
-        workflow_state == "awaiting_claude_prepublish"
+        workflow_state == "awaiting_pre_publish_review"
         and not active_pr_number
         and lane_row.get("required_internal_review")
         and (internal_review is None or internal_review.get("status") in {None, "", "pending", "not_started"})
@@ -1699,7 +1699,7 @@ def _run_legacy_publish_pr(*, workflow_root: Path) -> dict[str, Any]:
 
 
 def _run_legacy_request_internal_review(*, workflow_root: Path) -> dict[str, Any]:
-    return _run_workflow_cli_json(workflow_root=workflow_root, command="dispatch-claude-review")
+    return _run_workflow_cli_json(workflow_root=workflow_root, command="dispatch-internal-review")
 
 
 def _run_legacy_merge_pr(*, workflow_root: Path) -> dict[str, Any]:

--- a/daedalus/skills/daedalus-architecture/SKILL.md
+++ b/daedalus/skills/daedalus-architecture/SKILL.md
@@ -378,7 +378,7 @@ Recommended order:
 9. add heartbeat / lease refresh and a one-shot shadow iteration loop shell
 10. only then build the long-running service loop and plugin control surface
 11. first active-execution slice should usually wrap the existing workflow package's side-effect command (for example `dispatch-implementation-turn`) while Daedalus owns leases, action rows, and execution accounting
-12. when expanding active execution beyond the first slice, keep the same pattern: add or reuse a dedicated workflow CLI subcommand per side effect (for example `dispatch-claude-review`, `dispatch-repair-handoff`, `push-pr-update`, or `publish-ready-pr`) and route Daedalus execution through a small action-runner registry keyed by Daedalus `action_type`
+12. when expanding active execution beyond the first slice, keep the same pattern: add or reuse a dedicated workflow CLI subcommand per side effect (for example `dispatch-internal-review`, `dispatch-repair-handoff`, `push-pr-update`, or `publish-ready-pr`) and route Daedalus execution through a small action-runner registry keyed by Daedalus `action_type`
 - when the next active slice is a repair-handoff path, do not route Daedalus through a generic implementation command and hope workflow internals happen to do the right thing; add a dedicated workflow command (for example `dispatch-repair-handoff`) backed by a shared helper that both direct execution and reconcile/tick can call
 - that shared-helper extraction matters because duplicated repair-handoff logic across reconcile and direct execution will drift, and then Daedalus active mode and workflow-derived status will disagree in deeply annoying ways
 

--- a/daedalus/skills/operator/SKILL.md
+++ b/daedalus/skills/operator/SKILL.md
@@ -253,7 +253,7 @@ The workflow ledger renames two `reviews.*` keys for provider neutrality:
 around the canonical provider-neutral keys.
 
 **Action-type literal.** Operator commands should use
-`dispatch-claude-review`; runtime execution records use
+`dispatch-internal-review`; runtime execution records use
 `request_internal_review`.
 
 **What this means for you:** nothing — the rename is transparent. If you write external tooling that reads the ledger directly (e.g., a dashboard parsing `workflow-status.json`), update it to use `reviews.internalReview` / `reviews.externalReview`.
@@ -261,10 +261,10 @@ around the canonical provider-neutral keys.
 ## Deprecation cleanup (Phase D-2)
 
 The one-release back-compat aliases introduced in Phases B / D-1 have been removed:
-- `render_codex_cloud_repair_handoff_prompt` no longer importable — use `render_external_reviewer_repair_handoff_prompt`
-- The `run_claude_review` action-type literal is no longer dispatched — only `run_internal_review`
+- `render_external_review_repair_handoff_prompt` no longer importable — use `render_external_reviewer_repair_handoff_prompt`
+- Provider-specific internal-review action literals are gone; use `run_internal_review` at workflow level and `request_internal_review` in Daedalus action rows.
 - `get_review(reviews, key)` no longer falls back to legacy ledger keys — `migrate_persisted_ledger` already ran on D-1 boot
-- 8 functions in `workflows/change_delivery/reviews.py` were renamed (`fetch_codex_cloud_review` → `fetch_external_review`, etc.); old names retained as one-release aliases
+- 8 functions in `workflows/change_delivery/reviews.py` were renamed (`fetch_external_review_review` → `fetch_external_review`, etc.); old names are gone.
 
 ## Persisted-state migration round 2 (Phase D-3)
 
@@ -283,12 +283,12 @@ Plus `claudeModel` is dropped entirely — its value lives in `internalReviewerM
 
 **Status output keys also renamed** — external tooling that parsed `claudeModel` / `interReviewAgentModel` / `codexCloudAutoResolved` / `lastClaudeVerdict` from `workflow-status.json` should switch to the new names.
 
-**Workspace internals.** Four `_codex_cloud_repair_handoff_*` shims in `workflows/change_delivery/workspace.py` renamed to `_external_review_repair_handoff_*`. Workspace-internal API; affects subagent test fixtures only.
+**Workspace internals.** Repair-handoff shims in `workflows/change_delivery/workspace.py` use provider-neutral internal/external review names. Workspace-internal API; affects subagent test fixtures only.
 
 ## Deprecation cleanup round 2 (Phase D-4)
 
 The Phase D-2 / D-3 one-release back-compat aliases have been removed:
-- 8 D-2 module-level function aliases in `workflows/change_delivery/reviews.py` (`fetch_codex_cloud_review`, etc.) — gone. Use the `external_review` names.
+- 8 D-2 module-level function aliases in `workflows/change_delivery/reviews.py` (`fetch_external_review_review`, etc.) — gone. Use the `external_review` names.
 - D-3 read-time legacy-key fallbacks in `get_ledger_field`, `reviews.py:308`, `workspace.py:504` — gone. Live ledgers were migrated by the D-3 bootstrap; restored backups still get migrated automatically before any read.
 - Per-thread `"source": "codexCloud"` review-thread label is now `"externalReview"`. Threads are rebuilt from GitHub data each tick, so old labels self-heal.
 

--- a/daedalus/workflows/change_delivery/__init__.py
+++ b/daedalus/workflows/change_delivery/__init__.py
@@ -30,8 +30,7 @@ CONFIG_SCHEMA_PATH = Path(__file__).parent / "schema.yaml"
 PREFLIGHT_GATED_COMMANDS = frozenset({
     "tick",
     "dispatch-implementation-turn",
-    "dispatch-claude-review",
-    "dispatch-inter-review-agent",
+    "dispatch-internal-review",
     "dispatch-repair-handoff",
     "restart-actor-session",
     "publish-ready-pr",

--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -552,9 +552,9 @@ def run_dispatch_inter_review_agent_review(
     worktree = Path(impl['worktree']) if impl.get('worktree') else None
     if worktree is None:
         return {'dispatched': False, 'reason': 'missing-worktree'}
-    preflight = ((status.get('preflight') or {}).get('interReviewAgent') or (status.get('preflight') or {}).get('claudeReview') or {})
+    preflight = ((status.get('preflight') or {}).get('prePublishReview') or {})
     if not preflight.get('shouldRun'):
-        return {'dispatched': False, 'reason': 'claude-preflight-blocked', 'preflight': preflight}
+        return {'dispatched': False, 'reason': 'internal-review-preflight-blocked', 'preflight': preflight}
     head_sha = preflight.get('currentHeadSha')
     now_iso = now_iso_fn()
     run_id = new_inter_review_agent_run_id_fn()

--- a/daedalus/workflows/change_delivery/cli.py
+++ b/daedalus/workflows/change_delivery/cli.py
@@ -39,12 +39,9 @@ def build_parser() -> argparse.ArgumentParser:
     doctor_parser = sub.add_parser("doctor", help="Check and attempt safe workflow repair.")
     doctor_parser.add_argument("--no-fix-watchers", action="store_true", help="Do not disable broken issue watchers during doctor.")
 
-    preflight_claude = sub.add_parser("preflight-claude-review", help="Run cheap deterministic preflight for the internal review agent.")
-    preflight_claude.add_argument("--json", action="store_true", help="Accepted for compatibility; preflight output is always JSON.")
-    preflight_claude.add_argument("--wake-if-needed", action="store_true", help="Wake the internal review runner when preflight says it should run soon.")
-    preflight_inter = sub.add_parser("preflight-inter-review-agent", help="Run cheap deterministic preflight for the internal review agent.")
-    preflight_inter.add_argument("--json", action="store_true", help="Accepted for compatibility; preflight output is always JSON.")
-    preflight_inter.add_argument("--wake-if-needed", action="store_true", help="Wake the internal review runner when preflight says it should run soon.")
+    preflight_internal = sub.add_parser("preflight-internal-review", help="Run cheap deterministic preflight for the internal review stage.")
+    preflight_internal.add_argument("--json", action="store_true", help="Accepted for scripting; preflight output is always JSON.")
+    preflight_internal.add_argument("--wake-if-needed", action="store_true", help="Wake the internal review runner when preflight says it should run soon.")
 
     wake_job = sub.add_parser("wake-job", help="Wake one named job now by pulling its next run forward.")
     wake_job.add_argument("name", help="Exact cron job name to wake.")
@@ -64,10 +61,8 @@ def build_parser() -> argparse.ArgumentParser:
     push_pr_update_parser.add_argument("--json", action="store_true", help="Print machine-readable push output.")
     merge_and_promote_parser = sub.add_parser("merge-and-promote", help="Merge the approved PR and promote the next lane.")
     merge_and_promote_parser.add_argument("--json", action="store_true", help="Print machine-readable merge output.")
-    claude_dispatch = sub.add_parser("dispatch-claude-review", help="Run the local pre-publish internal review directly from the wrapper.")
-    claude_dispatch.add_argument("--json", action="store_true", help="Print machine-readable dispatch output.")
-    inter_dispatch = sub.add_parser("dispatch-inter-review-agent", help="Run the local pre-publish internal review directly from the wrapper.")
-    inter_dispatch.add_argument("--json", action="store_true", help="Print machine-readable dispatch output.")
+    internal_dispatch = sub.add_parser("dispatch-internal-review", help="Run the local pre-publish internal review directly from the wrapper.")
+    internal_dispatch.add_argument("--json", action="store_true", help="Print machine-readable dispatch output.")
     restart_actor = sub.add_parser("restart-actor-session", help="Force-close and recreate the active coder session before dispatching the next lane turn.")
     restart_actor.add_argument("--json", action="store_true", help="Print machine-readable restart output.")
     repair_dispatch = sub.add_parser("dispatch-repair-handoff", help="Send the current repair brief back into the active Codex session.")
@@ -179,9 +174,9 @@ def main(workspace: Any, argv: list[str] | None = None) -> int:
         print(json.dumps(result, indent=2))
         return 0
 
-    if args.command in {"preflight-claude-review", "preflight-inter-review-agent"}:
+    if args.command == "preflight-internal-review":
         status = workspace.build_status()
-        preflight = ((status.get("preflight") or {}).get("interReviewAgent") or (status.get("preflight") or {}).get("claudeReview") or {})
+        preflight = ((status.get("preflight") or {}).get("prePublishReview") or {})
         if args.wake_if_needed and preflight.get("wakeSuggested"):
             workspace.wake_named_jobs([workspace.WORKFLOW_WATCHDOG_JOB_NAME])
             preflight = {**preflight, "woken": True, "wokenJob": workspace.WORKFLOW_WATCHDOG_JOB_NAME}
@@ -251,7 +246,7 @@ def main(workspace: Any, argv: list[str] | None = None) -> int:
         print(json.dumps(result, indent=2))
         return 0
 
-    if args.command in {"dispatch-claude-review", "dispatch-inter-review-agent"}:
+    if args.command == "dispatch-internal-review":
         result = workspace.dispatch_inter_review_agent_review()
         print(json.dumps(result, indent=2))
         return 0

--- a/daedalus/workflows/change_delivery/orchestrator.py
+++ b/daedalus/workflows/change_delivery/orchestrator.py
@@ -74,22 +74,22 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
 
     existing_reviews = ledger.get("reviews") or {}
     if publish_ready:
-        codex_cloud = ws._fetch_external_review(
+        external_review = ws._fetch_external_review(
             open_pr.get("number") if open_pr else None,
             open_pr.get("headRefOid") if open_pr else None,
             get_review(existing_reviews, "externalReview"),
         )
     elif open_pr and open_pr.get("isDraft"):
-        codex_cloud = ws._external_review_placeholder(
+        external_review = ws._external_review_placeholder(
             required=False,
             status="not_started",
-            summary="Draft PR is not ready for Codex Cloud review yet.",
+            summary="Draft PR is not ready for external review yet.",
         )
     else:
-        codex_cloud = ws._external_review_placeholder(
+        external_review = ws._external_review_placeholder(
             required=False,
             status="not_started",
-            summary="Codex Cloud review starts only after the PR is published ready-for-review.",
+            summary="External review starts only after the PR is published ready-for-review.",
         )
 
     implementation = ws._normalize_implementation_for_active_lane(
@@ -144,24 +144,24 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
 
     local_candidate_exists = ws._has_local_candidate(local_head_sha, worktree_commits_ahead)
     existing_internal_review = get_review(existing_reviews, "internalReview")
-    single_pass_claude_gate_satisfied = ws._single_pass_local_claude_gate_satisfied(existing_internal_review, local_head_sha, lane_state)
+    single_pass_internal_review_gate_satisfied = ws._single_pass_local_internal_review_gate_satisfied(existing_internal_review, local_head_sha, lane_state)
     effective_workflow_state = ledger_state
     effective_review_state = ledger.get("reviewState")
-    if not publish_ready and local_candidate_exists and single_pass_claude_gate_satisfied:
+    if not publish_ready and local_candidate_exists and single_pass_internal_review_gate_satisfied:
         effective_workflow_state = "ready_to_publish"
         effective_review_state = "ready_to_publish"
     reviews = ws._load_adapter_reviews_module().build_reviews_block(
         existing_reviews=existing_reviews,
-        codex_cloud=codex_cloud,
+        external_review=external_review,
         publish_ready=publish_ready,
         local_head_sha=local_head_sha,
         local_candidate_exists=local_candidate_exists,
-        inter_review_agent_model=ws.INTER_REVIEW_AGENT_MODEL,
+        inter_review_agent_model=ws.INTERNAL_REVIEW_MODEL,
         internal_reviewer_agent_name=ws.INTERNAL_REVIEWER_AGENT_NAME,
         external_reviewer_agent_name=ws.EXTERNAL_REVIEWER_AGENT_NAME,
         advisory_reviewer_agent_name=ws.ADVISORY_REVIEWER_AGENT_NAME,
         now_iso=ws._now_iso(),
-        claude_seed_fn=(lambda existing, head_sha, now_iso: ws._normalize_local_inter_review_agent_seed(
+        internal_review_seed_fn=(lambda existing, head_sha, now_iso: ws._normalize_local_inter_review_agent_seed(
             existing,
             local_head_sha=head_sha,
             now_iso=now_iso,
@@ -175,7 +175,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
             review_loop_state,
             merge_blocked=merge_blocked,
         )
-    claude_preflight = ws._inter_review_agent_preflight(
+    pre_publish_review_preflight = ws._inter_review_agent_preflight(
         active_lane=active_lane,
         open_pr=open_pr,
         workflow_state=effective_workflow_state,
@@ -184,18 +184,18 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         inter_review_agent_job=ws._summarize_job(job_map.get(ws.WORKFLOW_WATCHDOG_JOB_NAME)),
         local_head_sha=local_head_sha,
         implementation_commits_ahead=worktree_commits_ahead,
-        single_pass_gate_satisfied=single_pass_claude_gate_satisfied,
+        single_pass_gate_satisfied=single_pass_internal_review_gate_satisfied,
     )
     if (
-        ws.INTER_REVIEW_AGENT_FREEZE_CODER_WHILE_RUNNING
+        ws.INTERNAL_REVIEW_FREEZE_CODER_WHILE_RUNNING
         and ws._inter_review_agent_is_running_on_head(get_review(reviews, "internalReview"), local_head_sha)
     ):
         session_action_recommendation = {
             "action": "no-action",
-            "reason": "claude-review-running",
+            "reason": "internal-review-running",
             "sessionName": (active_session_health or {}).get("sessionName"),
         }
-        nudge_preflight = {"shouldNudge": False, "reason": "claude-review-running"}
+        nudge_preflight = {"shouldNudge": False, "reason": "internal-review-running"}
         acp_session_strategy = ws.build_acp_session_strategy(
             implementation_session_key=implementation.get("session"),
             session_action=session_action_recommendation,
@@ -223,7 +223,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         latest_progress_epoch = ws._latest_lane_progress_epoch(implementation, lane_state)
         if latest_progress_epoch and time.time() - latest_progress_epoch > (ws.LANE_NO_PR_MINUTES * 60):
             stale_lane_reasons.append("active lane has no PR and implementation state is stale")
-    if publish_ready and review_loop_state == "awaiting_reviews" and open_pr and codex_cloud.get("reviewedHeadSha") in {None, ""}:
+    if publish_ready and review_loop_state == "awaiting_reviews" and open_pr and external_review.get("reviewedHeadSha") in {None, ""}:
         stale_lane_reasons.append("published PR is waiting for review artifacts")
     if publish_ready and ledger_state in {"under_review", "revalidating", "findings_open", "rework_required"} and open_pr and (ledger.get("pr") or {}).get("headSha") in {None, ""}:
         stale_lane_reasons.append("review state lacks current PR head SHA")
@@ -272,7 +272,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         },
         reviews=reviews,
         repair_brief=effective_repair_brief,
-        preflight={"claudeReview": claude_preflight},
+        preflight={"prePublishReview": pre_publish_review_preflight},
         workflow_state=effective_workflow_state,
         review_loop_state=review_loop_state,
         merge_blocked=merge_blocked,
@@ -312,7 +312,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         review_loop_state=review_loop_state,
         merge_blocked=merge_blocked,
         merge_blockers=merge_blockers,
-        claude_preflight=claude_preflight,
+        pre_publish_review_preflight=pre_publish_review_preflight,
         detailed_jobs=detailed_jobs,
         hermes_job_names=ws.HERMES_JOB_NAMES,
         missing_core_jobs=missing_core_jobs,
@@ -324,7 +324,7 @@ def build_status_raw(workspace: Any) -> dict[str, Any]:
         health=health,
         legacy_watchdog_present=legacy_watchdog_present,
         legacy_watchdog_mode=legacy_watchdog_mode,
-        inter_review_agent_model=ws.INTER_REVIEW_AGENT_MODEL,
+        inter_review_agent_model=ws.INTERNAL_REVIEW_MODEL,
         next_action=next_action,
     )
 
@@ -347,7 +347,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
     review_loop_state = status.get("derivedReviewLoopState")
     merge_blockers = status.get("derivedMergeBlockers") or []
     merge_blocked = bool(status.get("derivedMergeBlocked"))
-    claude_preflight = ((status.get("preflight") or {}).get("interReviewAgent") or (status.get("preflight") or {}).get("claudeReview") or {})
+    pre_publish_review_preflight = ((status.get("preflight") or {}).get("prePublishReview") or {})
     now_iso = status["updatedAt"]
     codex_model = impl.get("codexModel") or ws._codex_model_for_issue(
         active_lane,
@@ -363,7 +363,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         and get_review(reviews, "internalReview").get("verdict") == "PASS_CLEAN"
         and ws._mark_pr_ready_for_review(open_pr.get("number"))
     ):
-        ws.audit("reconcile", "Marked draft PR ready for review after clean pre-publish Claude gate", prNumber=open_pr.get("number"), headSha=impl.get("localHeadSha"))
+        ws.audit("reconcile", "Marked draft PR ready for review after clean pre-publish internal review gate", prNumber=open_pr.get("number"), headSha=impl.get("localHeadSha"))
         status = ws.build_status()
         active_lane = status.get("activeLane")
         open_pr = status.get("openPr")
@@ -372,7 +372,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         review_loop_state = status.get("derivedReviewLoopState")
         merge_blockers = status.get("derivedMergeBlockers") or []
         merge_blocked = bool(status.get("derivedMergeBlocked"))
-        claude_preflight = ((status.get("preflight") or {}).get("interReviewAgent") or (status.get("preflight") or {}).get("claudeReview") or {})
+        pre_publish_review_preflight = ((status.get("preflight") or {}).get("prePublishReview") or {})
         now_iso = status["updatedAt"]
         codex_model = impl.get("codexModel") or ws._codex_model_for_issue(
             active_lane,
@@ -397,7 +397,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         ledger,
         review_loop_state=review_loop_state,
         codex_model=codex_model,
-        inter_review_agent_model=ws.INTER_REVIEW_AGENT_MODEL,
+        inter_review_agent_model=ws.INTERNAL_REVIEW_MODEL,
         actor_labels=ws._actor_labels_payload(codex_model),
         reviews=reviews,
     )
@@ -434,7 +434,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
             now_iso=now_iso,
             repair_brief=repair_brief,
             operator_attention_needed=operator_attention_needed,
-            pass_with_findings_reviews=ws.CLAUDE_PASS_WITH_FINDINGS_REVIEWS,
+            pass_with_findings_reviews=ws.INTERNAL_REVIEW_PASS_WITH_FINDINGS_REVIEWS,
         )
         new_workflow_state = ledger.get("workflowState") or "unknown"
         emit_operator_attention_transition(
@@ -465,15 +465,15 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
             changed["jobs"] = True
             ws.audit("reconcile", "Disabled broken issue watcher jobs", disabledWatchers=disabled_watchers)
 
-    if claude_preflight.get("wakeSuggested"):
+    if pre_publish_review_preflight.get("wakeSuggested"):
         touched = ws._wake_jobs(jobs_payload, [ws.WORKFLOW_WATCHDOG_JOB_NAME])
         if touched:
             changed["jobs"] = True
             ws.audit(
                 "reconcile",
-                "Woke workflow watchdog from cheap Claude preflight",
+                "Woke workflow watchdog from cheap internal review preflight",
                 jobNames=touched,
-                headSha=claude_preflight.get("currentHeadSha"),
+                headSha=pre_publish_review_preflight.get("currentHeadSha"),
             )
 
     resolved_codex_threads = ws._resolve_codex_superseded_threads(
@@ -491,7 +491,7 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         ledger["externalReviewAutoResolved"] = resolution_event
         ws.audit(
             "reconcile",
-            "Resolved superseded Codex Cloud review threads after clean PR-body signal",
+            "Resolved superseded external review threads after clean PR-body signal",
             threadIds=resolved_codex_threads,
             activeLane=(active_lane or {}).get("number"),
             prNumber=(open_pr or {}).get("number"),

--- a/daedalus/workflows/change_delivery/prompts.py
+++ b/daedalus/workflows/change_delivery/prompts.py
@@ -134,14 +134,14 @@ def render_implementation_dispatch_prompt(
     if workflow_state == "ready_to_publish":
         action_and_workflow_block = "\n".join([
             action_line,
-            "The local branch has already passed the Claude pre-publish gate.",
+            "The local branch has already passed the pre-publish internal review gate.",
             "Publish now: push the branch, open or update the PR, and make sure it is ready for review immediately (not left as draft).",
         ])
-    elif workflow_state in {"awaiting_claude_prepublish", "claude_prepublish_findings", "implementing_local", "implementing"} and not open_pr:
+    elif workflow_state in {"awaiting_pre_publish_review", "pre_publish_review_findings", "implementing_local", "implementing"} and not open_pr:
         action_and_workflow_block = "\n".join([
             action_line,
             "Do not publish yet.",
-            "Your target in this phase is a committed local candidate head that is ready for Claude pre-publish review.",
+            "Your target in this phase is a committed local candidate head that is ready for pre-publish internal review.",
         ])
     else:
         action_and_workflow_block = action_line
@@ -202,7 +202,7 @@ def render_external_reviewer_repair_handoff_prompt(
     return apply_workflow_policy(prompt_text, workflow_policy)
 
 
-def render_claude_repair_handoff_prompt(
+def render_internal_review_repair_handoff_prompt(
     *,
     issue: dict[str, Any] | None,
     internal_review: dict[str, Any] | None,
@@ -224,7 +224,7 @@ def render_claude_repair_handoff_prompt(
         reviewed_head_sha=review.get("reviewedHeadSha") or "unknown",
         lane_memo_line=f"Lane memo: {lane_memo_path}" if lane_memo_path else "Lane memo: none",
         lane_state_line=f"Lane state: {lane_state_path}" if lane_state_path else "Lane state: none",
-        review_summary=review.get("summary") or "No Claude summary recorded.",
+        review_summary=review.get("summary") or "No internal review summary recorded.",
         must_fix_lines=must_fix_lines,
         should_fix_lines=should_fix_lines,
     )

--- a/daedalus/workflows/change_delivery/prompts/repair-handoff.md
+++ b/daedalus/workflows/change_delivery/prompts/repair-handoff.md
@@ -4,10 +4,10 @@ Issue: #{issue_number} {issue_title}
 {lane_state_line}
 Read .lane-memo.md and .lane-state.json first; they are authoritative.
 Do not publish yet.
-Stay in the same lane and fix the current Claude pre-publish findings on the local branch.
-After fixes, run focused validation, update the local branch head, and stop for Claude re-review.
+Stay in the same lane and fix the current pre-publish internal review findings on the local branch.
+After fixes, run focused validation, update the local branch head, and stop for internal re-review.
 
-Claude summary:
+Internal review summary:
 {review_summary}
 
 Current must-fix items:

--- a/daedalus/workflows/change_delivery/reviewers/github_comments.py
+++ b/daedalus/workflows/change_delivery/reviewers/github_comments.py
@@ -1,6 +1,6 @@
 """GitHub PR-comments external reviewer.
 
-Generalizes the Codex Cloud fetcher: configurable bot logins,
+Generalizes the external reviewer fetcher: configurable bot logins,
 clean/pending reactions, repo slug, cache TTL. Delegates to
 ``reviews.fetch_external_review`` /
 ``reviews.fetch_external_review_pr_body_signal`` for the actual work.

--- a/daedalus/workflows/change_delivery/reviews.py
+++ b/daedalus/workflows/change_delivery/reviews.py
@@ -272,15 +272,15 @@ def classify_lane_failure(
     internal_review = get_review(reviews, "internalReview")
     if internal_review.get("status") in {"failed", "timed_out"}:
         detail = internal_review.get("failureClass") or internal_review.get("status")
-        return {"failureClass": f"claude_review_{internal_review.get('status')}", "detail": detail}
+        return {"failureClass": f"internal_review_{internal_review.get('status')}", "detail": detail}
     if internal_review.get("required") and internal_review.get("verdict") in {"PASS_WITH_FINDINGS", "REWORK"}:
-        return {"failureClass": "claude_findings_open", "detail": internal_review.get("verdict")}
+        return {"failureClass": "internal_review_findings_open", "detail": internal_review.get("verdict")}
     if external_review.get("required") and int(external_review.get("openFindingCount") or 0) > 0:
-        return {"failureClass": "codex_cloud_findings_open", "detail": external_review.get("verdict") or "open-findings"}
-    claude_preflight = preflight.get("claudeReview") or {}
-    reasons = list(claude_preflight.get("reasons") or [])
+        return {"failureClass": "external_review_findings_open", "detail": external_review.get("verdict") or "open-findings"}
+    pre_publish_review_preflight = preflight.get("prePublishReview") or {}
+    reasons = list(pre_publish_review_preflight.get("reasons") or [])
     if reasons:
-        return {"failureClass": "claude_preflight_blocked", "detail": reasons[0]}
+        return {"failureClass": "internal_review_preflight_blocked", "detail": reasons[0]}
     return {"failureClass": None, "detail": None}
 
 
@@ -354,7 +354,7 @@ def local_inter_review_agent_review_count(review: dict[str, Any] | None, lane_st
     return count
 
 
-def single_pass_local_claude_gate_satisfied(
+def single_pass_local_internal_review_gate_satisfied(
     review: dict[str, Any] | None,
     local_head_sha: str | None,
     lane_state: dict[str, Any] | None = None,
@@ -442,30 +442,30 @@ def inter_review_agent_preflight(
     if not active_lane:
         reasons.append("no-active-lane")
     if publish_ready:
-        reasons.append("postpublish-claude-disabled")
+        reasons.append("postpublish-internal-review-disabled")
     if not has_local_candidate_fn(local_head_sha, implementation_commits_ahead):
         reasons.append("no-local-head-candidate")
-    if workflow_state not in {"implementing_local", "awaiting_claude_prepublish", "claude_prepublish_findings", "ready_to_publish", "implementing"}:
-        reasons.append("workflow-not-awaiting-local-claude")
+    if workflow_state not in {"implementing_local", "awaiting_pre_publish_review", "pre_publish_review_findings", "ready_to_publish", "implementing"}:
+        reasons.append("workflow-not-awaiting-local-review")
     if not checks_acceptable:
         reasons.append("checks-not-acceptable")
     if single_pass_gate_satisfied:
-        reasons.append("single-pass-claude-already-satisfied")
+        reasons.append("single-pass-internal-review-already-satisfied")
 
     review_status = inter_review_agent_review.get("status")
     reviewed_head = inter_review_agent_review.get("reviewedHeadSha")
     requested_head = target_head_fn(inter_review_agent_review)
     requested_at = _iso_to_epoch(inter_review_agent_review.get("requestedAt"))
     if target_head_sha and review_status == "completed" and reviewed_head == target_head_sha and inter_review_agent_review.get("reviewScope") == review_scope:
-        reasons.append("claude-review-already-current")
+        reasons.append("internal-review-already-current")
     if target_head_sha and review_status == "running" and requested_head == target_head_sha:
         started_epoch = started_epoch_fn(inter_review_agent_review)
         if started_epoch is not None and (now_epoch - started_epoch) >= timeout_seconds:
-            reasons.append("claude-review-running-timed-out")
+            reasons.append("internal-review-running-timed-out")
         else:
-            reasons.append("claude-review-running-current-head")
+            reasons.append("internal-review-running-current-head")
             if requested_at is not None and (now_epoch - requested_at) < request_cooldown_seconds:
-                reasons.append("claude-review-request-recent")
+                reasons.append("internal-review-request-recent")
 
     should_run = not reasons
     next_run_at = (inter_review_agent_job or {}).get("nextRunAtMs")
@@ -1060,7 +1060,7 @@ def record_external_review_repair_handoff(
     return state
 
 
-def build_claude_repair_handoff_payload(
+def build_internal_review_repair_handoff_payload(
     *,
     session_action: dict[str, Any],
     issue: dict[str, Any] | None,
@@ -1088,7 +1088,7 @@ def build_claude_repair_handoff_payload(
     }
 
 
-def record_claude_repair_handoff(
+def record_internal_review_repair_handoff(
     *,
     worktree: Any,
     payload: dict[str, Any],
@@ -1206,7 +1206,7 @@ def normalize_local_inter_review_agent_seed(
     return inter_review_agent_pending_seed(model=model)
 
 
-def should_dispatch_claude_repair_handoff(
+def should_dispatch_internal_review_repair_handoff(
     *,
     lane_state: dict[str, Any] | None,
     session_action: dict[str, Any],
@@ -1219,7 +1219,7 @@ def should_dispatch_claude_repair_handoff(
     review = internal_review or {}
     if has_open_pr:
         return {"shouldDispatch": False, "reason": "published-pr-phase"}
-    if workflow_state != "claude_prepublish_findings":
+    if workflow_state != "pre_publish_review_findings":
         return {"shouldDispatch": False, "reason": "workflow-not-awaiting-local-repair"}
     if session_action.get("action") not in {"continue-session", "poke-session"}:
         return {"shouldDispatch": False, "reason": "session-not-routable"}
@@ -1228,9 +1228,9 @@ def should_dispatch_claude_repair_handoff(
     if review.get("reviewScope") != "local-prepublish":
         return {"shouldDispatch": False, "reason": "wrong-review-scope"}
     if review.get("status") != "completed":
-        return {"shouldDispatch": False, "reason": "claude-review-not-complete"}
+        return {"shouldDispatch": False, "reason": "internal-review-not-complete"}
     if review.get("verdict") not in {"PASS_WITH_FINDINGS", "REWORK"}:
-        return {"shouldDispatch": False, "reason": "claude-review-not-actionable"}
+        return {"shouldDispatch": False, "reason": "internal-review-not-actionable"}
     if not current_head_sha or review.get("reviewedHeadSha") != current_head_sha:
         return {"shouldDispatch": False, "reason": "review-head-mismatch"}
     if (repair_brief or {}).get("forHeadSha") != current_head_sha:
@@ -1269,9 +1269,9 @@ def should_dispatch_external_review_repair_handoff(
     if review.get("reviewScope") != "postpublish-pr":
         return {"shouldDispatch": False, "reason": "wrong-review-scope"}
     if review.get("status") != "completed":
-        return {"shouldDispatch": False, "reason": "codex-review-not-complete"}
+        return {"shouldDispatch": False, "reason": "external-review-not-complete"}
     if review.get("verdict") not in {"PASS_WITH_FINDINGS", "REWORK"}:
-        return {"shouldDispatch": False, "reason": "codex-review-not-actionable"}
+        return {"shouldDispatch": False, "reason": "external-review-not-actionable"}
     if not current_head_sha or review.get("reviewedHeadSha") != current_head_sha:
         return {"shouldDispatch": False, "reason": "review-head-mismatch"}
     if (repair_brief or {}).get("forHeadSha") != current_head_sha:
@@ -1337,7 +1337,7 @@ def maybe_dispatch_repair_handoff(
     from pathlib import Path as _Path
 
     from workflows.change_delivery.prompts import (
-        render_claude_repair_handoff_prompt,
+        render_internal_review_repair_handoff_prompt,
         render_external_reviewer_repair_handoff_prompt,
     )
 
@@ -1363,7 +1363,7 @@ def maybe_dispatch_repair_handoff(
     lane_memo_path_obj = _Path(lane_memo_path_str) if lane_memo_path_str else None
     lane_state_path_obj = _Path(lane_state_path_str) if lane_state_path_str else None
 
-    claude_decision = should_dispatch_claude_repair_handoff(
+    internal_review_decision = should_dispatch_internal_review_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
         internal_review=get_review(reviews, "internalReview"),
@@ -1372,8 +1372,8 @@ def maybe_dispatch_repair_handoff(
         current_head_sha=impl.get("localHeadSha"),
         has_open_pr=bool(open_pr),
     )
-    if claude_decision.get("shouldDispatch"):
-        repair_payload = build_claude_repair_handoff_payload(
+    if internal_review_decision.get("shouldDispatch"):
+        repair_payload = build_internal_review_repair_handoff_payload(
             session_action=session_action,
             issue=issue,
             internal_review=get_review(reviews, "internalReview"),
@@ -1382,7 +1382,7 @@ def maybe_dispatch_repair_handoff(
             lane_state_path=lane_state_path_str,
             now_iso=now_iso,
         )
-        repair_prompt = render_claude_repair_handoff_prompt(
+        repair_prompt = render_internal_review_repair_handoff_prompt(
             issue=issue,
             internal_review=get_review(reviews, "internalReview"),
             repair_brief=repair_brief,
@@ -1396,7 +1396,7 @@ def maybe_dispatch_repair_handoff(
             prompt=repair_prompt,
             codex_model=codex_model,
         )
-        record_claude_repair_handoff(
+        record_internal_review_repair_handoff(
             worktree=worktree,
             payload=repair_payload,
             lane_state_path_fn=lane_state_path_fn,
@@ -1423,7 +1423,7 @@ def maybe_dispatch_repair_handoff(
             "payload": repair_payload,
         }, True
 
-    codex_cloud_decision = should_dispatch_external_review_repair_handoff(
+    external_review_decision = should_dispatch_external_review_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
         external_review=get_review(reviews, "externalReview"),
@@ -1432,7 +1432,7 @@ def maybe_dispatch_repair_handoff(
         current_head_sha=open_pr.get("headRefOid") or impl.get("localHeadSha"),
         has_open_pr=bool(open_pr),
     )
-    if codex_cloud_decision.get("shouldDispatch"):
+    if external_review_decision.get("shouldDispatch"):
         repair_payload = build_external_review_repair_handoff_payload(
             session_action=session_action,
             issue=issue,
@@ -1487,15 +1487,15 @@ def maybe_dispatch_repair_handoff(
     return {
         "dispatched": False,
         "reason": "repair-handoff-not-needed",
-        "internalReviewReason": claude_decision.get("reason"),
-        "externalReviewReason": codex_cloud_decision.get("reason"),
+        "internalReviewReason": internal_review_decision.get("reason"),
+        "externalReviewReason": external_review_decision.get("reason"),
     }, False
 
 
 def build_reviews_block(
     *,
     existing_reviews: dict[str, Any],
-    codex_cloud: dict[str, Any],
+    external_review: dict[str, Any],
     publish_ready: bool,
     local_head_sha: str | None,
     local_candidate_exists: bool,
@@ -1504,12 +1504,12 @@ def build_reviews_block(
     external_reviewer_agent_name: str,
     advisory_reviewer_agent_name: str,
     now_iso: str,
-    claude_seed_fn: Callable[[dict[str, Any] | None, str | None, str], dict[str, Any]] | None = None,
+    internal_review_seed_fn: Callable[[dict[str, Any] | None, str | None, str], dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Assemble the ``reviews`` block exposed by ``build_status_raw``.
 
     Routes publish-ready vs pre-publish branches to the right normalized seeds,
-    using adapter-owned review normalizers. ``claude_seed_fn`` is optional; if
+    using adapter-owned review normalizers. ``internal_review_seed_fn`` is optional; if
     not provided, a minimal pre-publish seed with the given model is used.
     """
     existing_internal_review = get_review(existing_reviews, "internalReview")
@@ -1525,22 +1525,22 @@ def build_reviews_block(
             "internalReview": normalize_review(
                 {**(existing_internal_review or {}), "model": (existing_internal_review or {}).get("model") or inter_review_agent_model},
                 required=False,
-                pending_summary="Claude pre-publish gate already completed before publication.",
+                pending_summary="Internal pre-publish review already completed before publication.",
                 agent_name=internal_reviewer_agent_name,
                 agent_role="internal_reviewer_agent",
             ),
             "externalReview": {
-                **codex_cloud,
+                **external_review,
                 "required": True,
                 "reviewScope": "postpublish-pr",
-                "agentName": codex_cloud.get("agentName") or external_reviewer_agent_name,
-                "agentRole": codex_cloud.get("agentRole") or "external_reviewer_agent",
+                "agentName": external_review.get("agentName") or external_reviewer_agent_name,
+                "agentRole": external_review.get("agentRole") or "external_reviewer_agent",
             },
         }
-    if claude_seed_fn is not None:
-        claude_seed = claude_seed_fn(existing_internal_review, local_head_sha, now_iso)
+    if internal_review_seed_fn is not None:
+        internal_review_seed = internal_review_seed_fn(existing_internal_review, local_head_sha, now_iso)
     else:
-        claude_seed = inter_review_agent_pending_seed(model=inter_review_agent_model)
+        internal_review_seed = inter_review_agent_pending_seed(model=inter_review_agent_model)
     return {
         "rockClaw": normalize_review(
             existing_reviews.get("rockClaw"),
@@ -1550,16 +1550,16 @@ def build_reviews_block(
             agent_role="advisory_reviewer_agent",
         ),
         "internalReview": normalize_review(
-            claude_seed,
+            internal_review_seed,
             required=local_candidate_exists,
             pending_summary="Pending local unpublished branch review before publication.",
             agent_name=internal_reviewer_agent_name,
             agent_role="internal_reviewer_agent",
         ),
         "externalReview": {
-            **codex_cloud,
-            "agentName": codex_cloud.get("agentName") or external_reviewer_agent_name,
-            "agentRole": codex_cloud.get("agentRole") or "external_reviewer_agent",
+            **external_review,
+            "agentName": external_review.get("agentName") or external_reviewer_agent_name,
+            "agentRole": external_review.get("agentRole") or "external_reviewer_agent",
         },
     }
 
@@ -1589,7 +1589,7 @@ def audit_inter_review_agent_transition(
         or current_review.get("reviewScope") != previous_review.get("reviewScope")
     ):
         audit_fn(
-            "claude-review-requested",
+            "internal-review-requested",
             f"{internal_reviewer_agent_name} review requested for head {requested_head}",
             headSha=requested_head,
             status=current_review.get("status") or "pending",
@@ -1605,7 +1605,7 @@ def audit_inter_review_agent_transition(
         or current_review.get("verdict") != previous_review.get("verdict")
     ):
         audit_fn(
-            "claude-review-completed",
+            "internal-review-completed",
             f"{internal_reviewer_agent_name} {current_review.get('verdict') or 'completed'} for head {reviewed_head}",
             headSha=reviewed_head,
             verdict=current_review.get("verdict"),
@@ -1621,7 +1621,7 @@ def audit_inter_review_agent_transition(
     ):
         summary = current_review.get("failureSummary") or current_review.get("summary") or f"{terminal_status} local internal review"
         audit_fn(
-            f"claude-review-{terminal_status}",
+            f"internal-review-{terminal_status}",
             summary,
             headSha=target_head_fn(current_review),
             status=terminal_status,
@@ -1749,7 +1749,7 @@ def run_inter_review_agent_review(
     inter_review_agent_max_turns: int,
     error_cls: type = subprocess.CalledProcessError,
 ) -> dict[str, Any]:
-    """Run the Claude inter-review agent CLI and return its parsed verdict.
+    """Run the internal review agent CLI and return its parsed verdict.
 
     Callers inject the subprocess ``run_fn`` (wrapper's ``_run``), the
     CalledProcessError class raised by that runner, and the model/max-turns

--- a/daedalus/workflows/change_delivery/sessions.py
+++ b/daedalus/workflows/change_delivery/sessions.py
@@ -552,7 +552,7 @@ def decide_session_action(
         return {"action": "continue-session", "reason": None, "sessionName": health.get("sessionName")}
     if health.get("canPoke") and health.get("reason") == "stale-open-session":
         return {"action": "poke-session", "reason": health.get("reason"), "sessionName": health.get("sessionName")}
-    if implementation_status in {"implementing", "implementing_local", "revalidating", "findings_open", "rework_required", "self_checked", "awaiting_claude_prepublish", "claude_prepublish_findings", "ready_to_publish"} or has_open_pr:
+    if implementation_status in {"implementing", "implementing_local", "revalidating", "findings_open", "rework_required", "self_checked", "awaiting_pre_publish_review", "pre_publish_review_findings", "ready_to_publish"} or has_open_pr:
         return {"action": "restart-session", "reason": health.get("reason") or "missing-session", "sessionName": health.get("sessionName")}
     return {"action": "no-action", "reason": "lane-not-active", "sessionName": health.get("sessionName")}
 

--- a/daedalus/workflows/change_delivery/status.py
+++ b/daedalus/workflows/change_delivery/status.py
@@ -23,7 +23,7 @@ from workflows.change_delivery.reviews import (
     has_local_candidate,
     inter_review_agent_target_head,
     local_inter_review_agent_review_count,
-    single_pass_local_claude_gate_satisfied,
+    single_pass_local_internal_review_gate_satisfied,
 )
 from workflows.change_delivery.sessions import (
     decide_session_action,
@@ -255,7 +255,7 @@ def normalize_status(status: dict[str, Any], workflow_root: Path | None = None) 
     open_pr = normalized.get("openPr")
     ledger = normalized.get("ledger") or {}
     reviews = normalized.get("reviews") or {}
-    codex_cloud = get_review(reviews, "externalReview")
+    external_review = get_review(reviews, "externalReview")
 
     implementation["sessionActionRecommendation"] = decide_session_action(
         active_session_health=implementation.get("activeSessionHealth"),
@@ -273,7 +273,7 @@ def normalize_status(status: dict[str, Any], workflow_root: Path | None = None) 
         review_loop_state=normalized.get("derivedReviewLoopState") or ledger.get("reviewLoopState"),
         ledger_state=ledger.get("workflowState"),
         ledger_pr_head_sha=((ledger.get("pr") or {}).get("headSha")),
-        codex_reviewed_head_sha=codex_cloud.get("reviewedHeadSha"),
+        codex_reviewed_head_sha=external_review.get("reviewedHeadSha"),
         now_epoch=int(time.time()),
     )
 
@@ -411,7 +411,7 @@ def assemble_status_payload(
     review_loop_state: str | None,
     merge_blocked: bool,
     merge_blockers: list[str],
-    claude_preflight: dict[str, Any],
+    pre_publish_review_preflight: dict[str, Any],
     detailed_jobs: dict[str, Any],
     hermes_job_names: list[str],
     missing_core_jobs: list[str],
@@ -490,14 +490,12 @@ def assemble_status_payload(
         },
         "reviews": {
             **reviews,
-            "interReviewAgent": get_review(reviews, "internalReview") or None,
         },
         "derivedReviewLoopState": review_loop_state,
         "derivedMergeBlocked": merge_blocked,
         "derivedMergeBlockers": merge_blockers,
         "preflight": {
-            "claudeReview": claude_preflight,
-            "interReviewAgent": claude_preflight,
+            "prePublishReview": pre_publish_review_preflight,
         },
         "nextAction": next_action,
         "coreJobs": detailed_jobs,
@@ -526,8 +524,8 @@ def derive_latest_progress(
 ) -> dict[str, Any]:
     """Return the meaningful-progress marker the lane state payload should record.
 
-    Mirrors the wrapper's ``_derive_latest_progress``: promotes the Codex Cloud
-    completion timestamp to ``kind="approved"`` when the PR is cleanly reviewed,
+    Mirrors the wrapper's ``_derive_latest_progress``: promotes the external
+    review completion timestamp to ``kind="approved"`` when the PR is cleanly reviewed,
     otherwise falls back to the implementation status / ledger workflow state.
     """
     impl = implementation or {}
@@ -538,16 +536,16 @@ def derive_latest_progress(
         "at": impl.get("updatedAt") or now_iso,
     }
     external_review = get_review(reviews, "externalReview")
-    codex_updated_at = external_review.get("updatedAt")
+    external_review_updated_at = external_review.get("updatedAt")
     if (
         open_pr
         and review_loop_state == "clean"
         and not merge_blocked
         and external_review.get("status") == "completed"
         and external_review.get("verdict") == "PASS_CLEAN"
-        and codex_updated_at
+        and external_review_updated_at
     ):
-        return {"kind": "approved", "at": codex_updated_at}
+        return {"kind": "approved", "at": external_review_updated_at}
     return default
 
 
@@ -690,12 +688,12 @@ def apply_active_lane_ledger_transition(
         approval["approvedAt"] = now_iso if ledger["workflowState"] == "approved" else None
         approval["approvedHeadSha"] = (open_pr or {}).get("headRefOid") if ledger["workflowState"] == "approved" else None
         approval["pendingReason"] = None if ledger["workflowState"] == "approved" else (
-            "open-review-findings" if review_loop_state in {"findings_open", "rework_required"} else "awaiting-codex-cloud"
+            "open-review-findings" if review_loop_state in {"findings_open", "rework_required"} else "awaiting-external-review"
         )
     else:
         local_candidate = has_local_candidate(local_head_sha, implementation.get("commitsAhead"))
-        claude_current = current_inter_review_agent_matches_local_head(internal_review, local_head_sha)
-        single_pass_gate = single_pass_local_claude_gate_satisfied(
+        internal_review_current = current_inter_review_agent_matches_local_head(internal_review, local_head_sha)
+        single_pass_gate = single_pass_local_internal_review_gate_satisfied(
             previous_internal_review or internal_review,
             local_head_sha,
             implementation.get("laneState"),
@@ -704,20 +702,20 @@ def apply_active_lane_ledger_transition(
         ledger["workflowState"] = resolve_prepublish_workflow_state(
             local_candidate=local_candidate,
             single_pass_gate_satisfied=single_pass_gate,
-            claude_current=claude_current,
-            claude_verdict=internal_review.get("verdict"),
+            internal_review_current=internal_review_current,
+            internal_review_verdict=internal_review.get("verdict"),
         )
         ledger["reviewState"] = ledger["workflowState"]
         approval["status"] = "not-approved"
         approval["approvedAt"] = None
         approval["approvedHeadSha"] = None
         approval["pendingReason"] = (
-            "awaiting-local-claude" if ledger["workflowState"] != "ready_to_publish" else "awaiting-publish"
+            "awaiting-local-review" if ledger["workflowState"] != "ready_to_publish" else "awaiting-publish"
         )
     ledger["repairBrief"] = repair_brief
     if repair_brief is not None and not publish_ready:
-        ledger["workflowState"] = "claude_prepublish_findings"
-        ledger["reviewState"] = "claude_prepublish_findings"
+        ledger["workflowState"] = "pre_publish_review_findings"
+        ledger["reviewState"] = "pre_publish_review_findings"
         approval["pendingReason"] = "open-review-findings"
     if operator_attention_needed:
         ledger["workflowState"] = "operator_attention_required"
@@ -781,27 +779,27 @@ def resolve_prepublish_workflow_state(
     *,
     local_candidate: bool,
     single_pass_gate_satisfied: bool,
-    claude_current: bool,
-    claude_verdict: str | None,
+    internal_review_current: bool,
+    internal_review_verdict: str | None,
 ) -> str:
     """Classify the pre-publish workflow state for an active lane.
 
     Ordered rules (first match wins):
 
     1. No local candidate yet -> ``implementing_local``.
-    2. Pre-publish Claude gate already satisfied on the current head ->
+    2. Pre-publish internal review gate already satisfied on the current head ->
        ``ready_to_publish``.
-    3. Claude review completed against the current head with actionable
-       findings -> ``claude_prepublish_findings``.
-    4. Fallback -> ``awaiting_claude_prepublish``.
+    3. Internal review completed against the current head with actionable
+       findings -> ``pre_publish_review_findings``.
+    4. Fallback -> ``awaiting_pre_publish_review``.
     """
     if not local_candidate:
         return "implementing_local"
     if single_pass_gate_satisfied:
         return "ready_to_publish"
-    if claude_current and claude_verdict in {"PASS_WITH_FINDINGS", "REWORK"}:
-        return "claude_prepublish_findings"
-    return "awaiting_claude_prepublish"
+    if internal_review_current and internal_review_verdict in {"PASS_WITH_FINDINGS", "REWORK"}:
+        return "pre_publish_review_findings"
+    return "awaiting_pre_publish_review"
 
 
 def increment_no_progress_ticks(
@@ -952,20 +950,12 @@ def write_lane_state(
             "lastInternalReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or get_lane_state_review_field(existing.get("review"), "lastInternalReviewedHeadSha"),
             "lastInternalVerdict": ((get_review(reviews, "internalReview")).get("verdict")) or ((existing.get("review") or {}).get("lastInternalVerdict")),
             "localInternalReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
-            "currentClaudeRunId": ((get_review(reviews, "internalReview")).get("runId")),
-            "currentClaudeTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
-            "currentClaudeStatus": ((get_review(reviews, "internalReview")).get("status")),
-            "currentClaudeTerminalState": ((get_review(reviews, "internalReview")).get("terminalState")),
-            "lastClaudeFailureClass": ((get_review(reviews, "internalReview")).get("failureClass")),
-            "lastInterReviewAgentReviewedHeadSha": ((get_review(reviews, "internalReview")).get("reviewedHeadSha")) or ((existing.get("review") or {}).get("lastInterReviewAgentReviewedHeadSha")),
-            "lastInterReviewAgentVerdict": ((get_review(reviews, "internalReview")).get("verdict")) or ((existing.get("review") or {}).get("lastInterReviewAgentVerdict")),
-            "localInterReviewAgentReviewCount": local_inter_review_agent_review_count((get_review(reviews, "internalReview") or None), existing),
-            "currentInterReviewAgentRunId": ((get_review(reviews, "internalReview")).get("runId")),
-            "currentInterReviewAgentTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
-            "currentInterReviewAgentStatus": ((get_review(reviews, "internalReview")).get("status")),
-            "currentInterReviewAgentTerminalState": ((get_review(reviews, "internalReview")).get("terminalState")),
-            "lastInterReviewAgentFailureClass": ((get_review(reviews, "internalReview")).get("failureClass")),
-            "lastCodexCloudReviewedHeadSha": (get_review(reviews, "externalReview").get("reviewedHeadSha")),
+            "currentInternalReviewRunId": ((get_review(reviews, "internalReview")).get("runId")),
+            "currentInternalReviewTargetHeadSha": inter_review_agent_target_head((get_review(reviews, "internalReview") or None)),
+            "currentInternalReviewStatus": ((get_review(reviews, "internalReview")).get("status")),
+            "currentInternalReviewTerminalState": ((get_review(reviews, "internalReview")).get("terminalState")),
+            "lastInternalReviewFailureClass": ((get_review(reviews, "internalReview")).get("failureClass")),
+            "lastExternalReviewReviewedHeadSha": (get_review(reviews, "externalReview").get("reviewedHeadSha")),
         },
         "failure": {
             "lastClass": failure_class,

--- a/daedalus/workflows/change_delivery/workflow.py
+++ b/daedalus/workflows/change_delivery/workflow.py
@@ -6,7 +6,7 @@ from workflows.change_delivery.migrations import get_review
 from workflows.change_delivery.reviews import (
     has_local_candidate,
     inter_review_agent_is_running_on_head,
-    should_dispatch_claude_repair_handoff,
+    should_dispatch_internal_review_repair_handoff,
     should_dispatch_external_review_repair_handoff,
 )
 
@@ -48,7 +48,7 @@ def derive_next_action(
     workflow_state = ((status.get("ledger") or {}).get("workflowState"))
     review_loop_state = status.get("derivedReviewLoopState")
     merge_blocked = bool(status.get("derivedMergeBlocked"))
-    claude_preflight = ((status.get("preflight") or {}).get("claudeReview") or {})
+    pre_publish_review_preflight = ((status.get("preflight") or {}).get("prePublishReview") or {})
     operator_attention_reasons = _operator_attention_reasons(status)
     pr_head_sha = (open_pr or {}).get("headRefOid")
     fallback = status.get("nextAction") or {"type": "noop", "reason": "no-forward-action-needed"}
@@ -64,7 +64,7 @@ def derive_next_action(
     if inter_review_agent_is_running_on_head(internal_review, local_head_sha):
         return {
             "type": "noop",
-            "reason": "claude-review-running",
+            "reason": "internal-review-running",
             "issueNumber": active_lane.get("number") if active_lane else None,
             "headSha": local_head_sha,
         }
@@ -97,13 +97,13 @@ def derive_next_action(
             health == "stale-lane"
             and not open_pr
             and not operator_attention_reasons
-            and claude_preflight.get("shouldRun")
-            and workflow_state in {"implementing_local", "awaiting_claude_prepublish", "claude_prepublish_findings", "implementing"}
+            and pre_publish_review_preflight.get("shouldRun")
+            and workflow_state in {"implementing_local", "awaiting_pre_publish_review", "pre_publish_review_findings", "implementing"}
         ):
             return {
                 "type": "run_internal_review",
-                "reason": "prepublish-claude-required",
-                "headSha": claude_preflight.get("currentHeadSha"),
+                "reason": "prepublish-review-required",
+                "headSha": pre_publish_review_preflight.get("currentHeadSha"),
                 "issueNumber": active_lane.get("number"),
                 "sessionName": session_action.get("sessionName"),
             }
@@ -138,7 +138,7 @@ def derive_next_action(
             "headSha": local_head_sha,
         }
 
-    if int(failure_state.get("retryCount") or 0) >= failure_retry_budget and workflow_state in {"implementing_local", "implementing", "claude_prepublish_findings", "findings_open", "rework_required"} and session_action.get("action") in {"continue-session", "poke-session", "restart-session"}:
+    if int(failure_state.get("retryCount") or 0) >= failure_retry_budget and workflow_state in {"implementing_local", "implementing", "pre_publish_review_findings", "findings_open", "rework_required"} and session_action.get("action") in {"continue-session", "poke-session", "restart-session"}:
         return {
             "type": "dispatch_codex_turn",
             "mode": "implementation" if not open_pr else "postpublish_repair",
@@ -163,16 +163,16 @@ def derive_next_action(
             "prNumber": (open_pr or {}).get("number"),
         }
 
-    if claude_preflight.get("shouldRun"):
+    if pre_publish_review_preflight.get("shouldRun"):
         return {
             "type": "run_internal_review",
-            "reason": "prepublish-claude-required",
-            "headSha": claude_preflight.get("currentHeadSha"),
+            "reason": "prepublish-review-required",
+            "headSha": pre_publish_review_preflight.get("currentHeadSha"),
             "issueNumber": active_lane.get("number"),
             "sessionName": session_action.get("sessionName"),
         }
 
-    if should_dispatch_claude_repair_handoff(
+    if should_dispatch_internal_review_repair_handoff(
         lane_state=lane_state,
         session_action=session_action,
         internal_review=get_review(reviews, "internalReview"),

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -147,8 +147,8 @@ def _yaml_to_legacy_view(yaml_cfg: dict, workspace_root: "Path | None" = None) -
             "reviewHeadMissingMinutes": 20,
         },
         "reviewCache": {
-            "codexCloudSeconds": ext_reviewer.get("cache-seconds", 1800),
-            "claudeReviewRequestCooldownSeconds": internal_review_gate.get("request-cooldown-seconds", 1200),
+            "externalReviewSeconds": ext_reviewer.get("cache-seconds", 1800),
+            "internalReviewRequestCooldownSeconds": internal_review_gate.get("request-cooldown-seconds", 1200),
         },
         "sessionPolicy": {
             "codexModel": coder_default.get("model", "gpt-5.3-codex-spark/high"),
@@ -167,11 +167,11 @@ def _yaml_to_legacy_view(yaml_cfg: dict, workspace_root: "Path | None" = None) -
             "codexSessionNudgeCooldownSeconds": acpx.get("session-nudge-cooldown-seconds", 600),
         },
         "reviewPolicy": {
-            "interReviewAgentPassWithFindingsReviews": internal_review_gate.get("pass-with-findings-tolerance", 1),
+            "internalReviewPassWithFindingsReviews": internal_review_gate.get("pass-with-findings-tolerance", 1),
             "internalReviewerModel": int_reviewer.get("model", "claude-sonnet-4-6"),
-            "interReviewAgentMaxTurns": claude_cli.get("max-turns-per-invocation", 24),
-            "interReviewAgentTimeoutSeconds": claude_cli.get("timeout-seconds", 1200),
-            "freezeCoderWhileInterReviewAgentRunning": int_reviewer.get("freeze-coder-while-running", True),
+            "internalReviewMaxTurns": claude_cli.get("max-turns-per-invocation", 24),
+            "internalReviewTimeoutSeconds": claude_cli.get("timeout-seconds", 1200),
+            "freezeCoderWhileInternalReviewRunning": int_reviewer.get("freeze-coder-while-running", True),
         },
         "agentLabels": {
             "internalCoderAgent": coder_default.get("name", "Internal_Coder_Agent"),
@@ -459,8 +459,8 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     review_head_missing_minutes = int(staleness.get("reviewHeadMissingMinutes", 20))
 
     review_cache = config.get("reviewCache", {}) or {}
-    codex_cloud_cache_seconds = int(review_cache.get("codexCloudSeconds", 1800))
-    claude_review_request_cooldown_seconds = int(review_cache.get("claudeReviewRequestCooldownSeconds", 1200))
+    external_review_cache_seconds = int(review_cache.get("externalReviewSeconds", 1800))
+    internal_review_request_cooldown_seconds = int(review_cache.get("internalReviewRequestCooldownSeconds", 1200))
     internal_review_job_name = str(job_names.get("internalReviewRunner") or "internal-review-runner")
     workflow_checker_job_name = str(job_names.get("workflowChecker") or "workflow-checker")
     workflow_watchdog_job_name = str(job_names.get("workflowWatchdog") or "workflow-watchdog")
@@ -487,34 +487,15 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     codex_session_nudge_cooldown_seconds = int(session_policy.get("codexSessionNudgeCooldownSeconds", 600))
 
     review_policy = config.get("reviewPolicy", {}) or {}
-    inter_review_agent_pass_with_findings_reviews = int(
-        review_policy.get("interReviewAgentPassWithFindingsReviews")
-        or review_policy.get("internalReviewerAgentPassWithFindingsReviews")
-        or review_policy.get("claudePassWithFindingsReviews", 1)
-    )
-    inter_review_agent_model = str(
+    internal_review_pass_with_findings_reviews = int(review_policy.get("internalReviewPassWithFindingsReviews", 1))
+    internal_review_model = str(
         review_policy.get("internalReviewerModel")
         or "claude-sonnet-4-6"
     )
-    inter_review_agent_max_turns = int(
-        review_policy.get("interReviewAgentMaxTurns")
-        or review_policy.get("internalReviewerAgentMaxTurns")
-        or review_policy.get("claudeReviewMaxTurns", 12)
-    )
-    inter_review_agent_timeout_seconds = int(
-        review_policy.get("interReviewAgentTimeoutSeconds")
-        or review_policy.get("internalReviewerAgentTimeoutSeconds")
-        or review_policy.get("claudeReviewTimeoutSeconds", 1200)
-    )
-    inter_review_agent_freeze_coder_while_running = bool(
-        review_policy.get(
-            "freezeCoderWhileInterReviewAgentRunning",
-            review_policy.get(
-                "freezeCoderWhileInternalReviewAgentRunning",
-                review_policy.get("freezeCoderWhileClaudeReviewRunning", True),
-            ),
-        )
-    )
+    internal_review_max_turns = int(review_policy.get("internalReviewMaxTurns", 12))
+    internal_review_timeout_seconds = int(review_policy.get("internalReviewTimeoutSeconds", 1200))
+    freeze_internal_review = review_policy.get("freezeCoderWhileInternalReviewRunning")
+    internal_review_freeze_coder_while_running = bool(True if freeze_internal_review is None else freeze_internal_review)
 
     agent_labels = config.get("agentLabels", {}) or {}
     internal_coder_agent_name = str(agent_labels.get("internalCoderAgent", "Internal_Coder_Agent"))
@@ -665,14 +646,14 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         MISS_MULTIPLIER=miss_multiplier,
         LANE_NO_PR_MINUTES=lane_no_pr_minutes,
         REVIEW_HEAD_MISSING_MINUTES=review_head_missing_minutes,
-        CLAUDE_REVIEW_JOB_NAME=internal_review_job_name,
+        INTERNAL_REVIEW_JOB_NAME=internal_review_job_name,
         WORKFLOW_CHECKER_JOB_NAME=workflow_checker_job_name,
         WORKFLOW_WATCHDOG_JOB_NAME=workflow_watchdog_job_name,
         CODEX_WATCHDOG_JOB_NAME=workflow_watchdog_job_name,
         TELEGRAM_JOB_NAME=milestone_notifier_job_name,
-        CLAUDE_TRIGGER_STATES={"under_review", "findings_open", "revalidating"},
-        CODEX_CLOUD_CACHE_SECONDS=codex_cloud_cache_seconds,
-        CLAUDE_REVIEW_REQUEST_COOLDOWN_SECONDS=claude_review_request_cooldown_seconds,
+        INTERNAL_REVIEW_TRIGGER_STATES={"under_review", "findings_open", "revalidating"},
+        EXTERNAL_REVIEW_CACHE_SECONDS=external_review_cache_seconds,
+        INTERNAL_REVIEW_REQUEST_COOLDOWN_SECONDS=internal_review_request_cooldown_seconds,
         CODEX_SESSION_POLICY=session_policy,
         CODEX_MODEL_DEFAULT=codex_model_default,
         CODEX_MODEL_HIGH_EFFORT=codex_model_high_effort,
@@ -690,17 +671,11 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         CODEX_SESSION_POKE_GRACE_SECONDS=codex_session_poke_grace_seconds,
         CODEX_SESSION_NUDGE_COOLDOWN_SECONDS=codex_session_nudge_cooldown_seconds,
         REVIEW_POLICY=review_policy,
-        INTER_REVIEW_AGENT_PASS_WITH_FINDINGS_REVIEWS=inter_review_agent_pass_with_findings_reviews,
-        INTER_REVIEW_AGENT_MODEL=inter_review_agent_model,
-        INTER_REVIEW_AGENT_MAX_TURNS=inter_review_agent_max_turns,
-        INTER_REVIEW_AGENT_TIMEOUT_SECONDS=inter_review_agent_timeout_seconds,
-        INTER_REVIEW_AGENT_FREEZE_CODER_WHILE_RUNNING=inter_review_agent_freeze_coder_while_running,
-        # Back-compat aliases for older call-sites still using "CLAUDE" names.
-        CLAUDE_MODEL=inter_review_agent_model,
-        CLAUDE_REVIEW_MAX_TURNS=inter_review_agent_max_turns,
-        CLAUDE_REVIEW_TIMEOUT_SECONDS=inter_review_agent_timeout_seconds,
-        CLAUDE_REVIEW_FREEZE_CODER_WHILE_RUNNING=inter_review_agent_freeze_coder_while_running,
-        CLAUDE_PASS_WITH_FINDINGS_REVIEWS=inter_review_agent_pass_with_findings_reviews,
+        INTERNAL_REVIEW_PASS_WITH_FINDINGS_REVIEWS=internal_review_pass_with_findings_reviews,
+        INTERNAL_REVIEW_MODEL=internal_review_model,
+        INTERNAL_REVIEW_MAX_TURNS=internal_review_max_turns,
+        INTERNAL_REVIEW_TIMEOUT_SECONDS=internal_review_timeout_seconds,
+        INTERNAL_REVIEW_FREEZE_CODER_WHILE_RUNNING=internal_review_freeze_coder_while_running,
         AGENT_LABELS=agent_labels,
         INTERNAL_CODER_AGENT_NAME=internal_coder_agent_name,
         ESCALATION_CODER_AGENT_NAME=escalation_coder_agent_name,
@@ -765,14 +740,14 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     ns.reviewer = build_reviewer(ext_reviewer_cfg, ws_context=reviewer_ctx)
 
     # -- runtimes -------------------------------------------------------
-    # Legacy JSON configs synthesize runtime profiles from session/review
-    # policy fields. Repo-owned WORKFLOW.md configs use their top-level
-    # runtimes block directly, so shared runtimes such as codex-app-server are
-    # configured in one place and selected by actors.*.runtime.
+    # Default runtime profiles are derived from workflow policy fields.
+    # Repo-owned WORKFLOW.md configs can override the top-level runtimes block
+    # directly, so shared runtimes are configured once and selected by
+    # actors.*.runtime.
     _session_policy = config.get("sessionPolicy", {}) or {}
     _review_policy = config.get("reviewPolicy", {}) or {}
 
-    _legacy_runtimes_cfg = {
+    _default_runtimes_cfg = {
         "acpx-codex": {
             "kind": "acpx-codex",
             "session-idle-freshness-seconds": int(
@@ -787,21 +762,13 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         },
         "claude-cli": {
             "kind": "claude-cli",
-            "max-turns-per-invocation": int(
-                _review_policy.get("interReviewAgentMaxTurns")
-                or _review_policy.get("internalReviewerAgentMaxTurns")
-                or _review_policy.get("claudeReviewMaxTurns", 24)
-            ),
-            "timeout-seconds": int(
-                _review_policy.get("interReviewAgentTimeoutSeconds")
-                or _review_policy.get("internalReviewerAgentTimeoutSeconds")
-                or _review_policy.get("claudeReviewTimeoutSeconds", 1200)
-            ),
+            "max-turns-per-invocation": int(_review_policy.get("internalReviewMaxTurns", 24)),
+            "timeout-seconds": int(_review_policy.get("internalReviewTimeoutSeconds", 1200)),
         },
     }
     _runtimes_cfg = {
         str(name): dict(profile or {})
-        for name, profile in (((yaml_cfg or {}).get("runtimes") or _legacy_runtimes_cfg).items())
+        for name, profile in (((yaml_cfg or {}).get("runtimes") or _default_runtimes_cfg).items())
     }
 
     _runtimes = build_runtimes(_runtimes_cfg, run=ns._run, run_json=ns._run_json)
@@ -1048,7 +1015,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def _inter_review_agent_pending_seed():
         return ns._load_adapter_reviews_module().inter_review_agent_pending_seed(
-            model=ns.INTER_REVIEW_AGENT_MODEL,
+            model=ns.INTERNAL_REVIEW_MODEL,
         )
 
     def _session_record_files(session_name):
@@ -1120,9 +1087,6 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def dispatch_inter_review_agent_review():
         return ns._load_adapter_actions_module().dispatch_inter_review_agent_review(ns.WORKSPACE)
-
-    def dispatch_claude_review():
-        return ns._load_adapter_actions_module().dispatch_claude_review(ns.WORKSPACE)
 
     def dispatch_repair_handoff():
         return ns._load_adapter_actions_module().dispatch_repair_handoff(ns.WORKSPACE)
@@ -1571,7 +1535,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             internal_coder_agent_name=ns.INTERNAL_CODER_AGENT_NAME,
             escalation_coder_agent_name=ns.ESCALATION_CODER_AGENT_NAME,
             internal_reviewer_agent_name=ns.INTERNAL_REVIEWER_AGENT_NAME,
-            internal_reviewer_model=ns.INTER_REVIEW_AGENT_MODEL,
+            internal_reviewer_model=ns.INTERNAL_REVIEW_MODEL,
             external_reviewer_agent_name=ns.EXTERNAL_REVIEWER_AGENT_NAME,
             advisory_reviewer_agent_name=ns.ADVISORY_REVIEWER_AGENT_NAME,
         )
@@ -1623,7 +1587,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def _new_inter_review_agent_run_id():
         import uuid as _uuid
-        return f"inter-review-agent:{_uuid.uuid4()}"
+        return f"internal-review:{_uuid.uuid4()}"
 
     def _extract_inter_review_agent_payload(raw_output):
         return ns._load_adapter_reviews_module().extract_inter_review_agent_payload(
@@ -1646,7 +1610,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         adapter_reviews = ns._load_adapter_reviews_module()
         agent_cfg = {
             "name": ns.INTERNAL_REVIEWER_AGENT_NAME,
-            "model": ns.INTER_REVIEW_AGENT_MODEL,
+            "model": ns.INTERNAL_REVIEW_MODEL,
             "runtime": "claude-cli",
         }
         agent_cfg.update(
@@ -1751,12 +1715,12 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         epochs = [epoch for epoch in (ns._iso_to_epoch(value) for value in candidates if value) if epoch is not None]
         return max(epochs) if epochs else None
 
-    def _single_pass_local_claude_gate_satisfied(review, local_head_sha, lane_state=None):
-        return ns._load_adapter_reviews_module().single_pass_local_claude_gate_satisfied(
+    def _single_pass_local_internal_review_gate_satisfied(review, local_head_sha, lane_state=None):
+        return ns._load_adapter_reviews_module().single_pass_local_internal_review_gate_satisfied(
             review,
             local_head_sha,
             lane_state,
-            pass_with_findings_reviews=ns.CLAUDE_PASS_WITH_FINDINGS_REVIEWS,
+            pass_with_findings_reviews=ns.INTERNAL_REVIEW_PASS_WITH_FINDINGS_REVIEWS,
         )
 
     def _fetch_external_review_pr_body_signal(pr_number):
@@ -1803,8 +1767,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             review,
             local_head_sha=local_head_sha,
             now_iso=now_iso,
-            model=ns.INTER_REVIEW_AGENT_MODEL,
-            timeout_seconds=ns.INTER_REVIEW_AGENT_TIMEOUT_SECONDS,
+            model=ns.INTERNAL_REVIEW_MODEL,
+            timeout_seconds=ns.INTERNAL_REVIEW_TIMEOUT_SECONDS,
             target_head_fn=ns._inter_review_agent_target_head,
             started_epoch_fn=ns._inter_review_agent_started_epoch,
             now_epoch_fn=lambda: int(time.time()),
@@ -1876,8 +1840,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             write_json_fn=ns._write_json,
         )
 
-    def should_dispatch_claude_repair_handoff(*, lane_state, session_action, internal_review, repair_brief, workflow_state, current_head_sha, has_open_pr):
-        return ns._load_adapter_reviews_module().should_dispatch_claude_repair_handoff(
+    def should_dispatch_internal_review_repair_handoff(*, lane_state, session_action, internal_review, repair_brief, workflow_state, current_head_sha, has_open_pr):
+        return ns._load_adapter_reviews_module().should_dispatch_internal_review_repair_handoff(
             lane_state=lane_state,
             session_action=session_action,
             internal_review=internal_review,
@@ -1930,8 +1894,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             workflow_policy=ns.WORKFLOW_POLICY,
         )
 
-    def build_claude_repair_handoff_payload(*, session_action, issue, internal_review, repair_brief, lane_memo_path, lane_state_path, now_iso):
-        return ns._load_adapter_reviews_module().build_claude_repair_handoff_payload(
+    def build_internal_review_repair_handoff_payload(*, session_action, issue, internal_review, repair_brief, lane_memo_path, lane_state_path, now_iso):
+        return ns._load_adapter_reviews_module().build_internal_review_repair_handoff_payload(
             session_action=session_action,
             issue=issue,
             internal_review=internal_review,
@@ -1941,8 +1905,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             now_iso=now_iso,
         )
 
-    def record_claude_repair_handoff(*, worktree, payload):
-        return ns._load_adapter_reviews_module().record_claude_repair_handoff(
+    def record_internal_review_repair_handoff(*, worktree, payload):
+        return ns._load_adapter_reviews_module().record_internal_review_repair_handoff(
             worktree=worktree,
             payload=payload,
             lane_state_path_fn=ns._lane_state_path,
@@ -1950,8 +1914,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             write_json_fn=ns._write_json,
         )
 
-    def _render_claude_repair_handoff_prompt(*, issue, internal_review, repair_brief, lane_memo_path, lane_state_path):
-        return ns._load_adapter_prompts_module().render_claude_repair_handoff_prompt(
+    def _render_internal_review_repair_handoff_prompt(*, issue, internal_review, repair_brief, lane_memo_path, lane_state_path):
+        return ns._load_adapter_prompts_module().render_internal_review_repair_handoff_prompt(
             issue=issue,
             internal_review=internal_review,
             repair_brief=repair_brief,
@@ -2081,8 +2045,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             started_epoch_fn=ns._inter_review_agent_started_epoch,
             now_ms_fn=ns._now_ms,
             now_epoch_fn=lambda: int(time.time()),
-            timeout_seconds=ns.INTER_REVIEW_AGENT_TIMEOUT_SECONDS,
-            request_cooldown_seconds=ns.CLAUDE_REVIEW_REQUEST_COOLDOWN_SECONDS,
+            timeout_seconds=ns.INTERNAL_REVIEW_TIMEOUT_SECONDS,
+            request_cooldown_seconds=ns.INTERNAL_REVIEW_REQUEST_COOLDOWN_SECONDS,
         )
 
     def _derive_next_action(*, active_lane, open_pr, health, implementation, reviews, repair_brief, preflight, workflow_state, review_loop_state, merge_blocked):
@@ -2255,12 +2219,9 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             now_iso_fn=ns._now_iso,
             new_inter_review_agent_run_id_fn=ns._new_inter_review_agent_run_id,
             actor_labels_payload_fn=ns._actor_labels_payload,
-            inter_review_agent_model=ns.INTER_REVIEW_AGENT_MODEL,
+            inter_review_agent_model=ns.INTERNAL_REVIEW_MODEL,
             internal_reviewer_agent_name=ns.INTERNAL_REVIEWER_AGENT_NAME,
         )
-
-    def dispatch_claude_review_raw():
-        return ns.dispatch_inter_review_agent_review_raw()
 
     def _maybe_dispatch_repair_handoff(*, status, ledger, now_iso, codex_model, lane_state_override=None):
         return ns._load_adapter_reviews_module().maybe_dispatch_repair_handoff(
@@ -2383,9 +2344,6 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
     def dispatch_inter_review_agent_review():
         return ns.dispatch_inter_review_agent_review_raw()
 
-    def dispatch_claude_review():
-        return ns.dispatch_claude_review_raw()
-
     def dispatch_repair_handoff():
         return ns.dispatch_repair_handoff_raw()
 
@@ -2436,21 +2394,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
         return _normalize_status(ns.build_status_raw(), ns.WORKSPACE)
 
-    # Back-compat aliases ------------------------------------------------
-    # Reference local function variables directly — those are bound by `def`
-    # in the current scope; dereferencing via ``ns.`` would fail here because
-    # the ``setattr(ns, …)`` loop below hasn't run yet.
     _new_review_run_id = _new_inter_review_agent_run_id
-    _claude_review_target_head = _inter_review_agent_target_head
-    _claude_review_started_epoch = _inter_review_agent_started_epoch
-    _claude_review_is_running_on_head = _inter_review_agent_is_running_on_head
-    _classify_claude_review_failure_text = _classify_inter_review_agent_failure_text
-    _extract_claude_review_payload = _extract_inter_review_agent_payload
-    _claude_review_failure_message = _inter_review_agent_failure_message
-    _claude_review_failure_class = _inter_review_agent_failure_class
-    _render_claude_review_prompt = _render_inter_review_agent_prompt
-    _run_claude_change_delivery = _run_inter_review_agent_review
-    _audit_claude_review_transition = _audit_inter_review_agent_transition
 
     # Expose the InterReviewAgentError class so callers using
     # ``workspace.InterReviewAgentError`` can catch it. We bind lazily — if the
@@ -2459,7 +2403,6 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
     # call time via ``ns._load_adapter_reviews_module()`` instead.
     try:
         ns.InterReviewAgentError = ns._load_adapter_reviews_module().InterReviewAgentError
-        ns.ClaudeReviewError = ns.InterReviewAgentError
     except FileNotFoundError:
         pass
 

--- a/docs/adr/ADR-0002-workflows-contract.md
+++ b/docs/adr/ADR-0002-workflows-contract.md
@@ -34,7 +34,7 @@ Re-frame the plugin around a **workflow-plugin contract**:
   `ws.runtime(name)`.
 - The contract front matter cleanly separates **role** (coder, reviewer) from
   **identity** (name, model) from **runtime** (plumbing); no more
-  Claude-prefixed and inter-review-agent-prefixed aliases for the same
+  provider-prefixed aliases for the same
   concept.
 
 ## Consequences

--- a/docs/assets/daedalus-architecture-diagram.svg
+++ b/docs/assets/daedalus-architecture-diagram.svg
@@ -95,11 +95,11 @@
 
   <rect x="990" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
   <text x="1060" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">External Reviewer</text>
-  <text x="1060" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Codex Cloud</text>
+  <text x="1060" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">external review</text>
 
   <rect x="650" y="430" width="480" height="80" rx="10" fill="rgba(6,78,59,0.2)" stroke="#34d399" stroke-width="1.5"/>
   <text x="890" y="452" fill="white" font-family="monospace" font-size="12" font-weight="600" text-anchor="middle">Lane State Machine</text>
-  <text x="890" y="475" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">implementing → awaiting_claude_prepublish → ready_to_publish</text>
+  <text x="890" y="475" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">implementing → awaiting_pre_publish_review → ready_to_publish</text>
   <text x="890" y="492" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">→ under_review → findings_open → approved → merged</text>
 
   <rect x="650" y="535" width="480" height="55" rx="8" fill="rgba(6,78,59,0.15)" stroke="#34d399" stroke-width="1" stroke-dasharray="4,4"/>

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -91,7 +91,7 @@ How code gets written, reviewed, and shipped by explicit actors with defined rol
 |:---|:---|:---|
 | [**Runtimes**](./runtimes.md) | The thing Daedalus shells out to. Claude CLI, Codex, or any subprocess that speaks the session protocol. | ...you want to add a new AI backend or local tool. |
 | [**Sessions**](./sessions.md) | The runtime's handle to a persistent or one-shot execution context. | ...you want to understand how Daedalus manages long-lived coder sessions. |
-| [**Reviewers**](./reviewers.md) | Multi-stage review pipeline: internal (Claude), external (Codex Cloud), advisory (optional). | ...you want to see how review gates are structured and enforced. |
+| [**Reviewers**](./reviewers.md) | Multi-stage review pipeline: internal, external (external review), advisory (optional). | ...you want to see how review gates are structured and enforced. |
 
 **The narrative arc:** *Runtimes* execute → *Sessions* persist state → *Reviewers* gate quality.
 

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -10,7 +10,7 @@ This page describes the `change-delivery` action queue. `issue-runner` uses shar
 
 | Workflow semantic action | Daedalus execution action |
 |---|---|
-| `run_claude_review` | `request_internal_review` |
+| `run_internal_review` | `request_internal_review` |
 | `publish_ready_pr` | `publish_pr` |
 | `merge_and_promote` | `merge_pr` |
 | `dispatch_codex_turn` | `dispatch_implementation_turn` |
@@ -35,7 +35,7 @@ That translation boundary is deliberate. The workflow package speaks **workflow 
 
 | Action | When dispatched |
 |---|---|
-| `request_internal_review` | Local unpublished branch exists and needs Claude gate before publish. |
+| `request_internal_review` | Local unpublished branch exists and needs internal review gate before publish. |
 
 ### PR lifecycle actions
 

--- a/docs/concepts/failures.md
+++ b/docs/concepts/failures.md
@@ -80,9 +80,9 @@ Two hardening fixes during lane 220 work changed how failures interact with the 
 
 ### Fix 1: Failed internal review no longer wedges workflow state
 
-**Before:** `dispatch_claude_review()` failed after marking review `running` in the workflow read model. The lane stayed stuck at `running` forever.
+**Before:** `dispatch_internal_review()` failed after marking review `running` in the workflow read model. The lane stayed stuck at `running` forever.
 
-**After:** Failure resets the Claude review back to a retryable `pending` state.
+**After:** Failure resets the internal review back to a retryable `pending` state.
 
 ### Fix 2: Failed active actions no longer consume the idempotency slot permanently
 

--- a/docs/concepts/hot-reload.md
+++ b/docs/concepts/hot-reload.md
@@ -42,7 +42,7 @@ flowchart LR
   E -- no --> G[abort tick]
 ```
 
-`PREFLIGHT_GATED_COMMANDS` is declared on each workflow module. `change-delivery` gates dispatching commands such as `tick`, `dispatch-implementation-turn`, `dispatch-claude-review`, `publish-ready-pr`, `merge-and-promote`, and `resume`. `issue-runner` gates `tick` and `run`. Read-only commands such as `status`, `doctor`, and inspection helpers bypass the gate.
+`PREFLIGHT_GATED_COMMANDS` is declared on each workflow module. `change-delivery` gates dispatching commands such as `tick`, `dispatch-implementation-turn`, `dispatch-internal-review`, `publish-ready-pr`, `merge-and-promote`, and `resume`. `issue-runner` gates `tick` and `run`. Read-only commands such as `status`, `doctor`, and inspection helpers bypass the gate.
 
 ### What preflight actually checks
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,7 +100,7 @@ pytest -n auto  # parallel (requires pytest-xdist)
 
 ## Adding a workflow stage
 
-The current change-delivery workflow has stages: `implementing` → `awaiting_claude_prepublish` → `ready_to_publish` → `under_review` → `approved` → `merged`.
+The current change-delivery workflow has stages: `implementing` → `awaiting_pre_publish_review` → `ready_to_publish` → `under_review` → `approved` → `merged`.
 
 To add a new stage:
 

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -81,10 +81,10 @@ python3 ~/.hermes/plugins/daedalus/workflows/__main__.py \
   --workflow-root ~/.hermes/workflows/<owner>-<repo>-<workflow-type> \
   dispatch-implementation-turn --json
 
-# Claude review
+# internal review
 python3 ~/.hermes/plugins/daedalus/workflows/__main__.py \
   --workflow-root ~/.hermes/workflows/<owner>-<repo>-<workflow-type> \
-  dispatch-claude-review --json
+  dispatch-internal-review --json
 ```
 
 ### Daedalus Runtime (Direct)
@@ -151,7 +151,7 @@ systemctl --user restart \
 ### Local Phase (No PR yet)
 
 ```
-implementing → awaiting_claude_prepublish → ready_to_publish
+implementing → awaiting_pre_publish_review → ready_to_publish
      ↑                    │
      └──── findings ──────┘
 ```
@@ -179,8 +179,8 @@ under_review → findings_open → approved → merged
 
 | Phase | Required Reviewer | Gate |
 |:---|:---|:---|
-| **Before PR** | Claude (internal) | Must pass before publish |
-| **After PR** | Codex Cloud (external) | Must pass before merge |
+| **Before PR** | Internal reviewer | Must pass before publish |
+| **After PR** | external review (external) | Must pass before merge |
 | **Advisory** | Rock Claw | Informative only |
 
 ---
@@ -192,7 +192,7 @@ under_review → findings_open → approved → merged
 | Internal Coder | `gpt-5.3-codex-spark/high` | Default implementation |
 | Escalation Coder | `gpt-5.4` | Large-effort / complex tasks |
 | Internal Reviewer | `claude-sonnet-4-6` | Local unpublished branch gate |
-| External Reviewer | Codex Cloud | Published PR review |
+| External Reviewer | external review | Published PR review |
 | Advisory Reviewer | Rock Claw | Optional additional eyes |
 
 ---
@@ -200,7 +200,7 @@ under_review → findings_open → approved → merged
 ## Handoff Map
 
 ```
-Orchestrator ──► Coder ──► Internal Reviewer (Claude) ──► Publish ──► External Reviewer (Codex Cloud) ──► Merge
+Orchestrator ──► Coder ──► Internal Reviewer ──► Publish ──► External Reviewer (external review) ──► Merge
      │              │                    │                                    │                          │
      │              │                    └─► repair ──────────────────────────┘                          │
      │              │                                                                                    │
@@ -212,11 +212,11 @@ Orchestrator ──► Coder ──► Internal Reviewer (Claude) ──► Publ
 | Step | Workflow Action | Daedalus Action |
 |:---|:---|:---|
 | 1. Orchestrator → Coder | `dispatch-implementation-turn` | `dispatch_implementation_turn` |
-| 2. Coder → Claude | `run_claude_review` | `request_internal_review` |
-| 3. Claude → Coder repair | local findings → lane session | `dispatch_repair_handoff` |
-| 4. Claude → Publish | workflow derives publish | `publish_pr` |
-| 5. Publish → Codex Cloud | external review triggered | — |
-| 6. Codex Cloud → Coder repair | post-publish findings | `dispatch_repair_handoff` |
+| 2. Coder → Internal Reviewer | `run_internal_review` | `request_internal_review` |
+| 3. Internal Reviewer → Coder repair | local findings → lane session | `dispatch_repair_handoff` |
+| 4. Internal Reviewer → Publish | workflow derives publish | `publish_pr` |
+| 5. Publish → external review | external review triggered | — |
+| 6. external review → Coder repair | post-publish findings | `dispatch_repair_handoff` |
 | 7. Clean → Merge | `merge_and_promote` | `merge_pr` |
 
 ---
@@ -240,7 +240,7 @@ Orchestrator ──► Coder ──► Internal Reviewer (Claude) ──► Publ
 
 ## Common Failure Signatures
 
-### A. Workflow says `run_claude_review`, Daedalus returns `[]`
+### A. Workflow says `run_internal_review`, Daedalus returns `[]`
 
 **Likely cause:** Failed active `request_internal_review` for the same head wedged the idempotency key.
 
@@ -258,9 +258,9 @@ order by requested_at desc;
 
 ### B. Workflow says review is `running` but nothing is actually running
 
-**Likely cause:** `dispatch_claude_review()` failed after marking review as running.
+**Likely cause:** `dispatch_internal_review()` failed after marking review as running.
 
-**Fix:** Already in place — failure now resets Claude review back to retryable pending state.
+**Fix:** Already in place — failure now resets internal review back to retryable pending state.
 
 ---
 
@@ -270,7 +270,7 @@ order by requested_at desc;
 
 **Typical causes:**
 - PR was published or updated
-- Codex Cloud review changed faster than ledger reconciliation
+- External review changed faster than ledger reconciliation
 - Live GitHub truth outran persisted state
 
 **Operator move:** Trust derived live state more than stale ledger prose.
@@ -383,9 +383,9 @@ Tracker feedback is configured in `WORKFLOW.md` under `tracker-feedback`.
 | Coder default model | `gpt-5.3-codex-spark/high` |
 | Coder large-effort model | `gpt-5.3-codex` |
 | Coder escalation model | `gpt-5.4` |
-| Claude model | `claude-sonnet-4-6` |
-| Claude pass-with-findings reviews | `1` |
-| Claude max turns | `12` |
+| Internal reviewer model | `claude-sonnet-4-6` |
+| Internal review pass-with-findings reviews | `1` |
+| Internal review max turns | `12` |
 | Lane failure retry budget | `3` |
 | Lane no-progress tick budget | `3` |
 | Operator-attention thresholds | `5 / 5` |

--- a/docs/operator/slash-commands.md
+++ b/docs/operator/slash-commands.md
@@ -210,7 +210,7 @@ This is the opinionated managed SDLC workflow.
 || `/workflow change-delivery show-lane-state` | `.lane-state.json` contents |
 || `/workflow change-delivery show-lane-memo` | `.lane-memo.md` contents |
 || `/workflow change-delivery dispatch-implementation-turn` | Force a coder turn |
-|| `/workflow change-delivery dispatch-claude-review` | Force an internal Claude review |
+|| `/workflow change-delivery dispatch-internal-review` | Force an internal review |
 || `/workflow change-delivery publish-ready-pr` | Force PR publish |
 || `/workflow change-delivery merge-and-promote` | Force merge + promote next lane |
 || `/workflow change-delivery reconcile` | Repair stale ledger state |

--- a/tests/test_change_delivery_provider_neutral_terms.py
+++ b/tests/test_change_delivery_provider_neutral_terms.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BANNED_TERMS = (
+    "awaiting_claude_prepublish",
+    "claude_prepublish_findings",
+    "dispatch-claude-review",
+    "preflight-claude-review",
+    "claudeReview",
+    "claude-review-",
+    "prepublish-claude-required",
+    "workflow-not-awaiting-local-claude",
+    "single-pass-claude",
+    "claude_findings_open",
+    "claude_preflight_blocked",
+    "codex_cloud_findings_open",
+    "currentClaude",
+    "lastCodexCloud",
+    "prePublishReviewModel",
+    "INTER_REVIEW_AGENT_",
+    "CLAUDE_REVIEW_",
+    "CLAUDE_PASS_",
+    "CODEX_CLOUD_",
+)
+
+SCAN_ROOTS = (
+    REPO_ROOT / "daedalus" / "workflows" / "change_delivery",
+    REPO_ROOT / "daedalus" / "runtime.py",
+    REPO_ROOT / "docs",
+    REPO_ROOT / "tests",
+)
+
+
+def _iter_files(root: Path):
+    if root.is_file():
+        yield root
+        return
+    for path in root.rglob("*"):
+        if path.is_file() and path.suffix in {".py", ".md", ".yaml", ".yml", ".svg"}:
+            yield path
+
+
+def test_change_delivery_workflow_semantics_do_not_use_provider_terms():
+    current_file = Path(__file__).resolve()
+    violations: list[str] = []
+    for root in SCAN_ROOTS:
+        for path in _iter_files(root):
+            if path.resolve() == current_file:
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for term in BANNED_TERMS:
+                if term in text:
+                    violations.append(f"{path.relative_to(REPO_ROOT)}: {term}")
+
+    assert violations == []

--- a/tests/test_external_reviewer_phase_b.py
+++ b/tests/test_external_reviewer_phase_b.py
@@ -131,7 +131,7 @@ def test_github_comments_reviewer_ignores_non_matching_logins():
 
 
 def test_github_comments_reviewer_placeholder():
-    """Placeholder shape matches reviews.codex_cloud_placeholder for back-compat."""
+    """Placeholder shape matches reviews.external_review_placeholder for back-compat."""
     from workflows.change_delivery.reviewers import build_reviewer
 
     cfg = {"enabled": True, "name": "X", "kind": "github-comments", "repo-slug": "x/y"}
@@ -201,7 +201,7 @@ def test_default_clean_reactions_only_includes_thumbs_up():
 
 
 def test_default_cache_seconds_matches_legacy_1800():
-    """Regression: legacy CODEX_CLOUD_CACHE_SECONDS was 1800."""
+    """Regression: default external review cache was 1800 seconds."""
     from workflows.change_delivery.reviewers.github_comments import _DEFAULT_CACHE_SECONDS
     assert _DEFAULT_CACHE_SECONDS == 1800
 

--- a/tests/test_rename_pass_phase_d_4.py
+++ b/tests/test_rename_pass_phase_d_4.py
@@ -14,7 +14,7 @@ import pytest
     "record_codex_cloud_repair_handoff",
     "fetch_codex_pr_body_signal",
 ])
-def test_codex_cloud_alias_dropped(name):
+def test_external_review_alias_dropped(name):
     """All 8 Phase D-2 module-level aliases should be gone."""
     from workflows.change_delivery import reviews
     assert not hasattr(reviews, name), f"{name} alias should have been removed"

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -207,14 +207,14 @@ def test_ingest_legacy_status_uses_canonical_internal_review_for_active_request(
             },
             "externalReview": {"required": False, "status": "not_started"},
         },
-        "ledger": {"workflowState": "awaiting_claude_prepublish", "reviewState": "awaiting_claude_prepublish", "repairBrief": None},
+        "ledger": {"workflowState": "awaiting_pre_publish_review", "reviewState": "awaiting_pre_publish_review", "repairBrief": None},
         "derivedReviewLoopState": "awaiting_reviews",
         "derivedMergeBlocked": False,
         "derivedMergeBlockers": [],
         "openPr": None,
         "activeLaneError": None,
         "staleLaneReasons": [],
-        "nextAction": {"type": "run_internal_review", "reason": "prepublish-claude-required"},
+        "nextAction": {"type": "run_internal_review", "reason": "prepublish-review-required"},
     }
 
     runtime_module.ingest_legacy_status(
@@ -265,14 +265,14 @@ def test_ingest_legacy_status_ignores_old_review_status_keys(runtime_module, tmp
             "claudeCode": {"required": True, "status": "pending", "requestedHeadSha": "abc123"},
             "codexCloud": {"required": True, "status": "pending", "requestedHeadSha": "abc123"},
         },
-        "ledger": {"workflowState": "awaiting_claude_prepublish", "reviewState": "awaiting_claude_prepublish", "repairBrief": None},
+        "ledger": {"workflowState": "awaiting_pre_publish_review", "reviewState": "awaiting_pre_publish_review", "repairBrief": None},
         "derivedReviewLoopState": "awaiting_reviews",
         "derivedMergeBlocked": False,
         "derivedMergeBlockers": [],
         "openPr": None,
         "activeLaneError": None,
         "staleLaneReasons": [],
-        "nextAction": {"type": "run_internal_review", "reason": "prepublish-claude-required"},
+        "nextAction": {"type": "run_internal_review", "reason": "prepublish-review-required"},
     }
 
     runtime_module.ingest_legacy_status(
@@ -303,7 +303,7 @@ def test_derive_shadow_actions_requests_internal_review_without_review_row(runti
         lane_row={
             "lane_id": "lane:221",
             "issue_number": 221,
-            "workflow_state": "awaiting_claude_prepublish",
+            "workflow_state": "awaiting_pre_publish_review",
             "required_internal_review": 1,
             "active_pr_number": None,
             "current_head_sha": "abc123",
@@ -328,7 +328,7 @@ def test_derive_shadow_actions_dispatches_local_review_repair_handoff_when_sessi
         lane_row={
             "lane_id": "lane:221",
             "issue_number": 221,
-            "workflow_state": "claude_prepublish_findings",
+            "workflow_state": "pre_publish_review_findings",
             "active_pr_number": None,
             "current_head_sha": "abc123",
             "repair_brief_json": json.dumps(
@@ -373,7 +373,7 @@ def test_derive_shadow_actions_skips_duplicate_local_review_repair_handoff(runti
         lane_row={
             "lane_id": "lane:221",
             "issue_number": 221,
-            "workflow_state": "claude_prepublish_findings",
+            "workflow_state": "pre_publish_review_findings",
             "active_pr_number": None,
             "current_head_sha": "abc123",
             "repair_brief_json": json.dumps(
@@ -443,7 +443,7 @@ def test_persist_shadow_actions_returns_existing_action_on_idempotency_conflict(
                 "/tmp/repo",
                 "acpx-codex",
                 "active",
-                "claude_prepublish_findings",
+                "pre_publish_review_findings",
                 "findings_open",
                 "blocked",
                 "abc123",
@@ -557,7 +557,7 @@ def test_execute_requested_action_records_ambiguous_failure_without_name_error(r
                 "/tmp/repo",
                 "acpx-codex",
                 "active",
-                "awaiting_claude_prepublish",
+                "awaiting_pre_publish_review",
                 "awaiting_reviews",
                 "not_ready",
                 "actor:1",

--- a/tests/test_webhooks_phase_c.py
+++ b/tests/test_webhooks_phase_c.py
@@ -226,13 +226,13 @@ def test_disabled_via_enabled_false():
 
 def test_event_filter_glob_matches_exact():
     from workflows.change_delivery.webhooks import event_matches
-    assert event_matches({"action": "run_claude_review"}, ["run_claude_review"]) is True
-    assert event_matches({"action": "merge_and_promote"}, ["run_claude_review"]) is False
+    assert event_matches({"action": "run_internal_review"}, ["run_internal_review"]) is True
+    assert event_matches({"action": "merge_and_promote"}, ["run_internal_review"]) is False
 
 
 def test_event_filter_glob_matches_prefix():
     from workflows.change_delivery.webhooks import event_matches
-    assert event_matches({"action": "run_claude_review"}, ["run_*"]) is True
+    assert event_matches({"action": "run_internal_review"}, ["run_*"]) is True
     assert event_matches({"action": "run_internal_review"}, ["run_*"]) is True
     assert event_matches({"action": "merge_and_promote"}, ["run_*"]) is False
 
@@ -255,7 +255,7 @@ def test_event_filter_multiple_globs_or():
     globs = ["merge_*", "operator_*"]
     assert event_matches({"action": "merge_and_promote"}, globs) is True
     assert event_matches({"action": "operator_attention_required"}, globs) is True
-    assert event_matches({"action": "run_claude_review"}, globs) is False
+    assert event_matches({"action": "run_internal_review"}, globs) is False
 
 
 def test_filtered_subscriber_does_not_deliver_unmatched_events():
@@ -268,7 +268,7 @@ def test_filtered_subscriber_does_not_deliver_unmatched_events():
     }]
     wh = build_webhooks(cfg, run_fn=None)[0]
     assert wh.matches({"action": "merge_and_promote"}) is True
-    assert wh.matches({"action": "run_claude_review"}) is False
+    assert wh.matches({"action": "run_internal_review"}) is False
 
 
 def test_build_webhooks_rejects_file_url():

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -558,7 +558,7 @@ def _dispatch_review_deps(tmp_path: Path):
         return {
             "activeLane": {"number": 224, "title": "T", "url": "https://example.test/224"},
             "implementation": {"worktree": str(worktree), "codexModel": "gpt-5.3-codex"},
-            "preflight": {"interReviewAgent": {"shouldRun": True, "currentHeadSha": "head123"}},
+            "preflight": {"prePublishReview": {"shouldRun": True, "currentHeadSha": "head123"}},
         }
 
     def load_ledger_fn():
@@ -630,13 +630,13 @@ def test_run_dispatch_inter_review_agent_review_skips_when_preflight_blocks(tmp_
         return {
             "activeLane": {"number": 224, "title": "T"},
             "implementation": {"worktree": str(tmp_path / "worktree")},
-            "preflight": {"interReviewAgent": {"shouldRun": False, "reasons": ["claude-cooldown"]}},
+            "preflight": {"prePublishReview": {"shouldRun": False, "reasons": ["internal-review-cooldown"]}},
         }
 
     deps["reconcile_fn"] = reconcile_fn
     result = actions_module.run_dispatch_inter_review_agent_review(**deps)
     assert result["dispatched"] is False
-    assert result["reason"] == "claude-preflight-blocked"
+    assert result["reason"] == "internal-review-preflight-blocked"
 
 
 def test_run_dispatch_inter_review_agent_review_records_completed_review_on_success(tmp_path):

--- a/tests/test_workflows_code_review_adapter_status.py
+++ b/tests/test_workflows_code_review_adapter_status.py
@@ -119,7 +119,7 @@ def test_adapter_status_surfaces_tick_dispatch_state(monkeypatch, tmp_path):
     state_dir.mkdir(parents=True)
     state_path = state_dir / "active.json"
     state_path.write_text(
-        '{"background": true, "command": "dispatch-inter-review-agent", "pid": 4321, "logPath": "/tmp/tick.log", "startedAt": "20260423T011700Z"}',
+        '{"background": true, "command": "dispatch-internal-review", "pid": 4321, "logPath": "/tmp/tick.log", "startedAt": "20260423T011700Z"}',
         encoding="utf-8",
     )
     monkeypatch.setattr(status_module, "_pid_is_running", lambda pid: pid == 4321)
@@ -127,7 +127,7 @@ def test_adapter_status_surfaces_tick_dispatch_state(monkeypatch, tmp_path):
     result = status_module.build_status(workflow_root)
 
     assert result["tickDispatch"]["active"] is True
-    assert result["tickDispatch"]["command"] == "dispatch-inter-review-agent"
+    assert result["tickDispatch"]["command"] == "dispatch-internal-review"
     assert result["tickDispatch"]["statePath"] == str(state_path)
 
 
@@ -637,8 +637,8 @@ def test_resolve_prepublish_workflow_state_returns_implementing_local_when_no_ca
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=False,
         single_pass_gate_satisfied=False,
-        claude_current=False,
-        claude_verdict=None,
+        internal_review_current=False,
+        internal_review_verdict=None,
     ) == "implementing_local"
 
 
@@ -648,46 +648,46 @@ def test_resolve_prepublish_workflow_state_returns_ready_to_publish_when_gate_al
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=True,
         single_pass_gate_satisfied=True,
-        claude_current=True,
-        claude_verdict="PASS_CLEAN",
+        internal_review_current=True,
+        internal_review_verdict="PASS_CLEAN",
     ) == "ready_to_publish"
 
 
-def test_resolve_prepublish_workflow_state_returns_findings_when_claude_current_and_actionable():
+def test_resolve_prepublish_workflow_state_returns_findings_when_internal_review_current_and_actionable():
     status_module = load_module("daedalus_workflows_change_delivery_status_rpre", "workflows/change_delivery/status.py")
 
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=True,
         single_pass_gate_satisfied=False,
-        claude_current=True,
-        claude_verdict="PASS_WITH_FINDINGS",
-    ) == "claude_prepublish_findings"
+        internal_review_current=True,
+        internal_review_verdict="PASS_WITH_FINDINGS",
+    ) == "pre_publish_review_findings"
 
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=True,
         single_pass_gate_satisfied=False,
-        claude_current=True,
-        claude_verdict="REWORK",
-    ) == "claude_prepublish_findings"
+        internal_review_current=True,
+        internal_review_verdict="REWORK",
+    ) == "pre_publish_review_findings"
 
 
-def test_resolve_prepublish_workflow_state_defaults_to_awaiting_claude_prepublish():
+def test_resolve_prepublish_workflow_state_defaults_to_awaiting_pre_publish_review():
     status_module = load_module("daedalus_workflows_change_delivery_status_rpre", "workflows/change_delivery/status.py")
 
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=True,
         single_pass_gate_satisfied=False,
-        claude_current=False,
-        claude_verdict=None,
-    ) == "awaiting_claude_prepublish"
+        internal_review_current=False,
+        internal_review_verdict=None,
+    ) == "awaiting_pre_publish_review"
 
-    # Even if verdict is set, it requires claude_current to branch into findings.
+    # Even if verdict is set, it requires internal_review_current to branch into findings.
     assert status_module.resolve_prepublish_workflow_state(
         local_candidate=True,
         single_pass_gate_satisfied=False,
-        claude_current=False,
-        claude_verdict="REWORK",
-    ) == "awaiting_claude_prepublish"
+        internal_review_current=False,
+        internal_review_verdict="REWORK",
+    ) == "awaiting_pre_publish_review"
 
 
 def test_apply_idle_ledger_transition_resets_active_lane_state():
@@ -838,8 +838,8 @@ def test_apply_active_lane_ledger_transition_prepublish_routes_through_claude_fi
         repair_brief={"forHeadSha": "head123", "mustFix": [{"summary": "x"}], "shouldFix": []},
         operator_attention_needed=False,
     )
-    assert ledger["workflowState"] == "claude_prepublish_findings"
-    assert ledger["reviewState"] == "claude_prepublish_findings"
+    assert ledger["workflowState"] == "pre_publish_review_findings"
+    assert ledger["reviewState"] == "pre_publish_review_findings"
     assert ledger["approval"]["pendingReason"] == "open-review-findings"
 
 
@@ -937,7 +937,7 @@ def test_assemble_status_payload_returns_fully_shaped_status_dict():
         review_loop_state="awaiting_reviews",
         merge_blocked=False,
         merge_blockers=[],
-        claude_preflight={"shouldRun": False},
+        pre_publish_review_preflight={"shouldRun": False},
         detailed_jobs={},
         hermes_job_names=[],
         missing_core_jobs=[],
@@ -959,9 +959,8 @@ def test_assemble_status_payload_returns_fully_shaped_status_dict():
     assert result["ledger"]["readyToCloseCount"] == 0
     assert result["implementation"]["publishStatus"] == "not_published"
     assert result["implementation"]["branch"] == "issue-224"
-    assert result["preflight"]["claudeReview"]["shouldRun"] is False
-    assert result["preflight"]["interReviewAgent"] == result["preflight"]["claudeReview"]
-    assert result["reviews"]["interReviewAgent"] == reviews["internalReview"]
+    assert result["preflight"]["prePublishReview"]["shouldRun"] is False
+    assert "prePublishReview" not in result["reviews"]
     assert result["nextAction"]["reason"] == "no-forward-action-needed"
     # Model fields fall back to the provided inter_review_agent_model when ledger entry is missing.
     assert result["ledger"]["internalReviewerModel"] == "claude-sonnet-4-6"

--- a/tests/test_workflows_code_review_cli.py
+++ b/tests/test_workflows_code_review_cli.py
@@ -46,7 +46,7 @@ def _make_workspace(**overrides):
             "implementation": {"worktree": "/tmp/worktree", "branch": "codex/issue-224-demo", "status": "implementing_local", "laneStatePath": "/tmp/lane.json", "laneMemoPath": "/tmp/lane.md"},
             "reviews": {},
             "derivedReviewLoopState": "awaiting_reviews",
-            "preflight": {"interReviewAgent": {"shouldRun": True, "currentHeadSha": "abc", "wakeSuggested": True}},
+            "preflight": {"prePublishReview": {"shouldRun": True, "currentHeadSha": "abc", "wakeSuggested": True}},
             "coreJobs": {"j1": {}},
             "missingCoreJobs": [],
             "disabledCoreJobs": [],
@@ -149,7 +149,7 @@ def test_wake_job_forwards_name():
 
 def test_preflight_inter_review_agent_can_wake_when_suggested():
     ws = _make_workspace()
-    code, out = _run_main(ws, ["preflight-inter-review-agent", "--wake-if-needed"])
+    code, out = _run_main(ws, ["preflight-internal-review", "--wake-if-needed"])
     assert code == 0
     assert "woken" in json.loads(out)
     names = [c[0] for c in ws.calls]
@@ -158,7 +158,7 @@ def test_preflight_inter_review_agent_can_wake_when_suggested():
 
 def test_preflight_claude_review_alias_works():
     ws = _make_workspace()
-    code, out = _run_main(ws, ["preflight-claude-review"])
+    code, out = _run_main(ws, ["preflight-internal-review"])
     assert code == 0
     assert json.loads(out)["shouldRun"] is True
 
@@ -179,13 +179,10 @@ def test_action_commands_delegate_to_workspace():
         assert [c[0] for c in ws.calls] == [method], command
 
 
-def test_dispatch_claude_review_and_inter_review_are_aliases():
-    ws_a = _make_workspace()
-    ws_b = _make_workspace()
-    _run_main(ws_a, ["dispatch-claude-review"])
-    _run_main(ws_b, ["dispatch-inter-review-agent"])
-    assert [c[0] for c in ws_a.calls] == ["dispatch_inter_review_agent_review"]
-    assert [c[0] for c in ws_b.calls] == ["dispatch_inter_review_agent_review"]
+def test_dispatch_internal_review_delegates_to_review_runner():
+    ws = _make_workspace()
+    _run_main(ws, ["dispatch-internal-review"])
+    assert [c[0] for c in ws.calls] == ["dispatch_inter_review_agent_review"]
 
 
 def test_show_active_lane_and_show_core_jobs_print_json_projection():

--- a/tests/test_workflows_code_review_prompts.py
+++ b/tests/test_workflows_code_review_prompts.py
@@ -50,7 +50,7 @@ def test_render_implementation_dispatch_prompt_includes_issue_summary_for_restar
     assert 'Issue summary:' in result
     assert 'Full issue body for restart turns.' in result
     assert 'Open PR: #301 https://example.com/pull/301' in result
-    assert 'The local branch has already passed the Claude pre-publish gate.' in result
+    assert 'The local branch has already passed the pre-publish internal review gate.' in result
 
 
 def test_render_implementation_dispatch_prompt_prepends_shared_workflow_policy():
@@ -73,10 +73,10 @@ def test_render_implementation_dispatch_prompt_prepends_shared_workflow_policy()
     assert '# Role-Specific Instructions' in result
 
 
-def test_render_claude_repair_handoff_prompt_includes_review_summary_and_fix_lists():
+def test_render_internal_review_repair_handoff_prompt_includes_review_summary_and_fix_lists():
     prompts_module = load_module("daedalus_workflows_change_delivery_prompts_test", "workflows/change_delivery/prompts.py")
 
-    result = prompts_module.render_claude_repair_handoff_prompt(
+    result = prompts_module.render_internal_review_repair_handoff_prompt(
         issue={"number": 224, "title": "Issue 224"},
         internal_review={"reviewedHeadSha": "abc123", "summary": "Claude found some stuff."},
         repair_brief={"mustFix": [{"summary": "Fix A"}], "shouldFix": [{"summary": "Fix B"}]},
@@ -86,7 +86,7 @@ def test_render_claude_repair_handoff_prompt_includes_review_summary_and_fix_lis
     )
 
     assert 'Internal_Reviewer_Agent pre-publish review found follow-up work for issue #224 on local head abc123.' in result
-    assert 'Claude summary:' in result
+    assert 'Internal review summary:' in result
     assert 'Claude found some stuff.' in result
     assert '- Fix A' in result
     assert '- Fix B' in result
@@ -98,7 +98,7 @@ def test_render_external_reviewer_repair_handoff_prompt_includes_pr_url_and_guar
 
     result = prompts_module.render_external_reviewer_repair_handoff_prompt(
         issue={"number": 224, "title": "Issue 224"},
-        external_review={"reviewedHeadSha": "def456", "summary": "Codex Cloud found follow-up work."},
+        external_review={"reviewedHeadSha": "def456", "summary": "external review found follow-up work."},
         repair_brief={"mustFix": [], "shouldFix": [{"summary": "Tighten edge case"}]},
         lane_memo_path=None,
         lane_state_path=None,

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -99,10 +99,10 @@ def test_run_inter_review_agent_review_via_runtime_uses_prompt_runtime(tmp_path)
     assert "Output contract for all runtimes" in calls["prompt"]["prompt"]
 
 
-def test_should_dispatch_claude_repair_handoff_when_local_review_is_actionable_and_routable():
+def test_should_dispatch_internal_review_repair_handoff_when_local_review_is_actionable_and_routable():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
-    result = reviews_module.should_dispatch_claude_repair_handoff(
+    result = reviews_module.should_dispatch_internal_review_repair_handoff(
         lane_state={},
         session_action={"action": "continue-session", "sessionName": "lane-224"},
         internal_review={
@@ -113,7 +113,7 @@ def test_should_dispatch_claude_repair_handoff_when_local_review_is_actionable_a
             "updatedAt": "2026-04-22T01:00:00Z",
         },
         repair_brief={"forHeadSha": "head123", "mustFix": [{"summary": "Fix this"}]},
-        workflow_state="claude_prepublish_findings",
+        workflow_state="pre_publish_review_findings",
         current_head_sha="head123",
         has_open_pr=False,
     )
@@ -121,10 +121,10 @@ def test_should_dispatch_claude_repair_handoff_when_local_review_is_actionable_a
     assert result == {"shouldDispatch": True, "reason": None}
 
 
-def test_should_dispatch_claude_repair_handoff_rejects_duplicate_handoff_for_same_review():
+def test_should_dispatch_internal_review_repair_handoff_rejects_duplicate_handoff_for_same_review():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
-    result = reviews_module.should_dispatch_claude_repair_handoff(
+    result = reviews_module.should_dispatch_internal_review_repair_handoff(
         lane_state={"sessionControl": {"lastInternalReviewRepairHandoff": {"sessionName": "lane-224", "headSha": "head123", "reviewedAt": "2026-04-22T01:00:00Z"}}},
         session_action={"action": "continue-session", "sessionName": "lane-224"},
         internal_review={
@@ -135,7 +135,7 @@ def test_should_dispatch_claude_repair_handoff_rejects_duplicate_handoff_for_sam
             "updatedAt": "2026-04-22T01:00:00Z",
         },
         repair_brief={"forHeadSha": "head123", "mustFix": [{"summary": "Fix this"}]},
-        workflow_state="claude_prepublish_findings",
+        workflow_state="pre_publish_review_findings",
         current_head_sha="head123",
         has_open_pr=False,
     )
@@ -143,7 +143,7 @@ def test_should_dispatch_claude_repair_handoff_rejects_duplicate_handoff_for_sam
     assert result == {"shouldDispatch": False, "reason": "repair-handoff-already-sent-for-review"}
 
 
-def test_should_dispatch_codex_cloud_repair_handoff_when_postpublish_review_is_actionable_and_routable():
+def test_should_dispatch_external_review_repair_handoff_when_postpublish_review_is_actionable_and_routable():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     result = reviews_module.should_dispatch_external_review_repair_handoff(
@@ -210,22 +210,22 @@ def test_local_inter_review_agent_review_count_increments_only_for_new_completed
     assert unchanged == 1
 
 
-def test_single_pass_local_claude_gate_satisfied_handles_pass_clean_and_pass_with_findings_threshold():
+def test_single_pass_local_internal_review_gate_satisfied_handles_pass_clean_and_pass_with_findings_threshold():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
-    pass_clean = reviews_module.single_pass_local_claude_gate_satisfied(
+    pass_clean = reviews_module.single_pass_local_internal_review_gate_satisfied(
         {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "abc123", "verdict": "PASS_CLEAN"},
         "abc123",
         {"review": {}},
         pass_with_findings_reviews=1,
     )
-    pass_with_findings = reviews_module.single_pass_local_claude_gate_satisfied(
+    pass_with_findings = reviews_module.single_pass_local_internal_review_gate_satisfied(
         {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "old-head", "verdict": "PASS_WITH_FINDINGS"},
         "new-head",
         {"review": {"localClaudeReviewCount": 0, "lastClaudeReviewedHeadSha": "older-head", "lastClaudeVerdict": "PASS_WITH_FINDINGS"}},
         pass_with_findings_reviews=1,
     )
-    rework = reviews_module.single_pass_local_claude_gate_satisfied(
+    rework = reviews_module.single_pass_local_internal_review_gate_satisfied(
         {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "abc123", "verdict": "REWORK"},
         "abc123",
         {"review": {}},
@@ -237,17 +237,17 @@ def test_single_pass_local_claude_gate_satisfied_handles_pass_clean_and_pass_wit
     assert rework is False
 
 
-def test_single_pass_local_claude_gate_satisfied_handles_new_key_shape():
+def test_single_pass_local_internal_review_gate_satisfied_handles_new_key_shape():
     """Phase D-5: post-migration lane-state with the new key shape works."""
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
-    pass_clean = reviews_module.single_pass_local_claude_gate_satisfied(
+    pass_clean = reviews_module.single_pass_local_internal_review_gate_satisfied(
         {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "abc", "verdict": "PASS_CLEAN"},
         "abc",
         {"review": {"lastInternalReviewedHeadSha": "abc", "lastInternalVerdict": "PASS_CLEAN"}},
         pass_with_findings_reviews=1,
     )
-    pass_with_findings = reviews_module.single_pass_local_claude_gate_satisfied(
+    pass_with_findings = reviews_module.single_pass_local_internal_review_gate_satisfied(
         {"reviewScope": "local-prepublish", "status": "completed", "reviewedHeadSha": "old-head", "verdict": "PASS_WITH_FINDINGS"},
         "new-head",
         {"review": {"localInternalReviewCount": 0, "lastInternalReviewedHeadSha": "older-head", "lastInternalVerdict": "PASS_WITH_FINDINGS"}},
@@ -292,7 +292,7 @@ def test_inter_review_agent_preflight_allows_clean_local_prepublish_run_and_sugg
     result = reviews_module.inter_review_agent_preflight(
         active_lane={"number": 224},
         open_pr=None,
-        workflow_state="awaiting_claude_prepublish",
+        workflow_state="awaiting_pre_publish_review",
         pr_ledger={},
         inter_review_agent_review={"status": "pending", "runId": "run-1"},
         inter_review_agent_job={"nextRunAtMs": 400_000},
@@ -350,10 +350,10 @@ def test_inter_review_agent_preflight_blocks_running_current_head_and_nonready_s
     assert result["wakeSuggested"] is False
     assert "no-active-lane" in result["reasons"]
     assert "no-local-head-candidate" in result["reasons"]
-    assert "workflow-not-awaiting-local-claude" in result["reasons"]
-    assert "single-pass-claude-already-satisfied" in result["reasons"]
-    assert "claude-review-running-current-head" in result["reasons"]
-    assert "claude-review-request-recent" in result["reasons"]
+    assert "workflow-not-awaiting-local-review" in result["reasons"]
+    assert "single-pass-internal-review-already-satisfied" in result["reasons"]
+    assert "internal-review-running-current-head" in result["reasons"]
+    assert "internal-review-request-recent" in result["reasons"]
 
 
 def test_normalize_review_fills_defaults_and_preserves_known_fields():
@@ -457,7 +457,7 @@ def test_normalize_local_inter_review_agent_seed_handles_running_current_timed_o
     assert pending == {"model": "claude-sonnet-4-6"}
 
 
-def test_review_bucket_and_codex_cloud_placeholder_cover_pending_findings_clean_and_blocking_cases():
+def test_review_bucket_and_external_review_placeholder_cover_pending_findings_clean_and_blocking_cases():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     assert reviews_module.review_bucket({"verdict": "REWORK"}) == "blocking"
@@ -468,14 +468,14 @@ def test_review_bucket_and_codex_cloud_placeholder_cover_pending_findings_clean_
     placeholder = reviews_module.external_review_placeholder(
         required=False,
         status="not_started",
-        summary="Codex Cloud review starts only after publish.",
+        summary="external review review starts only after publish.",
         normalize_review_fn=lambda review, **kwargs: {**review, **kwargs},
         agent_name="External_Reviewer_Agent",
         agent_role="external_reviewer_agent",
     )
 
     assert placeholder["status"] == "not_started"
-    assert placeholder["summary"] == "Codex Cloud review starts only after publish."
+    assert placeholder["summary"] == "external review review starts only after publish."
     assert placeholder["reviewScope"] == "postpublish-pr"
     assert placeholder["required"] is False
     assert placeholder["agent_name"] == "External_Reviewer_Agent"
@@ -534,7 +534,7 @@ def test_inter_review_agent_review_builders_shape_running_failed_and_completed_r
 def test_repair_handoff_payload_builders_shape_claude_and_codex_payloads():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
-    claude_payload = reviews_module.build_claude_repair_handoff_payload(
+    claude_payload = reviews_module.build_internal_review_repair_handoff_payload(
         session_action={"sessionName": "lane-224"},
         issue={"number": 224, "title": "Issue 224"},
         internal_review={"reviewedHeadSha": "abc123", "updatedAt": "2026-04-23T00:10:00Z", "reviewScope": "local-prepublish", "verdict": "REWORK"},
@@ -576,7 +576,7 @@ def test_record_repair_handoff_helpers_store_payload_under_session_control(tmp_p
     def fake_write(path, payload):
         seen.setdefault("written", []).append((path, payload))
 
-    claude_state = reviews_module.record_claude_repair_handoff(
+    claude_state = reviews_module.record_internal_review_repair_handoff(
         worktree=tmp_path,
         payload={"sessionName": "lane-224", "headSha": "abc123"},
         lane_state_path_fn=lambda worktree: worktree / ".lane-state.json",
@@ -648,17 +648,17 @@ def test_classify_lane_failure_covers_clean_session_review_and_preflight_paths()
     preflight_blocked = reviews_module.classify_lane_failure(
         implementation={},
         reviews={},
-        preflight={"claudeReview": {"reasons": ["checks-not-acceptable"]}},
+        preflight={"prePublishReview": {"reasons": ["checks-not-acceptable"]}},
     )
 
     assert clean == {"failureClass": None, "detail": None}
     assert session_failure == {"failureClass": "session_stale", "detail": "stale-session"}
-    assert claude_failed == {"failureClass": "claude_review_failed", "detail": "transport_failed"}
-    assert findings_open == {"failureClass": "codex_cloud_findings_open", "detail": "PASS_WITH_FINDINGS"}
-    assert preflight_blocked == {"failureClass": "claude_preflight_blocked", "detail": "checks-not-acceptable"}
+    assert claude_failed == {"failureClass": "internal_review_failed", "detail": "transport_failed"}
+    assert findings_open == {"failureClass": "external_review_findings_open", "detail": "PASS_WITH_FINDINGS"}
+    assert preflight_blocked == {"failureClass": "internal_review_preflight_blocked", "detail": "checks-not-acceptable"}
 
 
-def test_codex_cloud_review_shaping_helpers_cover_thread_mapping_findings_pending_and_clean():
+def test_external_review_review_shaping_helpers_cover_thread_mapping_findings_pending_and_clean():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     superseded_thread = reviews_module.build_external_review_thread(
@@ -823,7 +823,7 @@ def test_fetch_codex_pr_body_signal_picks_latest_codex_reaction_and_maps_clean_v
     }
 
 
-def test_fetch_codex_cloud_review_uses_cache_and_builds_from_graphql_threads():
+def test_fetch_external_review_review_uses_cache_and_builds_from_graphql_threads():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     cached = reviews_module.fetch_external_review(
@@ -952,11 +952,11 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
             },
         },
         "openPr": None,
-        "ledger": {"workflowState": "claude_prepublish_findings"},
+        "ledger": {"workflowState": "pre_publish_review_findings"},
     }
     ledger = {
         "repairBrief": {"forHeadSha": "head123", "mustFix": [{"summary": "Fix"}], "shouldFix": []},
-        "workflowState": "claude_prepublish_findings",
+        "workflowState": "pre_publish_review_findings",
     }
 
     result, changed = reviews_module.maybe_dispatch_repair_handoff(
@@ -979,7 +979,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
     assert (worktree / ".lane-state.json").exists()
 
 
-def test_maybe_dispatch_repair_handoff_dispatches_codex_cloud_branch_when_routable(tmp_path):
+def test_maybe_dispatch_repair_handoff_dispatches_external_review_branch_when_routable(tmp_path):
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_mdrh", "workflows/change_delivery/reviews.py")
     worktree = tmp_path / "worktree"
     worktree.mkdir()
@@ -1217,7 +1217,7 @@ def test_audit_inter_review_agent_transition_emits_requested_event_when_head_cha
         audit_fn=audit_fn,
         internal_reviewer_agent_name="Internal_Reviewer_Agent",
     )
-    assert any(e["action"] == "claude-review-requested" for e in events)
+    assert any(e["action"] == "internal-review-requested" for e in events)
 
 
 def test_audit_inter_review_agent_transition_emits_completed_event_on_success():
@@ -1237,7 +1237,7 @@ def test_audit_inter_review_agent_transition_emits_completed_event_on_success():
         audit_fn=audit_fn,
         internal_reviewer_agent_name="Internal_Reviewer_Agent",
     )
-    assert any(e["action"] == "claude-review-completed" and e["verdict"] == "PASS_CLEAN" for e in events)
+    assert any(e["action"] == "internal-review-completed" and e["verdict"] == "PASS_CLEAN" for e in events)
 
 
 def test_audit_inter_review_agent_transition_emits_failure_event_with_failure_class():
@@ -1257,7 +1257,7 @@ def test_audit_inter_review_agent_transition_emits_failure_event_with_failure_cl
         audit_fn=audit_fn,
         internal_reviewer_agent_name="Internal_Reviewer_Agent",
     )
-    assert any(e["action"] == "claude-review-failed" for e in events)
+    assert any(e["action"] == "internal-review-failed" for e in events)
 
 
 def test_build_reviews_block_routes_postpublish_defaults_when_pr_is_ready_for_review():
@@ -1269,7 +1269,7 @@ def test_build_reviews_block_routes_postpublish_defaults_when_pr_is_ready_for_re
             "claudeCode": {"reviewedHeadSha": "prsha", "verdict": "PASS_CLEAN"},
             "codexCloud": {"status": "running", "reviewScope": "postpublish-pr"},
         },
-        codex_cloud={"status": "running", "reviewScope": "postpublish-pr"},
+        external_review={"status": "running", "reviewScope": "postpublish-pr"},
         publish_ready=True,
         local_head_sha="prsha",
         local_candidate_exists=False,
@@ -1299,7 +1299,7 @@ def test_build_reviews_block_seeds_local_prepublish_for_draft_pr_state():
 
     reviews = reviews_module.build_reviews_block(
         existing_reviews={"rockClaw": None, "claudeCode": None, "codexCloud": {}},
-        codex_cloud={"required": False, "status": "not_started"},
+        external_review={"required": False, "status": "not_started"},
         publish_ready=False,
         local_head_sha="localsha",
         local_candidate_exists=True,
@@ -1308,7 +1308,7 @@ def test_build_reviews_block_seeds_local_prepublish_for_draft_pr_state():
         external_reviewer_agent_name="External_Reviewer_Agent",
         advisory_reviewer_agent_name="Advisory_Reviewer_Agent",
         now_iso="2026-04-23T00:00:00Z",
-        claude_seed_fn=fake_seed,
+        internal_review_seed_fn=fake_seed,
     )
     assert reviews["internalReview"]["required"] is True
     assert reviews["internalReview"]["reviewScope"] == "local-prepublish"

--- a/tests/test_workflows_code_review_runtimes_claude_cli.py
+++ b/tests/test_workflows_code_review_runtimes_claude_cli.py
@@ -27,11 +27,11 @@ def test_ensure_session_is_a_noop_and_returns_synthetic_handle(tmp_path):
     runtime, calls = _make_runtime()
     handle = runtime.ensure_session(
         worktree=tmp_path,
-        session_name="inter-review-agent:abc",
+        session_name="internal-review:abc",
         model="claude-sonnet-4-6",
     )
     assert calls == []
-    assert handle.name == "inter-review-agent:abc"
+    assert handle.name == "internal-review:abc"
     assert handle.session_id is None
     assert handle.record_id is None
 
@@ -52,7 +52,7 @@ def test_run_prompt_invokes_claude_cli_with_model(tmp_path):
     runtime, calls = _make_runtime()
     out = runtime.run_prompt(
         worktree=tmp_path,
-        session_name="inter-review-agent:abc",
+        session_name="internal-review:abc",
         prompt="review this",
         model="claude-sonnet-4-6",
     )
@@ -88,7 +88,7 @@ def test_run_prompt_supports_workspace_runner_without_timeout_kwarg(tmp_path):
 
     assert runtime.run_prompt(
         worktree=tmp_path,
-        session_name="inter-review-agent:abc",
+        session_name="internal-review:abc",
         prompt="review this",
         model="claude-sonnet-4-6",
     ) == "ok"

--- a/tests/test_workflows_code_review_workflow.py
+++ b/tests/test_workflows_code_review_workflow.py
@@ -25,7 +25,7 @@ def test_derive_next_action_prefers_merge_for_clean_published_pr():
             "implementation": {"localHeadSha": "abc123", "sessionActionRecommendation": {"action": "continue-session"}, "laneState": {}},
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "under_review"},
             "derivedReviewLoopState": "clean",
             "derivedMergeBlocked": False,
@@ -53,7 +53,7 @@ def test_derive_next_action_uses_fresh_session_noop_for_healthy_implementation_l
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "implementing_local"},
             "derivedReviewLoopState": "awaiting_reviews",
             "derivedMergeBlocked": False,
@@ -80,7 +80,7 @@ def test_derive_next_action_promotes_ready_local_branch_even_when_health_is_stal
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "ready_to_publish"},
             "derivedReviewLoopState": "awaiting_reviews",
             "derivedMergeBlocked": False,
@@ -109,7 +109,7 @@ def test_derive_next_action_pushes_pr_update_when_local_head_is_ahead_of_pr():
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
@@ -137,7 +137,7 @@ def test_derive_next_action_dispatches_turn_when_no_progress_budget_is_reached()
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "implementing_local"},
             "derivedReviewLoopState": "awaiting_reviews",
             "derivedMergeBlocked": False,
@@ -165,7 +165,7 @@ def test_derive_next_action_dispatches_retry_turn_when_failure_budget_is_reached
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
@@ -201,8 +201,8 @@ def test_derive_next_action_dispatches_internal_review_repair_handoff_when_revie
                 }
             },
             "repairBrief": {"forHeadSha": "head123", "mustFix": [{"summary": "Fix it"}]},
-            "preflight": {"claudeReview": {"shouldRun": False}},
-            "ledger": {"workflowState": "claude_prepublish_findings"},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
+            "ledger": {"workflowState": "pre_publish_review_findings"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
             "nextAction": {"type": "noop", "reason": "old-wrapper-value"},
@@ -237,7 +237,7 @@ def test_derive_next_action_dispatches_external_review_repair_handoff_when_revie
                 }
             },
             "repairBrief": {"forHeadSha": "prsha", "mustFix": [{"summary": "Fix it"}]},
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
@@ -272,7 +272,7 @@ def test_derive_next_action_dispatches_postpublish_repair_when_codex_findings_re
                 }
             },
             "repairBrief": {"forHeadSha": "prsha", "mustFix": [{"summary": "Fix it"}]},
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
@@ -301,7 +301,7 @@ def test_derive_next_action_falls_back_to_wrapper_value_for_unhandled_cases():
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,
@@ -333,7 +333,7 @@ def test_derive_next_action_short_circuits_when_claude_review_is_running_on_loca
                 }
             },
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "implementing_local"},
             "derivedReviewLoopState": "awaiting_reviews",
             "derivedMergeBlocked": False,
@@ -342,7 +342,7 @@ def test_derive_next_action_short_circuits_when_claude_review_is_running_on_loca
     )
 
     assert result["type"] == "noop"
-    assert result["reason"] == "claude-review-running"
+    assert result["reason"] == "internal-review-running"
     assert result["issueNumber"] == 224
     assert result["headSha"] == "head123"
 
@@ -361,7 +361,7 @@ def test_derive_next_action_honors_configurable_no_progress_tick_budget():
         },
         "reviews": {},
         "repairBrief": None,
-        "preflight": {"claudeReview": {"shouldRun": False}},
+        "preflight": {"prePublishReview": {"shouldRun": False}},
         "ledger": {"workflowState": "implementing_local"},
         "derivedReviewLoopState": "awaiting_reviews",
         "derivedMergeBlocked": False,
@@ -390,7 +390,7 @@ def test_derive_next_action_honors_configurable_failure_retry_budget():
         },
         "reviews": {},
         "repairBrief": None,
-        "preflight": {"claudeReview": {"shouldRun": False}},
+        "preflight": {"prePublishReview": {"shouldRun": False}},
         "ledger": {"workflowState": "findings_open"},
         "derivedReviewLoopState": "findings_open",
         "derivedMergeBlocked": True,
@@ -424,7 +424,7 @@ def test_derive_next_action_uses_has_local_candidate_for_push_pr_update_check():
             },
             "reviews": {},
             "repairBrief": None,
-            "preflight": {"claudeReview": {"shouldRun": False}},
+            "preflight": {"prePublishReview": {"shouldRun": False}},
             "ledger": {"workflowState": "findings_open"},
             "derivedReviewLoopState": "findings_open",
             "derivedMergeBlocked": True,

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -107,7 +107,7 @@ def test_make_workspace_exposes_config_constants_and_primitives(tmp_path):
     assert ws.ACTIVE_LANE_LABEL == "active-lane"
     assert ws.ENGINE_OWNER == "hermes"
     assert ws.WORKFLOW_WATCHDOG_JOB_NAME == "workflow-watchdog"
-    assert ws.INTER_REVIEW_AGENT_MODEL == "claude-sonnet-4-6"
+    assert ws.INTERNAL_REVIEW_MODEL == "claude-sonnet-4-6"
     assert ws.INTERNAL_REVIEWER_AGENT_NAME == "Internal_Reviewer_Agent"
     assert ws.LANE_FAILURE_RETRY_BUDGET == 3
     assert ws.WORKFLOW_POLICY == ""
@@ -242,7 +242,7 @@ def test_workspace_exposes_full_wrapper_facade(tmp_path):
     for name in (
         "publish_ready_pr_raw", "push_pr_update_raw", "merge_and_promote_raw",
         "dispatch_implementation_turn_raw", "restart_actor_session_raw",
-        "dispatch_inter_review_agent_review_raw", "dispatch_claude_review_raw",
+        "dispatch_inter_review_agent_review_raw",
         "dispatch_repair_handoff_raw", "tick_raw",
         "_dispatch_lane_turn", "_maybe_dispatch_repair_handoff",
     ):
@@ -294,14 +294,14 @@ def test_workspace_exposes_full_wrapper_facade(tmp_path):
         "render_lane_memo", "build_acp_session_strategy",
         "build_session_nudge_payload", "should_nudge_session",
         "record_session_nudge",
-        "should_dispatch_claude_repair_handoff",
+        "should_dispatch_internal_review_repair_handoff",
         "should_dispatch_external_review_repair_handoff",
         "build_external_review_repair_handoff_payload",
         "record_external_review_repair_handoff",
         "_render_external_review_repair_handoff_prompt",
-        "build_claude_repair_handoff_payload",
-        "record_claude_repair_handoff",
-        "_render_claude_repair_handoff_prompt",
+        "build_internal_review_repair_handoff_payload",
+        "record_internal_review_repair_handoff",
+        "_render_internal_review_repair_handoff_prompt",
     ):
         assert callable(getattr(ws, name)), name
 
@@ -380,8 +380,8 @@ def test_workspace_exposes_runtime_accessor_with_named_profiles(tmp_path):
             "codexSessionNudgeCooldownSeconds": 600,
         },
         "reviewPolicy": {
-            "interReviewAgentMaxTurns": 24,
-            "interReviewAgentTimeoutSeconds": 1200,
+            "internalReviewMaxTurns": 24,
+            "internalReviewTimeoutSeconds": 1200,
         },
         "agentLabels": {},
     }
@@ -439,7 +439,7 @@ def test_workspace_runtime_accessor_errors_on_unknown_name(tmp_path):
 
 def test_workspace_from_yaml_exposes_same_surface_as_legacy_json(tmp_path):
     """Given the new YAML shape, workspace exposes the same attribute surface
-    callers have historically used (REPO_PATH, INTER_REVIEW_AGENT_MODEL, etc.)."""
+    callers have historically used (REPO_PATH, INTERNAL_REVIEW_MODEL, etc.)."""
     from pathlib import Path as _Path
     from workflows.change_delivery.workspace import make_workspace
 
@@ -538,9 +538,9 @@ def test_workspace_from_yaml_exposes_same_surface_as_legacy_json(tmp_path):
     assert ws.CODEX_MODEL_DEFAULT == "gpt-5.3-codex-spark/high"
     assert ws.CODEX_MODEL_HIGH_EFFORT == "gpt-5.4"
     assert ws.CODEX_MODEL_ESCALATED == "gpt-5.4"
-    assert ws.INTER_REVIEW_AGENT_MODEL == "claude-sonnet-4-6"
-    assert ws.INTER_REVIEW_AGENT_MAX_TURNS == 24
-    assert ws.INTER_REVIEW_AGENT_TIMEOUT_SECONDS == 1200
+    assert ws.INTERNAL_REVIEW_MODEL == "claude-sonnet-4-6"
+    assert ws.INTERNAL_REVIEW_MAX_TURNS == 24
+    assert ws.INTERNAL_REVIEW_TIMEOUT_SECONDS == 1200
     assert ws.CODEX_SESSION_FRESHNESS_SECONDS == 900
     assert ws.CODEX_SESSION_POKE_GRACE_SECONDS == 1800
     assert ws.CODEX_SESSION_NUDGE_COOLDOWN_SECONDS == 600


### PR DESCRIPTION
## Summary

- Renames change-delivery workflow semantics away from provider-specific Claude/Codex Cloud terms and into internal/external review terminology.
- Hard-cuts old CLI/status/state names such as `dispatch-claude-review`, `preflight-claude-review`, `claudeReview`, and `awaiting_claude_prepublish`.
- Updates operator docs, workflow docs, tests, and adds a provider-neutral term guard to prevent semantic drift back to provider-specific names.

## Impact

Operators now use `preflight-internal-review` and `dispatch-internal-review`. Workflow state and lane-state fields use provider-neutral internal/external review names while runtime/model names like `claude-cli` remain valid runtime identities.

## Validation

- `pytest -q`
- Result: `874 passed, 7 skipped`