### PR TITLE
[codex] Ignore unscoped codex app-server turn errors

### DIFF
--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -1019,6 +1019,10 @@ class CodexAppServerRuntime:
         thread_id = self._message_thread_id(params)
         turn_id = self._message_turn_id(params)
 
+        # Shared app-server endpoints can emit unscoped errors for other turns.
+        # Request/response errors are still handled by _AppServerClient.request.
+        if method == "error" and not thread_id and not turn_id and state.thread_id and state.turn_id:
+            return False
         if thread_id and state.thread_id and thread_id != state.thread_id:
             return False
         if turn_id and state.turn_id and turn_id != state.turn_id:

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -528,6 +528,12 @@ def test_codex_app_server_runtime_filters_events_by_active_thread_and_turn():
     assert state.last_event is None
 
     assert (
+        runtime._consume_message({"method": "error", "params": {"message": "timed out"}}, state=state)
+        is False
+    )
+    assert state.last_event is None
+
+    assert (
         runtime._consume_message(
             {
                 "method": "turn/completed",
@@ -574,6 +580,21 @@ def test_codex_app_server_runtime_filters_events_by_active_thread_and_turn():
                 "params": {"threadId": "thread-current", "turnId": "turn-current", "message": "current failure"},
             },
             state=state,
+        )
+
+
+def test_codex_app_server_runtime_keeps_unscoped_startup_errors_fatal():
+    from runtimes.codex_app_server import CodexAppServerError, CodexAppServerRuntime, _RunState
+
+    runtime = CodexAppServerRuntime({"command": [sys.executable, "-c", ""]}, run=None)
+
+    with pytest.raises(CodexAppServerError, match="startup failed"):
+        runtime._consume_message({"method": "error", "params": {"message": "startup failed"}}, state=_RunState())
+
+    with pytest.raises(CodexAppServerError, match="turn start failed"):
+        runtime._consume_message(
+            {"method": "error", "params": {"message": "turn start failed"}},
+            state=_RunState(session_id="thread-current", thread_id="thread-current"),
         )
 
 


### PR DESCRIPTION
## Summary

- Ignore unscoped `error` notifications after Daedalus has identified the active Codex app-server thread and turn.
- Keep startup, turn-start, correlated turn, protocol, and JSON-RPC request errors fatal.
- Add regression coverage for the smoke-run failure shape and the still-fatal unscoped startup cases.

## Root Cause

During the playground smoke run, the shared Codex app-server emitted an unscoped `error` notification with message `timed out` while the active turn continued and later completed successfully. Daedalus treated that notification as the current turn failure because it had no thread or turn IDs to reject.

## Validation

- `python3 -m pytest tests/test_runtimes_codex_app_server.py -q` (`20 passed, 1 skipped`)
- `python3 -m pytest -q` (`877 passed, 7 skipped`)