### PR TITLE
[codex] Recover internal reviews and quiet websocket turns

### DIFF
--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -1272,12 +1272,13 @@ def derive_shadow_actions_for_lane(*, lane_row: dict[str, Any], reviews: list[di
     repair_brief = _parse_json_blob(lane_row.get("repair_brief_json")) or {}
     internal_review_status = str((internal_review or {}).get("status") or "").strip()
     internal_review_head = (internal_review or {}).get("reviewed_head_sha") or (internal_review or {}).get("requested_head_sha")
+    requestable_internal_review_statuses = {"", "not_started", "pending", "failed", "timed_out", "superseded"}
     internal_review_needs_request = bool(
         current_head_sha
         and lane_row.get("required_internal_review")
         and (
             internal_review is None
-            or internal_review_status in {"", "not_started", "pending"}
+            or internal_review_status in requestable_internal_review_statuses
             or (
                 internal_review_status == "completed"
                 and internal_review_head != current_head_sha

--- a/daedalus/runtimes/codex_app_server.py
+++ b/daedalus/runtimes/codex_app_server.py
@@ -308,6 +308,9 @@ class _WebSocketAppServerClient(_AppServerClient):
         response_headers = self._parse_http_headers(response)
         if response_headers.get("sec-websocket-accept", "") != accept:
             raise CodexAppServerError("codex-app-server websocket handshake returned an invalid accept key")
+        # Keep the handshake bounded, then let poll_message, turn_timeout, and
+        # stall_timeout control idle reads during long-running turns.
+        sock.settimeout(None)
         return sock
 
     def _read_http_response(self, sock: socket.socket) -> str:

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -708,7 +708,7 @@ def test_active_iteration_executes_queued_internal_review_recovery_after_failed_
             "worktree": "/tmp/issue-221",
             "branch": "codex/issue-221-test",
             "localHeadSha": "abc123",
-            "sessionRuntime": "codex-app-server",
+            "runtimeKind": "codex-app-server",
             "laneState": {"implementation": {}, "pr": {"lastPublishedHeadSha": None}},
             "activeSessionHealth": {"healthy": True, "lastUsedAt": "2026-04-22T00:00:00Z"},
             "sessionActionRecommendation": {"action": "continue-session"},

--- a/tests/test_runtime_tools_alerts.py
+++ b/tests/test_runtime_tools_alerts.py
@@ -357,6 +357,39 @@ def test_derive_shadow_actions_requests_internal_review_for_new_local_head(runti
     ]
 
 
+@pytest.mark.parametrize("review_status", ["failed", "timed_out", "superseded"])
+def test_derive_shadow_actions_requests_internal_review_after_terminal_review_status(runtime_module, review_status):
+    actions = runtime_module.derive_shadow_actions_for_lane(
+        lane_row={
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "workflow_state": "awaiting_pre_publish_review",
+            "required_internal_review": 1,
+            "active_pr_number": None,
+            "current_head_sha": "abc123",
+        },
+        reviews=[
+            {
+                "reviewer_scope": "internal",
+                "status": review_status,
+                "review_scope": "local-prepublish",
+                "requested_head_sha": "abc123",
+            }
+        ],
+        actor_row={},
+    )
+
+    assert actions == [
+        {
+            "action_type": "request_internal_review",
+            "lane_id": "lane:221",
+            "issue_number": 221,
+            "target_head_sha": "abc123",
+            "reason": "internal-review-pending",
+        }
+    ]
+
+
 def test_derive_shadow_actions_dispatches_local_review_repair_handoff_when_session_routable(runtime_module):
     actions = runtime_module.derive_shadow_actions_for_lane(
         lane_row={
@@ -655,6 +688,152 @@ def test_execute_requested_action_records_ambiguous_failure_without_name_error(r
 
     assert failure_row == ("request_internal_review_blocked", "mark_operator_attention")
     assert analysis_requested[-1]["project_key"] == "workflow-example"
+
+
+def test_active_iteration_executes_queued_internal_review_recovery_after_failed_review(runtime_module, tmp_path):
+    workflow_root = tmp_path / "workflow"
+    paths = runtime_module._runtime_paths(workflow_root)
+    runtime_module.init_daedalus_db(workflow_root=workflow_root, project_key="workflow-example")
+    runtime_module.bootstrap_runtime(
+        workflow_root=workflow_root,
+        project_key="workflow-example",
+        instance_id="active-test",
+        mode="active",
+        now_iso="2026-04-22T00:00:00Z",
+    )
+    legacy_status = {
+        "activeLane": {"number": 221, "url": "https://example.com/issues/221", "title": "Issue 221", "labels": []},
+        "repo": "/tmp/repo",
+        "implementation": {
+            "worktree": "/tmp/issue-221",
+            "branch": "codex/issue-221-test",
+            "localHeadSha": "abc123",
+            "sessionRuntime": "codex-app-server",
+            "laneState": {"implementation": {}, "pr": {"lastPublishedHeadSha": None}},
+            "activeSessionHealth": {"healthy": True, "lastUsedAt": "2026-04-22T00:00:00Z"},
+            "sessionActionRecommendation": {"action": "continue-session"},
+        },
+        "reviews": {
+            "internalReview": {
+                "required": True,
+                "status": "failed",
+                "reviewScope": "local-prepublish",
+                "requestedHeadSha": "abc123",
+                "failureClass": "transport_failed",
+                "summary": "timed out",
+            },
+            "externalReview": {"required": False, "status": "not_started"},
+        },
+        "ledger": {"workflowState": "awaiting_pre_publish_review", "reviewState": "awaiting_pre_publish_review", "repairBrief": None},
+        "derivedReviewLoopState": "awaiting_reviews",
+        "derivedMergeBlocked": False,
+        "derivedMergeBlockers": [],
+        "openPr": None,
+        "activeLaneError": None,
+        "staleLaneReasons": [],
+        "nextAction": {"type": "run_internal_review", "reason": "prepublish-review-required"},
+    }
+    runtime_module.ingest_legacy_status(
+        workflow_root=workflow_root,
+        legacy_status=legacy_status,
+        now_iso="2026-04-22T00:01:00Z",
+    )
+
+    conn = runtime_module._connect(paths["db_path"])
+    try:
+        conn.execute(
+            """
+            INSERT INTO lane_actions (
+              action_id, lane_id, action_type, action_reason, action_mode, requested_by,
+              target_actor_role, target_head_sha, idempotency_key, status, requested_at,
+              failed_at, request_payload_json, retry_count, recovery_attempt_count,
+              superseded_by_action_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "act:review:failed",
+                "lane:221",
+                "request_internal_review",
+                "internal-review-pending",
+                "active",
+                "Workflow_Orchestrator",
+                "Internal_Reviewer_Agent",
+                "abc123",
+                "active:request_internal_review:lane:221:abc123",
+                "failed",
+                "2026-04-22T00:01:00Z",
+                "2026-04-22T00:02:00Z",
+                json.dumps({"action_type": "request_internal_review"}, sort_keys=True),
+                0,
+                0,
+                "act:recovery:review:1",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO lane_actions (
+              action_id, lane_id, action_type, action_reason, action_mode, requested_by,
+              target_actor_role, target_head_sha, idempotency_key, status, requested_at,
+              request_payload_json, retry_count, recovery_attempt_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "act:recovery:review:1",
+                "lane:221",
+                "request_internal_review",
+                "automatic-retry-after-failure",
+                "active",
+                "Workflow_Orchestrator",
+                "Internal_Reviewer_Agent",
+                "abc123",
+                "active-recovery:request_internal_review:lane:221:abc123:1",
+                "requested",
+                "2026-04-22T00:02:00Z",
+                json.dumps(
+                    {
+                        "action_type": "request_internal_review",
+                        "prior_action_id": "act:review:failed",
+                        "target_head_sha": "abc123",
+                    },
+                    sort_keys=True,
+                ),
+                1,
+                1,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    calls = []
+
+    def retry_review():
+        calls.append("retry-review")
+        return {"dispatched": True, "after": legacy_status}
+
+    result = runtime_module.run_active_iteration(
+        workflow_root=workflow_root,
+        instance_id="active-test",
+        legacy_status=legacy_status,
+        now_iso="2026-04-22T00:03:00Z",
+        action_runners={"request_internal_review": retry_review},
+    )
+
+    assert result["iteration_status"] == "executed"
+    assert result["comparison"]["compatible"] is True
+    assert result["requested_actions"][0]["action_id"] == "act:recovery:review:1"
+    assert result["executed_action"]["action_type"] == "request_internal_review"
+    assert calls == ["retry-review"]
+
+    conn = sqlite3.connect(paths["db_path"])
+    try:
+        recovery_status = conn.execute(
+            "SELECT status FROM lane_actions WHERE action_id=?",
+            ("act:recovery:review:1",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert recovery_status == "completed"
 
 
 def test_request_active_actions_event_payload_uses_retry_count(runtime_module, tmp_path, monkeypatch):

--- a/tests/test_runtimes_codex_app_server.py
+++ b/tests/test_runtimes_codex_app_server.py
@@ -216,11 +216,12 @@ def _write_fake_cancellable_app_server(path: Path, requests_path: Path) -> None:
 
 
 class _FakeWebSocketAppServer:
-    def __init__(self, *, required_auth_token: str | None = None):
+    def __init__(self, *, required_auth_token: str | None = None, turn_completion_delay_s: float = 0):
         self.requests: list[dict] = []
         self.websocket_authorizations: list[str | None] = []
         self.websocket_connections = 0
         self.required_auth_token = required_auth_token
+        self.turn_completion_delay_s = turn_completion_delay_s
         self._stop = threading.Event()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -317,6 +318,8 @@ class _FakeWebSocketAppServer:
                         "params": {"threadId": thread_id, "turnId": "turn-ws", "itemId": "item-1", "delta": "ws ok"},
                     },
                 )
+                if self.turn_completion_delay_s:
+                    time.sleep(self.turn_completion_delay_s)
                 completed = {"id": "turn-ws", "status": "completed", "items": []}
                 self._send_ws_json(
                     conn,
@@ -958,6 +961,34 @@ def test_codex_app_server_runtime_sends_external_websocket_auth_token(tmp_path):
         "thread/start",
         "turn/start",
     ]
+
+
+def test_codex_app_server_runtime_allows_external_websocket_quiet_period_longer_than_read_timeout(tmp_path):
+    from runtimes.codex_app_server import CodexAppServerRuntime
+
+    with _FakeWebSocketAppServer(turn_completion_delay_s=1.2) as server:
+        runtime = CodexAppServerRuntime(
+            {
+                "mode": "external",
+                "endpoint": server.endpoint,
+                "approval_policy": "never",
+                "turn_timeout_ms": 5000,
+                "read_timeout_ms": 1000,
+                "stall_timeout_ms": 4000,
+            },
+            run=None,
+        )
+
+        result = runtime.run_prompt_result(
+            worktree=tmp_path,
+            session_name="ISSUE-QUIET-WS",
+            prompt="Work quietly",
+            model="gpt-5.5",
+        )
+
+    assert result.output == "ws ok\n"
+    assert result.thread_id == "thread-ws"
+    assert result.turn_id == "turn-ws"
 
 
 def test_codex_app_server_runtime_reuses_external_websocket_by_default(tmp_path):


### PR DESCRIPTION
## Summary
- Treat terminal local internal-review statuses (`failed`, `timed_out`, `superseded`) as requestable in Daedalus shadow action derivation.
- Keep external codex-app-server WebSocket reads open after the handshake so quiet turns are governed by `poll_message`, `turn_timeout_ms`, and `stall_timeout_ms` instead of a synthetic `protocol/error: timed out`.
- Add regression coverage for queued internal-review recovery retries and quiet WebSocket turn completion.

## Root Cause
After the smoke test internal review timed out, legacy status correctly reported `run_internal_review`, but the Daedalus read model derived no relay action for a failed internal review. Active mode then blocked on `shadow-parity-mismatch` before it could execute the queued recovery action.

The codex-app-server WebSocket client also left the short handshake/read timeout on the stream socket. A normal quiet period during model work could make `recv` raise `timed out`, which Daedalus treated as a fatal protocol error even though Codex completed the turn later.

## Validation
- `pytest tests/test_runtimes_codex_app_server.py -q`
- `pytest -q`