### PR TITLE
[codex] add runtime capability contract

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -45,6 +45,8 @@ from workflows.runtime_presets import (
     configure_runtime_contract,
     runtime_availability_checks,
     runtime_binding_checks,
+    runtime_capability_checks,
+    runtime_stage_checks,
 )
 from workflows.runtime_matrix import build_runtime_matrix_report
 from workflows.change_delivery.storage import ensure_change_delivery_state_files
@@ -2311,7 +2313,12 @@ def _runtime_doctor_checks(workflow_root: Path) -> list[dict[str, Any]]:
         ]
 
     checks = []
-    for check in [*runtime_binding_checks(config), *runtime_availability_checks(config)]:
+    for check in [
+        *runtime_stage_checks(config),
+        *runtime_binding_checks(config),
+        *runtime_capability_checks(config),
+        *runtime_availability_checks(config),
+    ]:
         status = str(check.get("status") or "info")
         severity = "info"
         if status == "fail":

--- a/daedalus/runtimes/capabilities.py
+++ b/daedalus/runtimes/capabilities.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+CAP_PROMPT_TURN = "prompt-turn"
+CAP_COMMAND_STAGE = "command-stage"
+CAP_ONE_SHOT = "one-shot"
+CAP_PERSISTENT_SESSION = "persistent-session"
+CAP_RESUME = "resume"
+CAP_CANCEL = "cancel"
+CAP_STRUCTURED_EVENTS = "structured-events"
+CAP_TOKEN_METRICS = "token-metrics"
+CAP_THREAD_VISIBLE = "thread-visible"
+CAP_ACTIVITY_HEARTBEAT = "activity-heartbeat"
+CAP_SERVICE_REQUIRED = "service-required"
+
+
+KNOWN_CAPABILITIES = frozenset(
+    {
+        CAP_PROMPT_TURN,
+        CAP_COMMAND_STAGE,
+        CAP_ONE_SHOT,
+        CAP_PERSISTENT_SESSION,
+        CAP_RESUME,
+        CAP_CANCEL,
+        CAP_STRUCTURED_EVENTS,
+        CAP_TOKEN_METRICS,
+        CAP_THREAD_VISIBLE,
+        CAP_ACTIVITY_HEARTBEAT,
+        CAP_SERVICE_REQUIRED,
+    }
+)
+
+
+@dataclass(frozen=True)
+class RuntimeCapabilityProfile:
+    kind: str
+    capabilities: frozenset[str]
+    summary: str
+
+    def has_all(self, required: set[str] | frozenset[str]) -> bool:
+        return set(required).issubset(self.capabilities)
+
+    def has_any(self, required: set[str] | frozenset[str]) -> bool:
+        return bool(set(required) & self.capabilities)
+
+
+_BASE_EXECUTION_CAPABILITIES = frozenset(
+    {
+        CAP_PROMPT_TURN,
+        CAP_COMMAND_STAGE,
+        CAP_ACTIVITY_HEARTBEAT,
+    }
+)
+
+_KIND_CAPABILITIES: dict[str, RuntimeCapabilityProfile] = {
+    "acpx-codex": RuntimeCapabilityProfile(
+        kind="acpx-codex",
+        capabilities=_BASE_EXECUTION_CAPABILITIES
+        | {
+            CAP_PERSISTENT_SESSION,
+            CAP_RESUME,
+        },
+        summary="ACPX-backed Codex sessions with resume support.",
+    ),
+    "claude-cli": RuntimeCapabilityProfile(
+        kind="claude-cli",
+        capabilities=_BASE_EXECUTION_CAPABILITIES | {CAP_ONE_SHOT},
+        summary="One-shot Claude CLI prompt execution.",
+    ),
+    "codex-app-server": RuntimeCapabilityProfile(
+        kind="codex-app-server",
+        capabilities=_BASE_EXECUTION_CAPABILITIES
+        | {
+            CAP_PERSISTENT_SESSION,
+            CAP_RESUME,
+            CAP_CANCEL,
+            CAP_STRUCTURED_EVENTS,
+            CAP_TOKEN_METRICS,
+            CAP_THREAD_VISIBLE,
+        },
+        summary="Codex app-server thread runtime with structured turn events.",
+    ),
+    "hermes-agent": RuntimeCapabilityProfile(
+        kind="hermes-agent",
+        capabilities=_BASE_EXECUTION_CAPABILITIES | {CAP_ONE_SHOT},
+        summary="Hermes Agent CLI execution via final or quiet chat mode.",
+    ),
+}
+
+
+def recognized_runtime_kinds() -> frozenset[str]:
+    return frozenset(_KIND_CAPABILITIES)
+
+
+def runtime_kind_profile(kind: str) -> RuntimeCapabilityProfile | None:
+    normalized = str(kind or "").strip()
+    return _KIND_CAPABILITIES.get(normalized)
+
+
+def runtime_profile_capabilities(runtime_cfg: Mapping[str, Any] | None) -> RuntimeCapabilityProfile | None:
+    cfg = runtime_cfg if isinstance(runtime_cfg, Mapping) else {}
+    kind = str(cfg.get("kind") or "").strip()
+    profile = runtime_kind_profile(kind)
+    if profile is None:
+        return None
+
+    capabilities = set(profile.capabilities)
+    if kind == "codex-app-server":
+        mode = str(cfg.get("mode") or ("external" if cfg.get("endpoint") else "managed")).strip()
+        if mode == "external":
+            capabilities.add(CAP_SERVICE_REQUIRED)
+    return RuntimeCapabilityProfile(
+        kind=profile.kind,
+        capabilities=frozenset(capabilities),
+        summary=profile.summary,
+    )
+
+
+def explicit_required_capabilities(config: Mapping[str, Any] | None) -> frozenset[str]:
+    if not isinstance(config, Mapping):
+        return frozenset()
+    raw = config.get("required-capabilities")
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str):
+        values = [raw]
+    elif isinstance(raw, list):
+        values = raw
+    else:
+        return frozenset({f"<invalid:{type(raw).__name__}>"})
+    return frozenset(str(value).strip() for value in values if str(value).strip())
+
+
+def unknown_capabilities(values: set[str] | frozenset[str]) -> frozenset[str]:
+    return frozenset(set(values) - KNOWN_CAPABILITIES)
+
+
+def format_capabilities(values: set[str] | frozenset[str]) -> str:
+    return ", ".join(sorted(values)) if values else "none"
+
+
+__all__ = [
+    "CAP_ACTIVITY_HEARTBEAT",
+    "CAP_CANCEL",
+    "CAP_COMMAND_STAGE",
+    "CAP_ONE_SHOT",
+    "CAP_PERSISTENT_SESSION",
+    "CAP_PROMPT_TURN",
+    "CAP_RESUME",
+    "CAP_SERVICE_REQUIRED",
+    "CAP_STRUCTURED_EVENTS",
+    "CAP_THREAD_VISIBLE",
+    "CAP_TOKEN_METRICS",
+    "KNOWN_CAPABILITIES",
+    "RuntimeCapabilityProfile",
+    "explicit_required_capabilities",
+    "format_capabilities",
+    "recognized_runtime_kinds",
+    "runtime_kind_profile",
+    "runtime_profile_capabilities",
+    "unknown_capabilities",
+]

--- a/daedalus/workflows/change_delivery/preflight.py
+++ b/daedalus/workflows/change_delivery/preflight.py
@@ -10,6 +10,8 @@ Error codes (fixed enum, mirrors Symphony's recommended categories):
 - ``workflow_parse_error``         — YAML syntax error
 - ``workflow_front_matter_not_a_map`` — root not a dict
 - ``unsupported_runtime_kind``     — runtime.kind not in registered kinds
+- ``invalid_runtime_binding``      — stage/actor/runtime binding is invalid
+- ``runtime_capability_mismatch``  — actor requires capabilities runtime lacks
 - ``unsupported_reviewer_kind``    — reviewer kind not in registered kinds
 - ``missing_tracker_credentials``  — required env var unset / empty
 - ``unsupported_tracker_kind``     — tracker.kind not supported
@@ -22,6 +24,8 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from runtimes.capabilities import recognized_runtime_kinds
+
 
 @dataclass(frozen=True)
 class PreflightResult:
@@ -31,7 +35,7 @@ class PreflightResult:
     can_reconcile: bool = True  # always True; preflight never blocks reconciliation
 
 
-_RECOGNIZED_RUNTIME_KINDS = frozenset({"acpx-codex", "claude-cli", "codex-app-server", "hermes-agent"})
+_RECOGNIZED_RUNTIME_KINDS = recognized_runtime_kinds()
 _RECOGNIZED_GATE_TYPES = frozenset({"agent-review", "pr-comment-approval", "code-host-checks"})
 _RECOGNIZED_TRACKER_KINDS = frozenset({"github"})
 _RECOGNIZED_CODE_HOST_KINDS = frozenset({"github"})
@@ -85,6 +89,18 @@ def run_preflight(config: Mapping[str, Any]) -> PreflightResult:
                     "unsupported_reviewer_kind",
                     f"gates.{name}.type={gate_type!r} not in {sorted(_RECOGNIZED_GATE_TYPES)}",
                 )
+
+    from workflows.runtime_presets import runtime_capability_checks, runtime_stage_checks
+
+    for check in [*runtime_stage_checks(dict(config)), *runtime_capability_checks(dict(config))]:
+        if check.get("status") != "fail":
+            continue
+        name = str(check.get("name") or "")
+        return PreflightResult(
+            False,
+            "runtime_capability_mismatch" if name.startswith("runtime-capability") else "invalid_runtime_binding",
+            str(check.get("detail") or name),
+        )
 
     tracker = config.get("tracker") or {}
     if isinstance(tracker, dict):

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -299,6 +299,8 @@ definitions:
       name: {type: string}
       model: {type: string}
       runtime: {type: string}
+      required-capabilities:
+        $ref: "#/definitions/runtime-capability-list"
       command:
         type: array
         items: {type: string}
@@ -417,6 +419,23 @@ definitions:
     properties:
       type: {const: code-host-checks}
       required-for-merge: {type: boolean}
+
+  runtime-capability-list:
+    type: array
+    items:
+      type: string
+      enum:
+        - prompt-turn
+        - command-stage
+        - one-shot
+        - persistent-session
+        - resume
+        - cancel
+        - structured-events
+        - token-metrics
+        - thread-visible
+        - activity-heartbeat
+        - service-required
 
   acpx-codex-runtime:
     type: object

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from runtimes.capabilities import recognized_runtime_kinds
 from workflows.issue_runner.tracker import TrackerConfigError, build_tracker_client, resolve_tracker_path
+from workflows.runtime_presets import runtime_capability_checks, runtime_stage_checks
 from trackers.github import (
     github_auth_host_from_slug,
     github_auth_success_accounts,
@@ -40,6 +42,11 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
             raise RuntimeError(f"agent.runtime={runtime_name!r} does not reference a declared runtime profile")
         runtime_cfg = runtimes.get(runtime_name) or {}
         runtime_kind = str(runtime_cfg.get("kind") or "").strip()
+        if runtime_kind not in recognized_runtime_kinds():
+            raise RuntimeError(
+                f"agent.runtime={runtime_name!r} uses unsupported runtime kind {runtime_kind!r}; "
+                f"expected one of {sorted(recognized_runtime_kinds())}"
+            )
         if runtime_kind == "codex-app-server":
             runtime_mode = str(
                 runtime_cfg.get("mode")
@@ -54,8 +61,12 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
                 raise RuntimeError(
                     "codex-app-server runtime requires command on the runtime profile or codex block"
                 )
-    elif not (agent.get("command") or codex_cfg.get("command")):
-        raise RuntimeError("issue-runner requires agent.runtime, agent.command, or codex.command")
+    else:
+        raise RuntimeError("issue-runner requires agent.runtime")
+
+    for check in [*runtime_stage_checks(config), *runtime_capability_checks(config)]:
+        if check.get("status") == "fail":
+            raise RuntimeError(str(check.get("detail") or check.get("name")))
 
     tracker_cfg = config.get("tracker") or {}
     repository_cfg = config.get("repository") or {}

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -109,11 +109,13 @@ properties:
 
   agent:
     type: object
-    required: [name, model]
+    required: [name, model, runtime]
     properties:
       name: {type: string}
       model: {type: string}
       runtime: {type: string}
+      required-capabilities:
+        $ref: "#/definitions/runtime-capability-list"
       command:
         type: array
         minItems: 1
@@ -247,6 +249,23 @@ definitions:
         patternProperties:
           "^on[-_.A-Za-z0-9]+$":
             type: string
+
+  runtime-capability-list:
+    type: array
+    items:
+      type: string
+      enum:
+        - prompt-turn
+        - command-stage
+        - one-shot
+        - persistent-session
+        - resume
+        - cancel
+        - structured-events
+        - token-metrics
+        - thread-visible
+        - activity-heartbeat
+        - service-required
 
   acpx-codex-runtime:
     type: object

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -51,7 +51,12 @@ from workflows.issue_runner.tracker import (
     select_issue,
 )
 from workflows.readiness import build_readiness_recommendations
-from workflows.runtime_presets import runtime_availability_checks, runtime_binding_checks
+from workflows.runtime_presets import (
+    runtime_availability_checks,
+    runtime_binding_checks,
+    runtime_capability_checks,
+    runtime_stage_checks,
+)
 from trackers.feedback import publish_tracker_feedback
 from trackers.github import (
     github_auth_host_from_slug,
@@ -330,10 +335,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         runtime_name = str(agent_cfg.get("runtime") or "").strip()
         if runtime_name:
             return runtime_name
-        codex_cfg = self.config.get("codex") or {}
-        if codex_cfg.get("command"):
-            return "codex"
-        raise RuntimeError("issue-runner requires agent.runtime, agent.command, or codex.command")
+        raise RuntimeError("issue-runner requires agent.runtime")
 
     def _agent_runtime(self) -> tuple[str, Runtime, dict[str, Any]]:
         runtime_name = self._agent_runtime_name()
@@ -424,7 +426,9 @@ class IssueRunnerWorkspace(WorkflowDriver):
             checks.append({"name": "agent-runtime", "status": "pass", "detail": runtime_name})
         except Exception as exc:
             checks.append({"name": "agent-runtime", "status": "fail", "detail": str(exc)})
+        checks.extend(runtime_stage_checks(self.config))
         checks.extend(runtime_binding_checks(self.config))
+        checks.extend(runtime_capability_checks(self.config))
         checks.extend(runtime_availability_checks(self.config))
 
         checks.extend(self.engine_store.doctor(event_retention=self.config.get("retention") or {}))

--- a/daedalus/workflows/readiness.py
+++ b/daedalus/workflows/readiness.py
@@ -69,6 +69,16 @@ def build_readiness_recommendations(
             _append_once(recommendations, _preflight_recommendation(check=check, workflow=workflow))
         elif name.startswith("runtime-binding"):
             _append_once(recommendations, _runtime_binding_recommendation(workflow=workflow))
+        elif name.startswith("runtime-stage"):
+            _append_once(
+                recommendations,
+                "Fix the actor/stage runtime references in `WORKFLOW.md`, then rerun `hermes daedalus validate`.",
+            )
+        elif name.startswith("runtime-capability"):
+            _append_once(
+                recommendations,
+                "Bind the role to a runtime with the required capabilities, or remove the explicit `required-capabilities` entry.",
+            )
         elif name.startswith("runtime-availability"):
             _append_once(recommendations, _runtime_availability_recommendation(detail))
         elif name == "github-auth":

--- a/daedalus/workflows/runtime_matrix.py
+++ b/daedalus/workflows/runtime_matrix.py
@@ -13,7 +13,9 @@ from workflows.change_delivery.contract_model import actor_config as change_deli
 from workflows.runtime_presets import (
     runtime_availability_checks,
     runtime_binding_checks,
+    runtime_capability_checks,
     runtime_role_bindings,
+    runtime_stage_checks,
 )
 
 
@@ -44,6 +46,8 @@ def build_runtime_matrix_report(
     runtime_filter = _normalized_filter(runtimes)
 
     binding_checks = runtime_binding_checks(config)
+    stage_checks = runtime_stage_checks(config)
+    capability_checks = runtime_capability_checks(config)
     availability_checks = runtime_availability_checks(config)
     bindings = runtime_role_bindings(config)
     selected_bindings = [
@@ -57,6 +61,7 @@ def build_runtime_matrix_report(
         _matrix_item(
             binding=binding,
             binding_checks=binding_checks,
+            capability_checks=capability_checks,
             availability_checks=availability_checks,
         )
         for binding in selected_bindings
@@ -75,17 +80,25 @@ def build_runtime_matrix_report(
             run_json=run_json,
         )
 
-    selected_binding_check_names = {
-        f"runtime-binding:{item.get('role')}"
+    selected_check_names = {
+        f"{prefix}:{item.get('role')}"
         for item in matrix
         if item.get("role")
+        for prefix in ("runtime-binding", "runtime-capability")
     }
     failures = [
         check
-        for check in binding_checks
-        if check.get("name") in selected_binding_check_names
-        and str(check.get("status") or "") == "fail"
+        for check in stage_checks
+        if str(check.get("status") or "") == "fail"
     ]
+    failures.extend(
+        [
+            check
+            for check in [*binding_checks, *capability_checks]
+            if check.get("name") in selected_check_names
+            and str(check.get("status") or "") == "fail"
+        ]
+    )
     if execute:
         failures.extend(
             {
@@ -116,7 +129,9 @@ def build_runtime_matrix_report(
             if isinstance(cfg, dict)
         },
         "bindings": bindings,
+        "stage_checks": stage_checks,
         "binding_checks": binding_checks,
+        "capability_checks": capability_checks,
         "availability_checks": availability_checks,
         "matrix": matrix,
         "failures": failures,
@@ -207,18 +222,22 @@ def _matrix_item(
     *,
     binding: dict[str, Any],
     binding_checks: list[dict[str, Any]],
+    capability_checks: list[dict[str, Any]],
     availability_checks: list[dict[str, Any]],
 ) -> dict[str, Any]:
     role = str(binding.get("role") or "")
     runtime_name = str(binding.get("runtime") or "")
     binding_check = _find_check(binding_checks, f"runtime-binding:{role}")
+    capability_check = _find_check(capability_checks, f"runtime-capability:{role}")
     availability_check = _find_check(availability_checks, f"runtime-availability:{runtime_name}")
     return {
         "role": role,
         "runtime": runtime_name or None,
         "kind": binding.get("kind"),
         "profile_exists": bool(binding.get("profile_exists")),
+        "capabilities": binding.get("capabilities") or [],
         "binding": binding_check,
+        "capability": capability_check,
         "availability": availability_check,
     }
 

--- a/daedalus/workflows/runtime_presets.py
+++ b/daedalus/workflows/runtime_presets.py
@@ -17,6 +17,15 @@ from workflows.change_delivery.contract_model import (
     bind_actor_runtime,
     change_delivery_actor_names,
 )
+from runtimes.capabilities import (
+    CAP_COMMAND_STAGE,
+    CAP_PROMPT_TURN,
+    explicit_required_capabilities,
+    format_capabilities,
+    recognized_runtime_kinds,
+    runtime_profile_capabilities,
+    unknown_capabilities,
+)
 
 
 RUNTIME_PRESETS: dict[str, dict[str, Any]] = {
@@ -92,6 +101,11 @@ def configure_runtime_contract(
         role=role,
         runtime_name=resolved_runtime_name,
     )
+    capability_checks = runtime_capability_checks(config)
+    capability_failures = _runtime_capability_failures_for_roles(capability_checks, changed_roles)
+    if capability_failures:
+        details = "; ".join(str(check.get("detail") or check.get("name")) for check in capability_failures)
+        raise RuntimePresetError(details)
 
     if not dry_run:
         contract.source_path.write_text(
@@ -112,6 +126,7 @@ def configure_runtime_contract(
         "changed_roles": changed_roles,
         "bindings": runtime_role_bindings(config),
         "checks": runtime_binding_checks(config),
+        "capability_checks": capability_checks,
         "availability_checks": runtime_availability_checks(config),
         "dry_run": dry_run,
     }
@@ -182,6 +197,31 @@ def runtime_binding_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
                 }
             )
             continue
+        kind = str(binding.get("kind") or "").strip()
+        if not kind:
+            checks.append(
+                {
+                    "name": f"runtime-binding:{role}",
+                    "status": "fail",
+                    "detail": f"{role} references runtime profile {runtime_name!r} without runtime.kind",
+                    "role": role,
+                    "runtime": runtime_name,
+                }
+            )
+            continue
+        if kind not in recognized_runtime_kinds():
+            checks.append(
+                {
+                    "name": f"runtime-binding:{role}",
+                    "status": "fail",
+                    "detail": f"{role} references runtime profile {runtime_name!r} with unsupported kind {kind!r}",
+                    "role": role,
+                    "runtime": runtime_name,
+                    "kind": kind,
+                    "expected": sorted(recognized_runtime_kinds()),
+                }
+            )
+            continue
         checks.append(
             {
                 "name": f"runtime-binding:{role}",
@@ -190,6 +230,111 @@ def runtime_binding_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
                 "role": role,
                 "runtime": runtime_name,
                 "kind": binding.get("kind"),
+                "capabilities": binding.get("capabilities"),
+            }
+        )
+    return checks
+
+
+def runtime_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    workflow_name = str(config.get("workflow") or "").strip()
+    if workflow_name == "issue-runner":
+        return _issue_runner_stage_checks(config)
+    if workflow_name == "change-delivery":
+        return _change_delivery_stage_checks(config)
+    return []
+
+
+def runtime_capability_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    runtimes = _runtime_profiles_from_config(config)
+    for binding in runtime_role_bindings(config):
+        role = str(binding.get("role") or "runtime-role")
+        runtime_name = str(binding.get("runtime") or "").strip()
+        if not runtime_name or not binding.get("profile_exists"):
+            continue
+        runtime_cfg = runtimes.get(runtime_name) if isinstance(runtimes.get(runtime_name), dict) else {}
+        profile = runtime_profile_capabilities(runtime_cfg)
+        if profile is None:
+            kind = str((runtime_cfg or {}).get("kind") or "").strip()
+            checks.append(
+                {
+                    "name": f"runtime-capability:{role}",
+                    "status": "fail",
+                    "detail": f"{role} uses unsupported runtime kind {kind!r}",
+                    "role": role,
+                    "runtime": runtime_name,
+                    "kind": kind,
+                }
+            )
+            continue
+
+        role_cfg = _runtime_role_config(config, role) or {}
+        explicit = explicit_required_capabilities(role_cfg)
+        unknown = unknown_capabilities(explicit)
+        if unknown:
+            checks.append(
+                {
+                    "name": f"runtime-capability:{role}",
+                    "status": "fail",
+                    "detail": f"{role} declares unknown required capabilities: {format_capabilities(unknown)}",
+                    "role": role,
+                    "runtime": runtime_name,
+                    "kind": profile.kind,
+                    "unknown_capabilities": sorted(unknown),
+                }
+            )
+            continue
+
+        required_any = _runtime_required_any_capabilities(role_cfg=role_cfg, runtime_cfg=runtime_cfg)
+        missing_all = explicit - profile.capabilities
+        if required_any and not profile.has_any(required_any):
+            checks.append(
+                {
+                    "name": f"runtime-capability:{role}",
+                    "status": "fail",
+                    "detail": (
+                        f"{role} requires one of {format_capabilities(required_any)}, "
+                        f"but {runtime_name} ({profile.kind}) has {format_capabilities(profile.capabilities)}"
+                    ),
+                    "role": role,
+                    "runtime": runtime_name,
+                    "kind": profile.kind,
+                    "required_any": sorted(required_any),
+                    "capabilities": sorted(profile.capabilities),
+                }
+            )
+            continue
+        if missing_all:
+            checks.append(
+                {
+                    "name": f"runtime-capability:{role}",
+                    "status": "fail",
+                    "detail": (
+                        f"{role} requires {format_capabilities(explicit)}, "
+                        f"but {runtime_name} ({profile.kind}) is missing {format_capabilities(missing_all)}"
+                    ),
+                    "role": role,
+                    "runtime": runtime_name,
+                    "kind": profile.kind,
+                    "required": sorted(explicit),
+                    "missing": sorted(missing_all),
+                    "capabilities": sorted(profile.capabilities),
+                }
+            )
+            continue
+        required_detail = format_capabilities(explicit or required_any)
+        checks.append(
+            {
+                "name": f"runtime-capability:{role}",
+                "status": "pass",
+                "detail": f"{role} runtime capabilities ok; required={required_detail}",
+                "role": role,
+                "runtime": runtime_name,
+                "kind": profile.kind,
+                "required": sorted(explicit),
+                "required_any": sorted(required_any),
+                "capabilities": sorted(profile.capabilities),
             }
         )
     return checks
@@ -263,14 +408,138 @@ def _append_binding(
     normalized_runtime = str(runtime_name or "").strip() or None
     runtime_cfg = runtimes.get(normalized_runtime) if normalized_runtime else None
     profile_exists = isinstance(runtime_cfg, dict)
+    capability_profile = runtime_profile_capabilities(runtime_cfg) if profile_exists else None
     bindings.append(
         {
             "role": role,
             "runtime": normalized_runtime,
             "profile_exists": profile_exists,
             "kind": str(runtime_cfg.get("kind") or "").strip() if profile_exists else None,
+            "capabilities": sorted(capability_profile.capabilities) if capability_profile else [],
         }
     )
+
+
+def _runtime_role_config(config: dict[str, Any], role: str) -> dict[str, Any] | None:
+    workflow_name = str(config.get("workflow") or "").strip()
+    if workflow_name == "issue-runner" and role == "agent":
+        agent = config.get("agent")
+        return agent if isinstance(agent, dict) else None
+    if workflow_name == "change-delivery":
+        return change_delivery_actor_config(config, role)
+    return None
+
+
+def _runtime_required_any_capabilities(*, role_cfg: dict[str, Any], runtime_cfg: dict[str, Any]) -> frozenset[str]:
+    if role_cfg.get("command") or runtime_cfg.get("command"):
+        return frozenset({CAP_COMMAND_STAGE})
+    return frozenset({CAP_PROMPT_TURN})
+
+
+def _runtime_capability_failures_for_roles(
+    checks: list[dict[str, Any]],
+    roles: list[str],
+) -> list[dict[str, Any]]:
+    role_set = set(roles)
+    return [
+        check
+        for check in checks
+        if check.get("status") == "fail" and str(check.get("role") or "") in role_set
+    ]
+
+
+def _issue_runner_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    agent = config.get("agent")
+    if not isinstance(agent, dict):
+        return [
+            {
+                "name": "runtime-stage:agent",
+                "status": "fail",
+                "detail": "issue-runner agent must be a mapping",
+                "role": "agent",
+            }
+        ]
+    runtime_name = str(agent.get("runtime") or "").strip()
+    if runtime_name:
+        return [
+            {
+                "name": "runtime-stage:agent",
+                "status": "pass",
+                "detail": f"agent dispatches through runtime profile {runtime_name!r}",
+                "role": "agent",
+                "runtime": runtime_name,
+            }
+        ]
+    return [
+        {
+            "name": "runtime-stage:agent",
+            "status": "fail",
+            "detail": "issue-runner agent requires runtime",
+            "role": "agent",
+        }
+    ]
+
+
+def _change_delivery_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+    actors = config.get("actors") if isinstance(config.get("actors"), dict) else {}
+    checks: list[dict[str, Any]] = []
+
+    def append_actor_ref(path: str, actor_name: Any) -> None:
+        actor = str(actor_name or "").strip()
+        if not actor:
+            return
+        actor_cfg = actors.get(actor) if isinstance(actors, dict) else None
+        if not isinstance(actor_cfg, dict):
+            checks.append(
+                {
+                    "name": f"runtime-stage:{path}",
+                    "status": "fail",
+                    "detail": f"{path} references missing actor {actor!r}",
+                    "path": path,
+                    "role": actor,
+                }
+            )
+            return
+        runtime_name = str(actor_cfg.get("runtime") or "").strip()
+        if not runtime_name:
+            checks.append(
+                {
+                    "name": f"runtime-stage:{path}",
+                    "status": "fail",
+                    "detail": f"{path} actor {actor!r} has no runtime profile",
+                    "path": path,
+                    "role": actor,
+                }
+            )
+            return
+        checks.append(
+            {
+                "name": f"runtime-stage:{path}",
+                "status": "pass",
+                "detail": f"{path} -> actor {actor} -> runtime {runtime_name}",
+                "path": path,
+                "role": actor,
+                "runtime": runtime_name,
+            }
+        )
+
+    stages = config.get("stages") if isinstance(config.get("stages"), dict) else {}
+    for stage_name, stage_cfg in stages.items():
+        if not isinstance(stage_cfg, dict):
+            continue
+        append_actor_ref(f"stages.{stage_name}.actor", stage_cfg.get("actor"))
+        escalation = stage_cfg.get("escalation")
+        if isinstance(escalation, dict):
+            append_actor_ref(f"stages.{stage_name}.escalation.actor", escalation.get("actor"))
+
+    gates = config.get("gates") if isinstance(config.get("gates"), dict) else {}
+    for gate_name, gate_cfg in gates.items():
+        if not isinstance(gate_cfg, dict):
+            continue
+        if str(gate_cfg.get("type") or "").strip() == "agent-review":
+            append_actor_ref(f"gates.{gate_name}.actor", gate_cfg.get("actor"))
+
+    return checks
 
 
 def _runtime_availability_check(*, name: str, kind: str, runtime_cfg: dict[str, Any]) -> dict[str, Any]:
@@ -355,6 +624,8 @@ __all__ = [
     "configure_runtime_contract",
     "runtime_availability_checks",
     "runtime_binding_checks",
+    "runtime_capability_checks",
     "runtime_preset_config",
     "runtime_role_bindings",
+    "runtime_stage_checks",
 ]

--- a/daedalus/workflows/validation.py
+++ b/daedalus/workflows/validation.py
@@ -11,7 +11,7 @@ import yaml
 from . import load_workflow
 from .contract import WorkflowContract, WorkflowContractError, load_workflow_contract
 from .readiness import build_readiness_recommendations
-from .runtime_presets import runtime_binding_checks
+from .runtime_presets import runtime_binding_checks, runtime_capability_checks, runtime_stage_checks
 
 
 SERVICE_MODES = frozenset({"active", "shadow"})
@@ -204,7 +204,9 @@ def validate_workflow_contract(
 
     checks.append(_instance_name_check(workflow_root=root, config=config))
     checks.append(_repository_path_check(workflow_root=root, config=config))
+    checks.extend(runtime_stage_checks(config))
     checks.extend(runtime_binding_checks(config))
+    checks.extend(runtime_capability_checks(config))
 
     if module is not None and run_preflight:
         preflight_fn = getattr(module, "run_preflight", None)

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -5,6 +5,9 @@ A **runtime** is the thing Daedalus shells out to when a turn happens. Daedalus 
 At the code level, these shared execution backends live under
 `daedalus/runtimes/`. The operator-facing contract also uses the `runtimes:`
 config block because workflows bind named runtime profiles to workflow roles.
+Every runtime-backed role must name a runtime profile. Command overrides are
+execution details on that role/profile; they are not fallback paths around the
+runtime contract.
 
 ## The Protocol
 
@@ -47,14 +50,44 @@ app-server transport. It is not treated as a per-stage command. Use
 
 ## Adapter shape comparison
 
-|| | `claude-cli` | `acpx-codex` | `hermes-agent` | `codex-app-server` |
-|---|---|---|---|---|---|
-| Persistent session | ❌ one-shot | ✅ resumable | ❌ one-shot | ✅ resumable Codex thread |
-| `ensure_session` | no-op | `acpx codex sessions ensure` | no-op | no-op |
-| `run_prompt` | `claude --print …` | `acpx codex prompt -s <name>` | `hermes -z` or `hermes chat --quiet -q` | JSON-RPC over stdio to `codex app-server` |
-| `assess_health` | always healthy | freshness + grace window | always healthy | always healthy |
-| `close_session` | no-op | `acpx codex sessions close` | no-op | no-op |
-| Records `last_activity_ts` | yes (before + after `_run`) | yes | yes | yes |
+| Runtime kind | Execution model | Session behavior | Strongest capabilities |
+|---|---|---|---|
+| `hermes-agent` | `hermes -z` or `hermes chat --quiet -q` | one-shot from Daedalus' point of view | `prompt-turn`, `command-stage`, `one-shot`, `activity-heartbeat` |
+| `codex-app-server` | JSON-RPC over stdio or WebSocket | resumable Codex threads | `persistent-session`, `resume`, `cancel`, `structured-events`, `token-metrics`, `thread-visible` |
+| `claude-cli` | `claude --print ...` | one-shot | `prompt-turn`, `command-stage`, `one-shot`, `activity-heartbeat` |
+| `acpx-codex` | `acpx codex prompt -s <name>` | resumable ACPX sessions | `persistent-session`, `resume`, `activity-heartbeat` |
+
+External `codex-app-server` profiles also expose `service-required` because the
+listener must already be running.
+
+## Capability Validation
+
+Daedalus validates runtime bindings before dispatch. The checks cover:
+
+- runtime profile exists
+- `runtime.kind` is one of the registered adapters
+- workflow stages and gates reference declared actors
+- each bound actor/agent has the execution capability needed for its stage
+- explicit `required-capabilities` are supported by the selected runtime
+
+Use `required-capabilities` only when the workflow role truly depends on a
+runtime feature:
+
+```yaml
+actors:
+  implementer:
+    name: Change_Implementer
+    model: gpt-5.4
+    runtime: codex-service
+    required-capabilities:
+      - persistent-session
+      - resume
+      - token-metrics
+```
+
+If the selected runtime lacks one of those capabilities, `hermes daedalus
+validate`, `doctor`, `runtime-matrix`, and `configure-runtime` fail instead of
+silently falling back.
 
 ## Selection in `WORKFLOW.md`
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -47,6 +47,33 @@ def test_codex_app_server_runtime_kind_returns_ok():
     assert result.ok is True
 
 
+def test_missing_stage_actor_yields_runtime_binding_error():
+    cfg = _minimal_ok_config()
+    cfg["stages"] = {
+        "implement": {
+            "actor": "implementer",
+            "escalation": {"after-attempts": 2, "actor": "missing-high-effort"},
+        }
+    }
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "invalid_runtime_binding"
+    assert "missing actor" in (result.error_detail or "")
+
+
+def test_required_capability_mismatch_yields_runtime_capability_error():
+    cfg = _minimal_ok_config()
+    cfg["actors"]["reviewer"]["required-capabilities"] = ["token-metrics"]
+
+    result = run_preflight(cfg)
+
+    assert result.ok is False
+    assert result.error_code == "runtime_capability_mismatch"
+    assert "token-metrics" in (result.error_detail or "")
+
+
 def test_non_dict_config_yields_front_matter_error():
     result = run_preflight("not-a-dict")  # type: ignore[arg-type]
     assert result.ok is False

--- a/tests/test_runtime_agnostic_schema.py
+++ b/tests/test_runtime_agnostic_schema.py
@@ -87,6 +87,12 @@ def test_schema_accepts_prompt_override_on_actor():
     Draft7Validator(_schema()).validate(cfg)
 
 
+def test_schema_accepts_actor_required_capabilities():
+    cfg = _base_config()
+    cfg["actors"]["implementer"]["required-capabilities"] = ["persistent-session", "resume"]
+    Draft7Validator(_schema()).validate(cfg)
+
+
 def test_schema_rejects_empty_command_array():
     from jsonschema import ValidationError
 

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -1,0 +1,36 @@
+from runtimes.capabilities import (
+    CAP_CANCEL,
+    CAP_ONE_SHOT,
+    CAP_SERVICE_REQUIRED,
+    CAP_TOKEN_METRICS,
+    recognized_runtime_kinds,
+    runtime_profile_capabilities,
+)
+
+
+def test_runtime_capability_registry_lists_builtin_kinds():
+    assert recognized_runtime_kinds() == {
+        "acpx-codex",
+        "claude-cli",
+        "codex-app-server",
+        "hermes-agent",
+    }
+
+
+def test_codex_app_server_external_profile_exposes_service_capabilities():
+    profile = runtime_profile_capabilities(
+        {"kind": "codex-app-server", "mode": "external", "endpoint": "ws://127.0.0.1:4500"}
+    )
+
+    assert profile is not None
+    assert CAP_CANCEL in profile.capabilities
+    assert CAP_TOKEN_METRICS in profile.capabilities
+    assert CAP_SERVICE_REQUIRED in profile.capabilities
+
+
+def test_hermes_agent_profile_is_one_shot_without_token_metrics():
+    profile = runtime_profile_capabilities({"kind": "hermes-agent", "mode": "chat"})
+
+    assert profile is not None
+    assert CAP_ONE_SHOT in profile.capabilities
+    assert CAP_TOKEN_METRICS not in profile.capabilities

--- a/tests/test_runtime_presets.py
+++ b/tests/test_runtime_presets.py
@@ -154,6 +154,36 @@ def test_configure_runtime_rejects_unknown_role(tmp_path):
         )
 
 
+def test_configure_runtime_rejects_capability_mismatch(tmp_path):
+    root = tmp_path / "attmous-daedalus-issue-runner"
+    root.mkdir()
+    _write_contract(
+        root / "WORKFLOW.md",
+        {
+            "workflow": "issue-runner",
+            "schema-version": 1,
+            "instance": {"name": root.name, "engine-owner": "hermes"},
+            "repository": {"local-path": str(tmp_path)},
+            "tracker": {"kind": "local-json"},
+            "workspace": {"root": "workspace/issues"},
+            "agent": {
+                "name": "runner",
+                "model": "gpt-5.4",
+                "required-capabilities": ["token-metrics"],
+            },
+            "storage": {"status": "memory/status.json", "health": "memory/health.json", "audit-log": "memory/audit.jsonl"},
+        },
+    )
+
+    with pytest.raises(RuntimePresetError, match="token-metrics"):
+        configure_runtime_contract(
+            workflow_root=root,
+            preset_name="hermes-final",
+            role="agent",
+            runtime_name=None,
+        )
+
+
 def test_configure_runtime_cli_outputs_json(tmp_path):
     tools = load_module("daedalus_tools_runtime_presets_test", "daedalus_cli.py")
     root = tmp_path / "attmous-daedalus-issue-runner"

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -173,3 +173,12 @@ def test_issue_runner_schema_accepts_tracker_feedback_config():
         },
     }
     jsonschema.validate(cfg, schema)
+
+
+def test_issue_runner_schema_accepts_agent_required_capabilities():
+    schema = yaml.safe_load(
+        (REPO_ROOT / "daedalus" / "workflows" / "issue_runner" / "schema.yaml").read_text(encoding="utf-8")
+    )
+    cfg = _config()
+    cfg["agent"]["required-capabilities"] = ["prompt-turn", "activity-heartbeat"]
+    jsonschema.validate(cfg, schema)

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -125,6 +125,25 @@ def _write_fake_codex_app_server(path: Path, *, requests_path: Path, fail: bool 
     path.write_text("\n".join(script) + "\n", encoding="utf-8")
 
 
+def _use_codex_runtime_profile(cfg: dict, command: str) -> None:
+    cfg["agent"]["runtime"] = "codex"
+    cfg.pop("daedalus", None)
+    cfg["codex"]["command"] = command
+    cfg["runtimes"] = {
+        "codex": {
+            "kind": "codex-app-server",
+            "command": command,
+            "ephemeral": False,
+            "approval_policy": "never",
+            "thread_sandbox": "workspace-write",
+            "turn_sandbox_policy": "workspace-write",
+            "turn_timeout_ms": 3600000,
+            "read_timeout_ms": 5000,
+            "stall_timeout_ms": 300000,
+        }
+    }
+
+
 def _write_issue_runner_contract(
     *,
     workflow_root: Path,
@@ -519,13 +538,14 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 
     cfg = _config(tmp_path)
-    cfg["agent"].pop("runtime", None)
-    cfg.pop("daedalus", None)
 
     runtime_script = tmp_path / "fake_codex_app_server.py"
     requests_path = tmp_path / "fake_codex_requests.jsonl"
     _write_fake_codex_app_server(runtime_script, requests_path=requests_path)
-    cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
+    _use_codex_runtime_profile(
+        cfg,
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}",
+    )
 
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     workflow_root.mkdir()
@@ -597,13 +617,14 @@ def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 
     cfg = _config(tmp_path)
-    cfg["agent"].pop("runtime", None)
-    cfg.pop("daedalus", None)
 
     runtime_script = tmp_path / "fake_codex_app_server.py"
     requests_path = tmp_path / "fake_codex_requests.jsonl"
     _write_fake_codex_app_server(runtime_script, requests_path=requests_path)
-    cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
+    _use_codex_runtime_profile(
+        cfg,
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}",
+    )
 
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     workflow_root.mkdir()
@@ -1235,13 +1256,14 @@ def test_issue_runner_codex_failure_preserves_partial_metrics(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 
     cfg = _config(tmp_path)
-    cfg["agent"].pop("runtime", None)
-    cfg.pop("daedalus", None)
 
     runtime_script = tmp_path / "fake_codex_app_server_fail.py"
     requests_path = tmp_path / "fake_codex_fail_requests.jsonl"
     _write_fake_codex_app_server(runtime_script, requests_path=requests_path, fail=True)
-    cfg["codex"]["command"] = f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}"
+    _use_codex_runtime_profile(
+        cfg,
+        f"{shlex.quote(sys.executable)} {shlex.quote(str(runtime_script))}",
+    )
 
     workflow_root = tmp_path / "attmous-daedalus-issue-runner"
     workflow_root.mkdir()


### PR DESCRIPTION
## Summary

Adds a shared runtime capability contract so Daedalus can validate runtime/stage bindings consistently across workflows.

## Changes

- Added shared runtime capability metadata for Hermes Agent, Codex app-server, Claude CLI, and ACPX Codex.
- Wired stage, binding, and capability checks into validate, doctor, preflight, runtime-matrix, and configure-runtime.
- Added `required-capabilities` schema support for issue-runner agents and change-delivery actors.
- Removed issue-runner's implicit codex command fallback so every execution path goes through an explicit runtime profile.
- Updated runtime documentation and tests for capability validation and explicit Codex app-server binding.

## Validation

- `pytest -q` -> `884 passed, 7 skipped`
- `git diff --check` -> clean