### PR TITLE
[codex] Reconcile app-server dispatch after landed commits

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1018,6 +1018,15 @@ def _required_review_flags(legacy_status: dict[str, Any]) -> tuple[int, int]:
     return internal_required, external_required
 
 
+def _implementation_backend_type(impl: dict[str, Any]) -> str:
+    return str(
+        impl.get("sessionRuntime")
+        or impl.get("runtimeKind")
+        or impl.get("backendType")
+        or "acpx-codex"
+    )
+
+
 def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], now_iso: str | None = None) -> dict[str, Any]:
     now_iso = now_iso or _now_iso()
     active_lane = legacy_status.get("activeLane") or {}
@@ -1029,6 +1038,7 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
     lane_state = (impl.get("laneState") or {}).get("implementation") or {}
     reviews = legacy_status.get("reviews") or {}
     internal_required, external_required = _required_review_flags(legacy_status)
+    implementation_backend = _implementation_backend_type(impl)
     repo_path = legacy_status.get("repo") or ""
     merge_blockers_json = json.dumps(legacy_status.get("derivedMergeBlockers") or [])
     repair_brief_json = json.dumps((legacy_status.get("ledger") or {}).get("repairBrief"))
@@ -1102,7 +1112,7 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
             (
                 lane_id, issue_number, active_lane.get("url") or "", active_lane.get("title") or "",
                 repo_path, impl.get("worktree"), impl.get("branch"), None, effort_label,
-                "acpx-codex", "active", (legacy_status.get("ledger") or {}).get("workflowState") or "unknown",
+                implementation_backend, "active", (legacy_status.get("ledger") or {}).get("workflowState") or "unknown",
                 legacy_status.get("derivedReviewLoopState") or (legacy_status.get("ledger") or {}).get("reviewState") or "unknown",
                 _merge_state_from_status(legacy_status), impl.get("localHeadSha"), ((impl.get("laneState") or {}).get("pr") or {}).get("lastPublishedHeadSha"),
                 (legacy_status.get("openPr") or {}).get("number"), (legacy_status.get("openPr") or {}).get("url"),
@@ -1139,7 +1149,7 @@ def ingest_legacy_status(*, workflow_root: Path, legacy_status: dict[str, Any], 
               updated_at=excluded.updated_at
             """,
             (
-                actor_id, lane_id, "Internal_Coder_Agent", "Internal_Coder_Agent", "acpx-codex",
+                actor_id, lane_id, "Internal_Coder_Agent", "Internal_Coder_Agent", implementation_backend,
                 impl.get("sessionName"), impl.get("resumeSessionId"), impl.get("codexModel"),
                 "healthy" if (impl.get("activeSessionHealth") or {}).get("healthy") else "unhealthy",
                 (impl.get("sessionActionRecommendation") or {}).get("action"), now_iso,
@@ -1261,6 +1271,20 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
     actor_metadata = _parse_json_blob(actor_row.get("metadata_json")) or {}
     session_control = actor_metadata.get("sessionControl") or {}
     repair_brief = _parse_json_blob(lane_row.get("repair_brief_json")) or {}
+    internal_review_status = str((internal_review or {}).get("status") or "").strip()
+    internal_review_head = (internal_review or {}).get("reviewed_head_sha") or (internal_review or {}).get("requested_head_sha")
+    internal_review_needs_request = bool(
+        current_head_sha
+        and lane_row.get("required_internal_review")
+        and (
+            internal_review is None
+            or internal_review_status in {"", "not_started", "pending"}
+            or (
+                internal_review_status == "completed"
+                and internal_review_head != current_head_sha
+            )
+        )
+    )
     has_actionable_repair_brief = bool(
         current_head_sha
         and repair_brief.get("forHeadSha") == current_head_sha
@@ -1281,6 +1305,18 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
         and external_review
         and last_external_review_handoff.get("reviewedAt") == external_review.get("completed_at")
     )
+    if (
+        workflow_state in {"implementing_local", "implementing"}
+        and not active_pr_number
+        and internal_review_needs_request
+    ):
+        return [{
+            "action_type": "request_internal_review",
+            "lane_id": lane_row.get("lane_id"),
+            "issue_number": lane_row.get("issue_number"),
+            "target_head_sha": current_head_sha,
+            "reason": "internal-review-pending",
+        }]
     if (
         workflow_state in {"implementing_local", "implementing"}
         and not active_pr_number
@@ -1368,9 +1404,7 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
     if (
         workflow_state == "awaiting_pre_publish_review"
         and not active_pr_number
-        and lane_row.get("required_internal_review")
-        and (internal_review is None or internal_review.get("status") in {None, "", "pending", "not_started"})
-        and current_head_sha
+        and internal_review_needs_request
     ):
         return [{
             "action_type": "request_internal_review",

--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable
 
 from workflows.change_delivery.migrations import get_review
@@ -55,6 +56,46 @@ def _runtime_metrics_payload(value: Any) -> dict[str, Any]:
         "tokens": tokens if isinstance(tokens, dict) else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         "rate_limits": _object_value(value, "rate_limits", "rateLimits"),
     }
+
+
+def _prompt_result_from_exception(exc: Exception) -> Any:
+    result = getattr(exc, "result", None)
+    if result is not None:
+        return result
+    return SimpleNamespace(
+        output="",
+        session_id=None,
+        thread_id=None,
+        turn_id=None,
+        last_event=None,
+        last_message=str(exc),
+        turn_count=0,
+        tokens={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        rate_limits=None,
+    )
+
+
+def _reconciled_status_after_prompt_error(
+    *,
+    reconcile_fn: Callable[..., dict[str, Any]],
+    status_before: dict[str, Any],
+    issue_number: Any,
+) -> dict[str, Any] | None:
+    try:
+        status_after = reconcile_fn(fix_watchers=True)
+    except Exception:
+        return None
+    active_lane = status_after.get("activeLane") or {}
+    if issue_number and active_lane.get("number") != issue_number:
+        return None
+    before_head = (status_before.get("implementation") or {}).get("localHeadSha")
+    after_head = (status_after.get("implementation") or {}).get("localHeadSha")
+    if not after_head:
+        return None
+    next_action_type = (status_after.get("nextAction") or {}).get("type")
+    if next_action_type not in {"run_internal_review", "publish_ready_pr", "push_pr_update", "merge_and_promote"}:
+        return None
+    return status_after
 
 
 def run_publish_ready_pr(
@@ -388,6 +429,8 @@ def run_dispatch_lane_turn(
         workflow_state=(status.get('ledger') or {}).get('workflowState'),
     )
     session_record_id = session_meta.get('record_id') or _object_value(ensured, "record_id", "recordId", "acpxRecordId")
+    reconciled_after_prompt_error: dict[str, Any] | None = None
+    prompt_error: Exception | None = None
     try:
         prompt_result = run_prompt_fn(
             worktree=worktree,
@@ -419,6 +462,16 @@ def run_dispatch_lane_turn(
             prompt=prompt,
             codex_model=codex_model,
         )
+    except Exception as exc:
+        reconciled_after_prompt_error = _reconciled_status_after_prompt_error(
+            reconcile_fn=reconcile_fn,
+            status_before=status,
+            issue_number=issue.get('number'),
+        )
+        if reconciled_after_prompt_error is None:
+            raise
+        prompt_error = exc
+        prompt_result = _prompt_result_from_exception(exc)
     runtime_metrics = _runtime_metrics_payload(prompt_result)
     if record_runtime_result_fn is not None:
         runtime_metrics = record_runtime_result_fn(
@@ -482,7 +535,7 @@ def run_dispatch_lane_turn(
         'lastRestartAt': attempt_at if action == 'restart-session' else ledger.get('implementation', {}).get('lastRestartAt'),
     }
     save_ledger_fn(ledger)
-    reconciled = reconcile_fn(fix_watchers=True)
+    reconciled = reconciled_after_prompt_error or reconcile_fn(fix_watchers=True)
     result = {
         'dispatched': True,
         'action': action,
@@ -501,6 +554,9 @@ def run_dispatch_lane_turn(
         'promptResult': _prompt_output(prompt_result),
         'health': reconciled.get('health'),
     }
+    if prompt_error is not None:
+        result['reconciledAfterRuntimeError'] = True
+        result['runtimeError'] = str(prompt_error)
     audit_fn(
         audit_action,
         f"Dispatched persistent Codex lane turn via {runtime_kind or 'acpx-codex'} session {session_name}",

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -193,6 +193,7 @@ def test_ingest_legacy_status_uses_canonical_internal_review_for_active_request(
             "worktree": "/tmp/issue-221",
             "branch": "codex/issue-221-test",
             "localHeadSha": "abc123",
+            "sessionRuntime": "codex-app-server",
             "laneState": {"implementation": {}, "pr": {"lastPublishedHeadSha": None}},
             "activeSessionHealth": {"healthy": False, "lastUsedAt": None},
             "sessionActionRecommendation": {"action": "restart-session"},
@@ -231,8 +232,12 @@ def test_ingest_legacy_status_uses_canonical_internal_review_for_active_request(
     conn = sqlite3.connect(paths["db_path"])
     try:
         lane_required = conn.execute(
-            "SELECT required_internal_review FROM lanes WHERE lane_id=?",
+            "SELECT required_internal_review, actor_backend FROM lanes WHERE lane_id=?",
             ("lane:221",),
+        ).fetchone()
+        actor_backend = conn.execute(
+            "SELECT backend_type FROM lane_actors WHERE actor_id=?",
+            ("actor:lane:221:coder",),
         ).fetchone()[0]
         review_row = conn.execute(
             "SELECT status, backend_type, requested_head_sha FROM lane_reviews WHERE review_id=?",
@@ -241,7 +246,8 @@ def test_ingest_legacy_status_uses_canonical_internal_review_for_active_request(
     finally:
         conn.close()
 
-    assert lane_required == 1
+    assert lane_required == (1, "codex-app-server")
+    assert actor_backend == "codex-app-server"
     assert review_row == ("pending", "internalReview", "abc123")
     assert actions[0]["action_type"] == "request_internal_review"
 
@@ -310,6 +316,34 @@ def test_derive_shadow_actions_requests_internal_review_without_review_row(runti
         },
         reviews=[],
         actor_row={},
+    )
+
+    assert actions == [
+        {
+            "action_type": "request_internal_review",
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "target_head_sha": "abc123",
+            "reason": "internal-review-pending",
+        }
+    ]
+
+
+def test_derive_shadow_actions_requests_internal_review_for_new_local_head(runtime_module):
+    actions = runtime_module.derive_shadow_actions_for_lane(
+        lane_row={
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "workflow_state": "implementing_local",
+            "required_internal_review": 1,
+            "active_pr_number": None,
+            "current_head_sha": "abc123",
+        },
+        reviews=[],
+        actor_row={
+            "runtime_status": "unhealthy",
+            "session_action_recommendation": "restart-session",
+        },
     )
 
     assert actions == [

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -517,6 +517,80 @@ def test_run_dispatch_lane_turn_records_codex_app_server_thread_metrics(tmp_path
     assert impl["runtimeMetrics"]["rate_limits"] == {"requests_remaining": 99}
 
 
+def test_run_dispatch_lane_turn_reconciles_runtime_error_after_local_head(tmp_path):
+    actions_module = load_module("daedalus_workflows_change_delivery_actions_reconciled_error", "workflows/change_delivery/actions.py")
+    state, worktree, deps = _dispatch_deps(tmp_path)
+    status = {
+        "activeLane": {"number": 224, "title": "T", "url": "https://example.test/issue/224"},
+        "implementation": {
+            "worktree": str(worktree),
+            "branch": "issue-224",
+            "sessionName": "lane-224",
+            "codexModel": "gpt-5.5",
+            "resumeSessionId": "thread-existing",
+            "sessionActionRecommendation": {"action": "continue-session"},
+            "laneState": {},
+        },
+        "ledger": {"workflowState": "implementing_local"},
+        "reviews": {},
+        "openPr": None,
+    }
+
+    class RuntimeCompletedThenTimedOut(RuntimeError):
+        def __init__(self):
+            super().__init__("codex-app-server failed: timed out")
+            self.result = SimpleNamespace(
+                output="implemented\n",
+                session_id="thread-1",
+                thread_id="thread-1",
+                turn_id="turn-1",
+                last_event="item/agentMessage/delta",
+                last_message=".",
+                turn_count=1,
+                tokens={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+                rate_limits=None,
+            )
+
+    def run_prompt_fn(*, worktree, session_name, prompt, codex_model):
+        raise RuntimeCompletedThenTimedOut()
+
+    def reconcile_fn(*, fix_watchers=False):
+        return {
+            "health": "healthy",
+            "activeLane": {"number": 224},
+            "implementation": {"localHeadSha": "head-after-error"},
+            "nextAction": {"type": "run_internal_review", "reason": "prepublish-review-required"},
+        }
+
+    recorded = {}
+
+    def record_runtime_result_fn(**kwargs):
+        recorded.update(kwargs)
+        return kwargs["metrics"]
+
+    result = actions_module.run_dispatch_lane_turn(
+        status=status,
+        forced_action=None,
+        audit_action="dispatch-implementation-turn",
+        **{
+            **deps,
+            "run_prompt_fn": run_prompt_fn,
+            "reconcile_fn": reconcile_fn,
+            "runtime_name": "coder-runtime",
+            "runtime_kind": "codex-app-server",
+            "record_runtime_result_fn": record_runtime_result_fn,
+        },
+    )
+
+    assert result["dispatched"] is True
+    assert result["reconciledAfterRuntimeError"] is True
+    assert result["runtimeError"] == "codex-app-server failed: timed out"
+    assert result["promptResult"] == "implemented"
+    assert result["health"] == "healthy"
+    assert recorded["metrics"]["thread_id"] == "thread-1"
+    assert state["save_ledger"]
+
+
 def test_run_dispatch_lane_turn_closes_session_for_restart(tmp_path):
     actions_module = load_module("daedalus_workflows_change_delivery_actions_rdlt", "workflows/change_delivery/actions.py")
     state, worktree, deps = _dispatch_deps(tmp_path)


### PR DESCRIPTION
## Summary

Fixes the smoke-test path where a Codex app-server turn can land a valid local commit but still surface a late runtime timeout. The change-delivery action now reconciles the lane after prompt errors and treats the dispatch as completed when the local candidate has advanced to a forward workflow action such as internal review or publish.

Also updates relay shadow action derivation so a new local head with a required internal review requests `request_internal_review` instead of dispatching another implementation turn, and records the implementation runtime backend from status instead of hard-coding `acpx-codex`.

## Root Cause

The app-server completed the implementation work in the worktree, but the workflow boundary treated the subsequent timeout as a hard failure. Separately, relay planning did not consider the required pre-publish review while the lane still reported `implementing_local`, so it kept asking for implementation even after a local head existed.

## Validation

- `python3 -m pytest tests/test_workflows_code_review_actions.py tests/test_runtime_tools_alerts.py tests/test_workflows_code_review_workflow.py tests/test_runtimes_codex_app_server.py -q`
- `python3 -m pytest -q`