### PR TITLE
[codex] make change-delivery dispatch runtime-neutral

### DIFF
--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
@@ -96,6 +95,15 @@ def _reconciled_status_after_prompt_error(
     if next_action_type not in {"run_internal_review", "publish_ready_pr", "push_pr_update", "merge_and_promote"}:
         return None
     return status_after
+
+
+def _stage_runtime_result(value: Any) -> Any:
+    runtime_result = _object_value(value, "runtime_result", "runtimeResult")
+    return runtime_result if runtime_result is not None else value
+
+
+def _stage_session_handle(value: Any) -> Any:
+    return _object_value(value, "session_handle", "sessionHandle")
 
 
 def run_publish_ready_pr(
@@ -355,25 +363,22 @@ def run_dispatch_lane_turn(
     forced_action: str | None,
     audit_action: str,
     now_iso_fn: Callable[[], str],
-    close_acpx_session_fn: Callable[..., Any],
-    ensure_acpx_session_fn: Callable[..., dict[str, Any]],
-    show_acpx_session_fn: Callable[..., dict[str, Any] | None],
-    run_prompt_fn: Callable[..., Any],
+    close_session_fn: Callable[..., Any],
+    show_session_fn: Callable[..., dict[str, Any] | None],
+    run_stage_fn: Callable[..., Any],
     prepare_lane_worktree_fn: Callable[..., dict[str, Any]],
-    codex_model_for_issue_fn: Callable[..., str],
+    implementation_actor_name: str,
+    implementation_actor_cfg: dict[str, Any],
     get_issue_details_fn: Callable[[Any], dict[str, Any] | None],
-    fallback_codex_model_for_prompt_error_fn: Callable[..., str | None],
-    coder_agent_name_for_model_fn: Callable[[str | None], str],
     actor_labels_payload_fn: Callable[[str | None], dict[str, Any]],
     load_ledger_fn: Callable[[], dict[str, Any]],
     save_ledger_fn: Callable[[dict[str, Any]], Any],
     reconcile_fn: Callable[..., dict[str, Any]],
     audit_fn: Callable[..., Any],
     render_implementation_dispatch_prompt_fn: Callable[..., str],
-    runtime_name: str | None = None,
+    runtime_name: str,
     runtime_kind: str = "acpx-codex",
     record_runtime_result_fn: Callable[..., dict[str, Any]] | None = None,
-    error_cls: type = subprocess.CalledProcessError,
 ) -> dict[str, Any]:
     """Adapter-owned implementation of ``_dispatch_lane_turn``.
 
@@ -398,24 +403,20 @@ def run_dispatch_lane_turn(
         return {'dispatched': False, 'reason': 'missing-branch'}
     worktree_info = prepare_lane_worktree_fn(worktree=worktree, branch=branch, open_pr=status.get('openPr'))
     action = forced_action or ((impl.get('sessionActionRecommendation') or {}).get('action')) or 'restart-session'
-    codex_model = impl.get('codexModel') or codex_model_for_issue_fn(
-        issue,
-        lane_state=impl.get('laneState'),
-        workflow_state=(status.get('ledger') or {}).get('workflowState'),
-        reviews=status.get('reviews') or {},
-    )
+    actor_cfg = dict(implementation_actor_cfg or {})
+    actor_key = str(implementation_actor_name or "").strip()
+    actor_display_name = str(actor_cfg.get("name") or actor_key or "implementation-actor")
+    actor_model = str(actor_cfg.get("model") or "")
     if action == 'no-action':
         return {'dispatched': False, 'reason': 'no-action'}
     if action == 'restart-session':
-        close_acpx_session_fn(worktree=worktree, session_name=session_name)
+        close_session_fn(
+            worktree=worktree,
+            session_name=session_name,
+            runtime_name=runtime_name,
+            runtime_kind=runtime_kind,
+        )
     issue_details = get_issue_details_fn(issue.get('number'))
-    ensured = ensure_acpx_session_fn(
-        worktree=worktree,
-        session_name=session_name,
-        codex_model=codex_model,
-        resume_session_id=impl.get('resumeSessionId'),
-    )
-    session_meta = show_acpx_session_fn(worktree=worktree, session_name=session_name) or {}
     attempt_at = now_iso_fn()
     attempt_id = f"{session_name}:{attempt_at}"
     prompt = render_implementation_dispatch_prompt_fn(
@@ -428,40 +429,21 @@ def run_dispatch_lane_turn(
         action=action,
         workflow_state=(status.get('ledger') or {}).get('workflowState'),
     )
-    session_record_id = session_meta.get('record_id') or _object_value(ensured, "record_id", "recordId", "acpxRecordId")
     reconciled_after_prompt_error: dict[str, Any] | None = None
     prompt_error: Exception | None = None
     try:
-        prompt_result = run_prompt_fn(
+        stage_result = run_stage_fn(
             worktree=worktree,
             session_name=session_name,
             prompt=prompt,
-            codex_model=codex_model,
+            actor_name=actor_key,
+            actor_cfg=actor_cfg,
+            runtime_name=runtime_name,
+            runtime_kind=runtime_kind,
+            resume_session_id=impl.get('resumeSessionId'),
         )
-    except error_cls as exc:
-        fallback_codex_model = fallback_codex_model_for_prompt_error_fn(
-            acpx_record_id=session_record_id,
-            codex_model=codex_model,
-            exc=exc,
-        )
-        if not fallback_codex_model:
-            raise
-        codex_model = fallback_codex_model
-        close_acpx_session_fn(worktree=worktree, session_name=session_name)
-        ensured = ensure_acpx_session_fn(
-            worktree=worktree,
-            session_name=session_name,
-            codex_model=codex_model,
-            resume_session_id=None,
-        )
-        session_meta = show_acpx_session_fn(worktree=worktree, session_name=session_name) or session_meta
-        session_record_id = session_meta.get('record_id') or _object_value(ensured, "record_id", "recordId", "acpxRecordId")
-        prompt_result = run_prompt_fn(
-            worktree=worktree,
-            session_name=session_name,
-            prompt=prompt,
-            codex_model=codex_model,
-        )
+        prompt_result = _stage_runtime_result(stage_result)
+        ensured = _stage_session_handle(stage_result)
     except Exception as exc:
         reconciled_after_prompt_error = _reconciled_status_after_prompt_error(
             reconcile_fn=reconcile_fn,
@@ -472,6 +454,13 @@ def run_dispatch_lane_turn(
             raise
         prompt_error = exc
         prompt_result = _prompt_result_from_exception(exc)
+        ensured = None
+    session_meta = show_session_fn(
+        worktree=worktree,
+        session_name=session_name,
+        runtime_name=runtime_name,
+        runtime_kind=runtime_kind,
+    ) or {}
     runtime_metrics = _runtime_metrics_payload(prompt_result)
     if record_runtime_result_fn is not None:
         runtime_metrics = record_runtime_result_fn(
@@ -507,8 +496,9 @@ def run_dispatch_lane_turn(
     )
     ledger = load_ledger_fn()
     ledger.setdefault('implementation', {})
-    ledger['codexModel'] = codex_model
-    ledger['workflowActors'] = actor_labels_payload_fn(codex_model)
+    ledger['actorModel'] = actor_model
+    ledger['codexModel'] = actor_model
+    ledger['workflowActors'] = actor_labels_payload_fn(actor_model)
     ledger['implementation'] = {
         **ledger.get('implementation', {}),
         'session': session_record_id,
@@ -516,8 +506,12 @@ def run_dispatch_lane_turn(
         'sessionRuntime': runtime_kind or 'acpx-codex',
         'runtimeName': runtime_name,
         'sessionName': session_name,
-        'codexModel': codex_model,
-        'agentName': coder_agent_name_for_model_fn(codex_model),
+        'actorKey': actor_key,
+        'actorName': actor_display_name,
+        'actorModel': actor_model,
+        'actorRole': 'implementation_actor',
+        'codexModel': actor_model,
+        'agentName': actor_display_name,
         'agentRole': 'coder_agent',
         'resumeSessionId': resume_session_id,
         'threadId': runtime_metrics.get("thread_id"),
@@ -543,7 +537,10 @@ def run_dispatch_lane_turn(
         'sessionRuntime': runtime_kind or 'acpx-codex',
         'runtimeName': runtime_name,
         'sessionName': session_name,
-        'codexModel': codex_model,
+        'actorKey': actor_key,
+        'actorName': actor_display_name,
+        'actorModel': actor_model,
+        'codexModel': actor_model,
         'sessionRecordId': session_record_id,
         'resumeSessionId': resume_session_id,
         'threadId': runtime_metrics.get("thread_id"),
@@ -559,7 +556,7 @@ def run_dispatch_lane_turn(
         result['runtimeError'] = str(prompt_error)
     audit_fn(
         audit_action,
-        f"Dispatched persistent Codex lane turn via {runtime_kind or 'acpx-codex'} session {session_name}",
+        f"Dispatched implementation actor turn via {runtime_kind or 'acpx-codex'} session {session_name}",
         issueNumber=issue.get('number'),
         sessionName=session_name,
         sessionRecordId=result.get('sessionRecordId'),

--- a/daedalus/workflows/change_delivery/orchestrator.py
+++ b/daedalus/workflows/change_delivery/orchestrator.py
@@ -561,7 +561,6 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
         status=status,
         ledger=ledger,
         now_iso=now_iso,
-        codex_model=codex_model,
         lane_state_override=lane_state_payload or (status.get("implementation") or {}).get("laneState"),
     )
     if repair_handoff_changed:

--- a/daedalus/workflows/change_delivery/reviews.py
+++ b/daedalus/workflows/change_delivery/reviews.py
@@ -1316,8 +1316,7 @@ def maybe_dispatch_repair_handoff(
     status: dict[str, Any],
     ledger: dict[str, Any],
     now_iso: str,
-    codex_model: str | None,
-    run_prompt_fn: Callable[..., Any],
+    run_actor_turn_fn: Callable[..., Any],
     audit_fn: Callable[..., Any],
     lane_state_override: dict[str, Any] | None = None,
     lane_state_path_fn: Callable[[Any], Any] | None = None,
@@ -1328,7 +1327,7 @@ def maybe_dispatch_repair_handoff(
 ) -> tuple[dict[str, Any], bool]:
     """Adapter-owned implementation of the wrapper's ``_maybe_dispatch_repair_handoff``.
 
-    Callers inject the side-effectful primitives (``run_prompt_fn`` to poke
+    Callers inject the side-effectful primitives (``run_actor_turn_fn`` to poke
     the actor session; ``audit_fn`` for audit trail) and optionally custom
     lane-state path / JSON I/O helpers. The default helpers write a
     ``.lane-state.json`` file adjacent to the worktree using stdlib primitives,
@@ -1390,11 +1389,10 @@ def maybe_dispatch_repair_handoff(
             lane_state_path=lane_state_path_obj,
             internal_reviewer_agent_name=internal_reviewer_agent_name,
         )
-        run_prompt_fn(
+        run_actor_turn_fn(
             worktree=worktree,
             session_name=repair_payload.get("sessionName"),
             prompt=repair_prompt,
-            codex_model=codex_model,
         )
         record_internal_review_repair_handoff(
             worktree=worktree,
@@ -1451,11 +1449,10 @@ def maybe_dispatch_repair_handoff(
             pr_url=open_pr.get("url"),
             external_reviewer_agent_name=external_reviewer_agent_name,
         )
-        run_prompt_fn(
+        run_actor_turn_fn(
             worktree=worktree,
             session_name=repair_payload.get("sessionName"),
             prompt=repair_prompt,
-            codex_model=codex_model,
         )
         record_external_review_repair_handoff(
             worktree=worktree,

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -1242,43 +1242,6 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             "record_id": payload.get("acpxRecordId") or payload.get("acpx_record_id"),
         }
 
-    def _acpx_session_stream_path(acpx_record_id):
-        if not acpx_record_id:
-            return None
-        return Path.home() / ".acpx" / "sessions" / f"{acpx_record_id}.stream.ndjson"
-
-    def _latest_acpx_prompt_error(acpx_record_id):
-        path = ns._acpx_session_stream_path(acpx_record_id)
-        if path is None or not path.exists():
-            return None
-        try:
-            lines = path.read_text(encoding="utf-8").splitlines()
-        except Exception:
-            return None
-        for raw_line in reversed(lines):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                payload = json.loads(line)
-            except Exception:
-                continue
-            error = payload.get("error")
-            if isinstance(error, dict):
-                return error
-        return None
-
-    def _fallback_codex_model_for_prompt_error(*, acpx_record_id, codex_model, exc):
-        error = ns._latest_acpx_prompt_error(acpx_record_id)
-        error_data = error.get("data") if isinstance(error, dict) else None
-        codex_error_info = (error_data or {}).get("codex_error_info") if isinstance(error_data, dict) else None
-        if codex_error_info == "usage_limit_exceeded" and codex_model != ns.CODEX_MODEL_ESCALATED:
-            return ns.CODEX_MODEL_ESCALATED
-        combined_output = "\n".join(part for part in [exc.stdout or "", exc.stderr or ""] if part).lower()
-        if "usage limit" in combined_output and codex_model != ns.CODEX_MODEL_ESCALATED:
-            return ns.CODEX_MODEL_ESCALATED
-        return None
-
     def _load_latest_session_meta(session_name):
         files = ns._session_record_files(session_name)
         if not files:
@@ -1495,6 +1458,61 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
     def _coder_runtime_kind_for_model(model):
         return ns._runtime_kind(ns._coder_runtime_name_for_model(model))
 
+    def _implementation_stage_cfg():
+        stages = (getattr(ns, "WORKFLOW_YAML", {}) or {}).get("stages") or {}
+        stage = stages.get("implement") if isinstance(stages, dict) else {}
+        return dict(stage) if isinstance(stage, dict) else {}
+
+    def _workflow_actor_cfg(actor_name):
+        actors = (getattr(ns, "WORKFLOW_YAML", {}) or {}).get("actors") or {}
+        actor = actors.get(actor_name) if isinstance(actors, dict) else None
+        if not isinstance(actor, dict):
+            raise KeyError(f"unknown change-delivery actor {actor_name!r}")
+        return dict(actor)
+
+    def _should_escalate_implementation_actor(*, issue=None, lane_state=None, workflow_state=None, reviews=None):
+        labels = ns._load_adapter_sessions_module().issue_label_names(issue)
+        if "effort:large" in labels or "effort:high" in labels:
+            return True
+        return ns._should_escalate_codex_model(
+            lane_state=lane_state,
+            workflow_state=workflow_state,
+            reviews=reviews,
+        )
+
+    def _implementation_actor_name_for_status(status):
+        impl = (status or {}).get("implementation") or {}
+        stage = ns._implementation_stage_cfg()
+        actor_name = str(stage.get("actor") or "").strip()
+        escalation = stage.get("escalation") if isinstance(stage.get("escalation"), dict) else {}
+        escalation_actor = str((escalation or {}).get("actor") or "").strip()
+        if (
+            escalation_actor
+            and ns._should_escalate_implementation_actor(
+                issue=(status or {}).get("activeLane"),
+                lane_state=impl.get("laneState"),
+                workflow_state=((status or {}).get("ledger") or {}).get("workflowState"),
+                reviews=(status or {}).get("reviews") or {},
+            )
+        ):
+            return escalation_actor
+        if actor_name:
+            return actor_name
+        raise KeyError("stages.implement.actor is required")
+
+    def _implementation_actor_for_status(status):
+        actor_name = ns._implementation_actor_name_for_status(status)
+        actor_cfg = ns._workflow_actor_cfg(actor_name)
+        runtime_name = str(actor_cfg.get("runtime") or "").strip()
+        if not runtime_name:
+            raise KeyError(f"actors.{actor_name}.runtime is required")
+        return {
+            "name": actor_name,
+            "config": actor_cfg,
+            "runtime_name": runtime_name,
+            "runtime_kind": ns._runtime_kind(runtime_name),
+        }
+
     def _should_escalate_codex_model(*, lane_state=None, workflow_state=None, reviews=None):
         return ns._load_adapter_sessions_module().should_escalate_codex_model(
             lane_state=lane_state,
@@ -1553,6 +1571,75 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             session_name=session_name,
             model=codex_model,
             resume_session_id=resume_session_id,
+        )
+
+    def _show_actor_session(*, worktree, session_name, runtime_name=None, runtime_kind=None):
+        runtime_kind = runtime_kind or ns._runtime_kind(runtime_name)
+        if runtime_kind == "codex-app-server":
+            issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+            thread_id = ns._codex_thread_for_issue_number(issue_number)
+            if thread_id:
+                entry = ((ns.load_scheduler().get("codex_threads") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
+                return {
+                    "name": session_name,
+                    "closed": False,
+                    "cwd": str(worktree) if worktree is not None else None,
+                    "last_used_at": entry.get("updated_at"),
+                    "session_id": thread_id,
+                    "record_id": thread_id,
+                }
+            return None
+        if runtime_kind == "acpx-codex":
+            return ns._show_acpx_session(worktree=worktree, session_name=session_name)
+        return None
+
+    def _close_actor_session(*, worktree, session_name, runtime_name=None, runtime_kind=None):
+        runtime_kind = runtime_kind or ns._runtime_kind(runtime_name)
+        issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+        if runtime_kind == "codex-app-server":
+            ns._clear_codex_thread_for_issue_number(issue_number)
+        if runtime_name:
+            closer = getattr(ns.runtime(runtime_name), "close_session", None)
+            if callable(closer):
+                return closer(worktree=worktree, session_name=session_name)
+        if runtime_kind == "acpx-codex":
+            return ns._close_acpx_session(worktree=worktree, session_name=session_name)
+        return None
+
+    def _run_implementation_stage(*, worktree, session_name, prompt, actor_name, actor_cfg, runtime_name, runtime_kind, resume_session_id=None):
+        from runtimes.stages import run_runtime_stage
+
+        issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
+        if runtime_kind == "codex-app-server":
+            resume_session_id = ns._codex_thread_for_issue_number(issue_number) or resume_session_id
+        return run_runtime_stage(
+            runtime=ns.runtime(runtime_name),
+            runtime_cfg=dict(((getattr(ns, "RUNTIME_PROFILES", {}) or {}).get(runtime_name) or {})),
+            agent_cfg=dict(actor_cfg or {}),
+            stage_name="implement",
+            worktree=Path(worktree),
+            session_name=session_name,
+            prompt=prompt,
+            resume_session_id=resume_session_id,
+            cancel_event=ns.ACTIVE_CANCEL_EVENT,
+            progress_callback=(
+                lambda result: ns._record_coder_runtime_progress(
+                    issue_number=issue_number,
+                    session_name=session_name,
+                    runtime_name=runtime_name,
+                    runtime_kind=runtime_kind,
+                    worktree=worktree,
+                    result=result,
+                )
+                if runtime_kind == "codex-app-server"
+                else None
+            ),
+            placeholders={
+                "actor": str(actor_name or ""),
+                "issue_number": str(issue_number or ""),
+                "runtime": str(runtime_name or ""),
+                "workflow_root": str(ns.WORKSPACE),
+            },
         )
 
     def _run_acpx_prompt(*, worktree, session_name, prompt, codex_model):
@@ -2223,13 +2310,27 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             internal_reviewer_agent_name=ns.INTERNAL_REVIEWER_AGENT_NAME,
         )
 
-    def _maybe_dispatch_repair_handoff(*, status, ledger, now_iso, codex_model, lane_state_override=None):
+    def _maybe_dispatch_repair_handoff(*, status, ledger, now_iso, lane_state_override=None):
+        actor = ns._implementation_actor_for_status(status)
+
+        def _run_repair_turn(*, worktree, session_name, prompt):
+            impl = (status or {}).get("implementation") or {}
+            return ns._run_implementation_stage(
+                worktree=worktree,
+                session_name=session_name,
+                prompt=prompt,
+                actor_name=actor["name"],
+                actor_cfg=actor["config"],
+                runtime_name=actor["runtime_name"],
+                runtime_kind=actor["runtime_kind"],
+                resume_session_id=impl.get("resumeSessionId"),
+            )
+
         return ns._load_adapter_reviews_module().maybe_dispatch_repair_handoff(
             status=status,
             ledger=ledger,
             now_iso=now_iso,
-            codex_model=codex_model,
-            run_prompt_fn=ns._run_acpx_prompt,
+            run_actor_turn_fn=_run_repair_turn,
             audit_fn=ns.audit,
             lane_state_override=lane_state_override,
             lane_state_path_fn=ns._lane_state_path,
@@ -2242,18 +2343,10 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
     def dispatch_repair_handoff_raw():
         status = ns.build_status()
         ledger = ns.load_ledger()
-        impl = status.get("implementation") or {}
-        codex_model = impl.get("codexModel") or ns._codex_model_for_issue(
-            status.get("activeLane"),
-            lane_state=impl.get("laneState"),
-            workflow_state=(status.get("ledger") or {}).get("workflowState"),
-            reviews=status.get("reviews") or {},
-        )
         result, changed = ns._maybe_dispatch_repair_handoff(
             status=status,
             ledger=ledger,
             now_iso=status.get("updatedAt") or ns._now_iso(),
-            codex_model=codex_model,
         )
         if changed:
             ns.save_ledger(ledger)
@@ -2278,38 +2371,28 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         )
 
     def _dispatch_lane_turn(*, status, forced_action=None, audit_action="dispatch-implementation-turn"):
-        impl = status.get("implementation") or {}
-        codex_model = impl.get("codexModel") or ns._codex_model_for_issue(
-            status.get("activeLane"),
-            lane_state=impl.get("laneState"),
-            workflow_state=(status.get("ledger") or {}).get("workflowState"),
-            reviews=status.get("reviews") or {},
-        )
-        runtime_name = ns._coder_runtime_name_for_model(codex_model)
+        actor = ns._implementation_actor_for_status(status)
         return ns._load_adapter_actions_module().run_dispatch_lane_turn(
             status=status,
             forced_action=forced_action,
             audit_action=audit_action,
             now_iso_fn=ns._now_iso,
-            close_acpx_session_fn=ns._close_acpx_session,
-            ensure_acpx_session_fn=ns._ensure_acpx_session,
-            show_acpx_session_fn=ns._show_acpx_session,
-            run_prompt_fn=ns._run_acpx_prompt,
+            close_session_fn=ns._close_actor_session,
+            show_session_fn=ns._show_actor_session,
+            run_stage_fn=ns._run_implementation_stage,
             prepare_lane_worktree_fn=ns._prepare_lane_worktree,
-            codex_model_for_issue_fn=ns._codex_model_for_issue,
+            implementation_actor_name=actor["name"],
+            implementation_actor_cfg=actor["config"],
             get_issue_details_fn=ns._get_issue_details,
-            fallback_codex_model_for_prompt_error_fn=ns._fallback_codex_model_for_prompt_error,
-            coder_agent_name_for_model_fn=ns._coder_agent_name_for_model,
             actor_labels_payload_fn=ns._actor_labels_payload,
             load_ledger_fn=ns.load_ledger,
             save_ledger_fn=ns.save_ledger,
             reconcile_fn=ns.reconcile,
             audit_fn=ns.audit,
             render_implementation_dispatch_prompt_fn=ns._render_implementation_dispatch_prompt,
-            runtime_name=runtime_name,
-            runtime_kind=ns._runtime_kind(runtime_name),
+            runtime_name=actor["runtime_name"],
+            runtime_kind=actor["runtime_kind"],
             record_runtime_result_fn=ns._record_coder_runtime_result,
-            error_cls=subprocess.CalledProcessError,
         )
 
     def dispatch_implementation_turn_raw():

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -562,7 +562,7 @@ def test_run_dispatch_lane_turn_reconciles_runtime_error_after_local_head(tmp_pa
                 rate_limits=None,
             )
 
-    def run_prompt_fn(*, worktree, session_name, prompt, codex_model):
+    def run_stage_fn(*, worktree, session_name, prompt, actor_name, actor_cfg, runtime_name, runtime_kind, resume_session_id=None):
         raise RuntimeCompletedThenTimedOut()
 
     def reconcile_fn(*, fix_watchers=False):
@@ -585,7 +585,12 @@ def test_run_dispatch_lane_turn_reconciles_runtime_error_after_local_head(tmp_pa
         audit_action="dispatch-implementation-turn",
         **{
             **deps,
-            "run_prompt_fn": run_prompt_fn,
+            "run_stage_fn": run_stage_fn,
+            "implementation_actor_cfg": {
+                "name": "Change_Implementer",
+                "model": "gpt-5.5",
+                "runtime": "coder-runtime",
+            },
             "reconcile_fn": reconcile_fn,
             "runtime_name": "coder-runtime",
             "runtime_kind": "codex-app-server",

--- a/tests/test_workflows_code_review_actions.py
+++ b/tests/test_workflows_code_review_actions.py
@@ -329,39 +329,34 @@ def test_run_ensure_active_lane_reports_selection_failure_without_raising():
 def _dispatch_deps(tmp_path: Path):
     worktree = tmp_path / "worktree"
     worktree.mkdir()
-    state: dict = {"close_calls": 0, "ensure_calls": 0, "run_prompt_calls": [], "save_ledger": []}
+    state: dict = {"close_calls": 0, "run_prompt_calls": [], "save_ledger": []}
 
     def now_iso_fn():
         return "2026-04-23T00:00:00Z"
 
-    def close_fn(*, worktree, session_name):
+    def close_fn(*, worktree, session_name, runtime_name=None, runtime_kind=None):
         state["close_calls"] += 1
 
-    def ensure_fn(*, worktree, session_name, codex_model, resume_session_id=None):
-        state["ensure_calls"] += 1
-        return {"acpxRecordId": "rec-123"}
-
-    def show_fn(*, worktree, session_name):
+    def show_fn(*, worktree, session_name, runtime_name=None, runtime_kind=None):
         return {"record_id": "rec-123", "session_id": "sess-abc"}
 
-    def run_prompt_fn(*, worktree, session_name, prompt, codex_model):
-        state["run_prompt_calls"].append({"session_name": session_name, "codex_model": codex_model})
+    def run_stage_fn(*, worktree, session_name, prompt, actor_name, actor_cfg, runtime_name, runtime_kind, resume_session_id=None):
+        state["run_prompt_calls"].append(
+            {
+                "session_name": session_name,
+                "actor_name": actor_name,
+                "actor_model": actor_cfg.get("model"),
+                "runtime_name": runtime_name,
+                "runtime_kind": runtime_kind,
+            }
+        )
         return "ok"
 
     def prepare_worktree_fn(*, worktree, branch, open_pr):
         return {"prepared": True}
 
-    def codex_model_for_issue_fn(issue, *, lane_state, workflow_state, reviews):
-        return "gpt-5.3-codex-spark/high"
-
     def get_issue_details_fn(number):
         return {"labels": []}
-
-    def fallback_codex_model_fn(*, acpx_record_id, codex_model, exc):
-        return None
-
-    def coder_agent_name_for_model_fn(model):
-        return "Internal_Coder_Agent"
 
     def actor_labels_payload_fn(model):
         return {}
@@ -386,15 +381,19 @@ def _dispatch_deps(tmp_path: Path):
 
     return state, worktree, {
         "now_iso_fn": now_iso_fn,
-        "close_acpx_session_fn": close_fn,
-        "ensure_acpx_session_fn": ensure_fn,
-        "show_acpx_session_fn": show_fn,
-        "run_prompt_fn": run_prompt_fn,
+        "close_session_fn": close_fn,
+        "show_session_fn": show_fn,
+        "run_stage_fn": run_stage_fn,
         "prepare_lane_worktree_fn": prepare_worktree_fn,
-        "codex_model_for_issue_fn": codex_model_for_issue_fn,
+        "implementation_actor_name": "implementer",
+        "implementation_actor_cfg": {
+            "name": "Change_Implementer",
+            "model": "gpt-5.3-codex-spark/high",
+            "runtime": "acpx-codex",
+        },
+        "runtime_name": "acpx-codex",
+        "runtime_kind": "acpx-codex",
         "get_issue_details_fn": get_issue_details_fn,
-        "fallback_codex_model_for_prompt_error_fn": fallback_codex_model_fn,
-        "coder_agent_name_for_model_fn": coder_agent_name_for_model_fn,
         "actor_labels_payload_fn": actor_labels_payload_fn,
         "load_ledger_fn": load_ledger_fn,
         "save_ledger_fn": save_ledger_fn,
@@ -447,8 +446,10 @@ def test_run_dispatch_lane_turn_executes_continue_session_when_healthy(tmp_path)
     assert result["action"] == "continue-session"
     assert result["issueNumber"] == 224
     assert result["sessionName"] == "lane-224"
+    assert result["actorKey"] == "implementer"
+    assert result["actorName"] == "Change_Implementer"
     assert state["close_calls"] == 0  # continue-session doesn't close
-    assert state["run_prompt_calls"]
+    assert state["run_prompt_calls"][0]["runtime_name"] == "acpx-codex"
     assert state["audits"][0]["action"] == "dispatch-implementation-turn"
 
 
@@ -471,17 +472,20 @@ def test_run_dispatch_lane_turn_records_codex_app_server_thread_metrics(tmp_path
         "openPr": None,
     }
 
-    def run_prompt_fn(*, worktree, session_name, prompt, codex_model):
+    def run_stage_fn(*, worktree, session_name, prompt, actor_name, actor_cfg, runtime_name, runtime_kind, resume_session_id=None):
         return SimpleNamespace(
-            output="codex ok\n",
-            session_id="thread-1",
-            thread_id="thread-1",
-            turn_id="turn-1",
-            last_event="turn/completed",
-            last_message="done",
-            turn_count=1,
-            tokens={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
-            rate_limits={"requests_remaining": 99},
+            runtime_result=SimpleNamespace(
+                output="codex ok\n",
+                session_id="thread-1",
+                thread_id="thread-1",
+                turn_id="turn-1",
+                last_event="turn/completed",
+                last_message="done",
+                turn_count=1,
+                tokens={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+                rate_limits={"requests_remaining": 99},
+            ),
+            session_handle={"record_id": "thread-1", "session_id": "thread-1"},
         )
 
     recorded = {}
@@ -496,7 +500,12 @@ def test_run_dispatch_lane_turn_records_codex_app_server_thread_metrics(tmp_path
         audit_action="dispatch-implementation-turn",
         **{
             **deps,
-            "run_prompt_fn": run_prompt_fn,
+            "run_stage_fn": run_stage_fn,
+            "implementation_actor_cfg": {
+                "name": "Change_Implementer",
+                "model": "gpt-5.5",
+                "runtime": "coder-runtime",
+            },
             "runtime_name": "coder-runtime",
             "runtime_kind": "codex-app-server",
             "record_runtime_result_fn": record_runtime_result_fn,
@@ -513,6 +522,8 @@ def test_run_dispatch_lane_turn_records_codex_app_server_thread_metrics(tmp_path
     impl = state["save_ledger"][-1]["implementation"]
     assert impl["sessionRuntime"] == "codex-app-server"
     assert impl["session"] == "thread-1"
+    assert impl["actorName"] == "Change_Implementer"
+    assert impl["actorModel"] == "gpt-5.5"
     assert impl["resumeSessionId"] == "thread-1"
     assert impl["runtimeMetrics"]["rate_limits"] == {"requests_remaining": 99}
 

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -910,19 +910,18 @@ def test_codex_parsing_and_checks_helpers_cover_severity_summary_and_acceptabili
 
 
 def _repair_handoff_deps(captured: dict):
-    def fake_run_acpx_prompt(*, worktree, session_name, prompt, codex_model):
-        captured["run_acpx"] = {
+    def fake_run_actor_turn(*, worktree, session_name, prompt):
+        captured["run_actor"] = {
             "worktree": str(worktree),
             "session_name": session_name,
             "prompt_len": len(prompt),
-            "codex_model": codex_model,
         }
         return "ok"
 
     def fake_audit(action, summary, **extra):
         captured.setdefault("audit", []).append({"action": action, "summary": summary, **extra})
 
-    return fake_run_acpx_prompt, fake_audit
+    return fake_run_actor_turn, fake_audit
 
 
 def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tmp_path):
@@ -930,7 +929,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
     worktree = tmp_path / "worktree"
     worktree.mkdir()
     captured: dict = {}
-    run_acpx, audit = _repair_handoff_deps(captured)
+    run_actor, audit = _repair_handoff_deps(captured)
 
     status = {
         "activeLane": {"number": 224, "title": "T"},
@@ -963,8 +962,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
         status=status,
         ledger=ledger,
         now_iso="2026-04-22T00:05:00Z",
-        codex_model="gpt-5.3-codex",
-        run_prompt_fn=run_acpx,
+        run_actor_turn_fn=run_actor,
         audit_fn=audit,
     )
 
@@ -973,7 +971,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_claude_branch_when_routable(tm
     assert result["mode"] == "internal_review_repair_handoff"
     assert result["issueNumber"] == 224
     assert ledger["internalReviewRepairHandoff"]["sessionName"] == "lane-224"
-    assert captured["run_acpx"]["session_name"] == "lane-224"
+    assert captured["run_actor"]["session_name"] == "lane-224"
     assert captured["audit"][0]["action"] == "internal-review-repair-handoff-dispatched"
     # Record helper actually wrote .lane-state.json
     assert (worktree / ".lane-state.json").exists()
@@ -984,7 +982,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_external_review_branch_when_ro
     worktree = tmp_path / "worktree"
     worktree.mkdir()
     captured: dict = {}
-    run_acpx, audit = _repair_handoff_deps(captured)
+    run_actor, audit = _repair_handoff_deps(captured)
 
     status = {
         "activeLane": {"number": 224, "title": "T"},
@@ -1017,8 +1015,7 @@ def test_maybe_dispatch_repair_handoff_dispatches_external_review_branch_when_ro
         status=status,
         ledger=ledger,
         now_iso="2026-04-22T00:05:00Z",
-        codex_model="gpt-5.3-codex",
-        run_prompt_fn=run_acpx,
+        run_actor_turn_fn=run_actor,
         audit_fn=audit,
     )
 
@@ -1035,7 +1032,7 @@ def test_maybe_dispatch_repair_handoff_returns_noop_when_no_dispatch_branch_is_r
     worktree = tmp_path / "worktree"
     worktree.mkdir()
     captured: dict = {}
-    run_acpx, audit = _repair_handoff_deps(captured)
+    run_actor, audit = _repair_handoff_deps(captured)
 
     status = {
         "activeLane": {"number": 224, "title": "T"},
@@ -1057,27 +1054,25 @@ def test_maybe_dispatch_repair_handoff_returns_noop_when_no_dispatch_branch_is_r
         status=status,
         ledger=ledger,
         now_iso="2026-04-22T00:05:00Z",
-        codex_model="gpt-5.3-codex",
-        run_prompt_fn=run_acpx,
+        run_actor_turn_fn=run_actor,
         audit_fn=audit,
     )
 
     assert changed is False
     assert result["dispatched"] is False
     assert "repair-handoff-not-needed" in result["reason"]
-    assert "run_acpx" not in captured
+    assert "run_actor" not in captured
 
 
 def test_maybe_dispatch_repair_handoff_short_circuits_when_no_active_lane(tmp_path):
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_mdrh", "workflows/change_delivery/reviews.py")
     captured: dict = {}
-    run_acpx, audit = _repair_handoff_deps(captured)
+    run_actor, audit = _repair_handoff_deps(captured)
     result, changed = reviews_module.maybe_dispatch_repair_handoff(
         status={"activeLane": None, "implementation": {}, "reviews": {}, "openPr": None, "ledger": {}},
         ledger={},
         now_iso="2026-04-22T00:00:00Z",
-        codex_model=None,
-        run_prompt_fn=run_acpx,
+        run_actor_turn_fn=run_actor,
         audit_fn=audit,
     )
     assert changed is False

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -290,6 +290,8 @@ def test_workspace_exposes_full_wrapper_facade(tmp_path):
     for name in (
         "_codex_model_for_issue", "_coder_agent_name_for_model",
         "_actor_labels_payload", "_ensure_acpx_session", "_run_acpx_prompt",
+        "_implementation_actor_for_status", "_run_implementation_stage",
+        "_show_actor_session", "_close_actor_session",
         "_prepare_lane_worktree", "decide_lane_session_action",
         "render_lane_memo", "build_acp_session_strategy",
         "build_session_nudge_payload", "should_nudge_session",
@@ -580,9 +582,47 @@ def test_workspace_yaml_can_select_codex_app_server_coder_runtime(tmp_path):
 
     ws = make_workspace(workspace_root=tmp_path, config=cfg)
 
-    assert ws._coder_runtime_name_for_model("gpt-5.3-codex-spark/high") == "coder-runtime"
-    assert ws._coder_runtime_kind_for_model("gpt-5.3-codex-spark/high") == "codex-app-server"
+    actor = ws._implementation_actor_for_status(
+        {
+            "activeLane": {"number": 224, "labels": []},
+            "implementation": {"laneState": {}},
+            "ledger": {"workflowState": "implementing_local"},
+            "reviews": {},
+        }
+    )
+    assert actor["name"] == "implementer"
+    assert actor["runtime_name"] == "coder-runtime"
+    assert actor["runtime_kind"] == "codex-app-server"
     assert hasattr(ws.runtime("coder-runtime"), "run_prompt_result")
+
+
+def test_workspace_escalated_implementation_actor_uses_its_runtime(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    cfg = _workflow_contract_config(tmp_path)
+    cfg["runtimes"] = {
+        "default-runtime": {"kind": "claude-cli"},
+        "high-runtime": {"kind": "hermes-agent", "command": ["hermes", "-z", "{prompt_path}"]},
+        "reviewer-runtime": {"kind": "claude-cli"},
+    }
+    cfg["actors"]["implementer"]["runtime"] = "default-runtime"
+    cfg["actors"]["implementer-high-effort"]["runtime"] = "high-runtime"
+    cfg["actors"]["reviewer"]["runtime"] = "reviewer-runtime"
+
+    ws = make_workspace(workspace_root=tmp_path, config=cfg)
+
+    actor = ws._implementation_actor_for_status(
+        {
+            "activeLane": {"number": 224, "labels": [{"name": "effort:large"}]},
+            "implementation": {"laneState": {}},
+            "ledger": {"workflowState": "implementing_local"},
+            "reviews": {},
+        }
+    )
+
+    assert actor["name"] == "implementer-high-effort"
+    assert actor["runtime_name"] == "high-runtime"
+    assert actor["runtime_kind"] == "hermes-agent"
 
 
 def test_workspace_internal_review_uses_configured_runtime(tmp_path):


### PR DESCRIPTION
## Summary

Make change-delivery implementation dispatch resolve the configured actor/runtime from `stages.implement.actor` and `actors.<name>.runtime` instead of selecting a runtime through Codex model names.

This also routes review repair handoffs through the same implementation actor runtime path and removes the silent prompt-error fallback model retry behavior.

## Rebase note

Rebased on `origin/main` after PR #92 merged and preserved the new runtime-error reconciliation behavior against the runtime-neutral `run_stage_fn` boundary.

## Impact

Operators can bind the implementation stage to any supported runtime profile, including Codex app-server or Hermes, without changing workflow code. Actor metadata is now recorded alongside the existing model fields so the status surface can move toward runtime-neutral naming in a later cleanup.

## Validation

- `pytest -q` -> `888 passed, 7 skipped`
- `git diff --check` -> clean
