### PR TITLE
[codex] default workflow stages to codex app-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ hermes plugins install attmous/daedalus --enable
 cd /path/to/your/repo
 hermes daedalus bootstrap
 $EDITOR WORKFLOW.md
+hermes daedalus codex-app-server up
 hermes daedalus validate
 hermes daedalus service-up
 hermes
@@ -51,7 +52,9 @@ hermes
 `issue-runner` is the default public bootstrap path.
 Bootstrap creates the workflow root, writes the workflow contract into your
 repo, commits it on a bootstrap branch, and stores a repo-local pointer so later
-commands can resolve the workflow instance.
+commands can resolve the workflow instance. The bundled templates default
+runtime-backed actors to `codex-app-server`; use `configure-runtime` if you want
+a Hermes runtime profile for a role instead.
 
 For the opinionated change-delivery workflow:
 

--- a/daedalus/skills/daedalus-architecture/SKILL.md
+++ b/daedalus/skills/daedalus-architecture/SKILL.md
@@ -192,8 +192,8 @@ Recommended roles:
 
 Semantics:
 - `Workflow_Orchestrator` is the sole owner of workflow policy and canonical state transitions
-- `Internal_Coder_Agent` should usually be a persistent session per lane
-- `Internal_Reviewer_Agent` should be a bounded review run, not the main coding session
+- `implementer` should usually use a resumable runtime when the stage spans multiple ticks
+- `reviewer` should be a bounded review run with a fresh context when possible
 - `External_Reviewer_Agent` is an external event source / review signal source
 - `Workflow_Error_Analyst` is bounded and only invoked when deterministic recovery is insufficient
 
@@ -202,12 +202,12 @@ Semantics:
 Strong rule:
 - persistent sessions for the main coding lane
 - stateless delegate_task children only for bounded analysis/research/review helpers
-- for Daedalus v1, keep the existing `acpx-codex` backend for the `Internal_Coder_Agent`
-- do not switch the primary coder backend during the same migration that replaces the watchdog architecture
+- bundled workflow templates default to `codex-app-server`
+- use `hermes-agent` selectively when a workflow stage benefits from Hermes skills/tooling
 
 Current practical finding:
-- Codex App Server is interesting for richer thread/turn/item streaming, but it introduces another conversation/runtime state model
-- that makes it a bad primary backend choice for the riskiest migration phase
+- Codex app-server is the primary resumable runtime path
+- Hermes Agent is the first-class local agent runtime path
 - treat Codex App Server as a future optional alternate backend only after Daedalus's canonical state, queue, leases, and action model are proven stable
 - even if adopted later, Codex App Server must remain only an execution substrate under Daedalus ownership, never the canonical owner of lane state
 

--- a/daedalus/skills/operator/SKILL.md
+++ b/daedalus/skills/operator/SKILL.md
@@ -33,7 +33,7 @@ Inside Hermes sessions:
 /daedalus doctor
 /daedalus configure-runtime --runtime hermes-final --role agent
 /daedalus configure-runtime --runtime hermes-chat --role reviewer
-/daedalus configure-runtime --runtime codex-service --role implementer
+/daedalus configure-runtime --runtime codex-app-server --role implementer
 /daedalus active-gate-status
 /daedalus set-active-execution --enabled true
 /daedalus set-active-execution --enabled false
@@ -109,13 +109,15 @@ Each agent role chooses a runtime, optionally a `command:` array, and optionally
 
 ```yaml
 runtimes:
-  codex-acpx:
-    kind: acpx-codex
-    command: ["acpx", "--model", "{model}", "--cwd", "{worktree}",
-              "codex", "prompt", "-s", "{session_name}", "{prompt_path}"]
-    session-idle-freshness-seconds: 900
-    session-idle-grace-seconds: 1800
-    session-nudge-cooldown-seconds: 600
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    ephemeral: false
+    keep_alive: true
+  hermes-review:
+    kind: hermes-agent
+    mode: final
 ```
 
 **Actor** picks a runtime and optionally overrides `command:` (full replacement) and/or `prompt:` (template path):
@@ -123,16 +125,16 @@ runtimes:
 ```yaml
 actors:
   implementer:
-    runtime: codex-acpx
-    model: gpt-5
+    runtime: codex-app-server
+    model: gpt-5.4
     # prompt: implied as <workspace>/config/prompts/implement.md,
     #         falls back to bundled prompts/coder.md
   implementer-high-effort:
-    runtime: codex-acpx
-    model: gpt-5
-    command: ["acpx", "--model", "{model}", "--cwd", "{worktree}",
-              "codex", "prompt", "-s", "{session_name}",
-              "--reasoning", "high", "{prompt_path}"]
+    runtime: codex-app-server
+    model: gpt-5.4
+  reviewer:
+    runtime: hermes-review
+    model: gpt-5.4
 ```
 
 **Placeholders** filled by the dispatcher:
@@ -147,18 +149,17 @@ actors:
 3. Bundled `workflows/change_delivery/prompts/<stage-or-role>.md`
 
 **Runtime kinds:**
-- `acpx-codex` — persistent Codex sessions via `acpx`
-- `claude-cli` — one-shot Claude CLI invocations
 - `hermes-agent` — Hermes CLI runtime; built-in `final` mode uses `hermes -z`, `chat` mode uses `hermes chat --quiet -q`, and custom `command:` overrides are supported
 - `codex-app-server` — managed stdio or external WebSocket Codex app-server runtime with durable thread resume
+- `acpx-codex` and `claude-cli` remain adapter kinds, but bundled templates no longer default to them
 
-To swap the implementer from Codex to Claude, change one line:
+To swap the reviewer from Codex app-server to Hermes, change one line:
 
 ```yaml
 actors:
-  implementer:
-    runtime: claude-oneshot   # was: codex-acpx
-    model: claude-sonnet-4
+  reviewer:
+    runtime: hermes-review
+    model: gpt-5.4
 ```
 
 No code changes required.

--- a/daedalus/workflows/change_delivery/actions.py
+++ b/daedalus/workflows/change_delivery/actions.py
@@ -377,7 +377,7 @@ def run_dispatch_lane_turn(
     audit_fn: Callable[..., Any],
     render_implementation_dispatch_prompt_fn: Callable[..., str],
     runtime_name: str,
-    runtime_kind: str = "acpx-codex",
+    runtime_kind: str = "codex-app-server",
     record_runtime_result_fn: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Adapter-owned implementation of ``_dispatch_lane_turn``.
@@ -500,7 +500,7 @@ def run_dispatch_lane_turn(
         "model": actor_model,
         "role": "implementation_actor",
         "runtimeName": runtime_name,
-        "runtimeKind": runtime_kind or "acpx-codex",
+        "runtimeKind": runtime_kind or "codex-app-server",
     }
     ledger = load_ledger_fn()
     ledger.setdefault('implementation', {})
@@ -511,7 +511,7 @@ def run_dispatch_lane_turn(
         'session': session_record_id,
         'previousSession': ledger.get('implementation', {}).get('previousSession'),
         'runtimeName': runtime_name,
-        'runtimeKind': runtime_kind or 'acpx-codex',
+        'runtimeKind': runtime_kind or 'codex-app-server',
         'sessionName': session_name,
         'actorKey': actor_key,
         'actorName': actor_display_name,
@@ -539,7 +539,7 @@ def run_dispatch_lane_turn(
         'action': action,
         'issueNumber': issue.get('number'),
         'runtimeName': runtime_name,
-        'runtimeKind': runtime_kind or 'acpx-codex',
+        'runtimeKind': runtime_kind or 'codex-app-server',
         'sessionName': session_name,
         'actorKey': actor_key,
         'actorName': actor_display_name,
@@ -559,7 +559,7 @@ def run_dispatch_lane_turn(
         result['runtimeError'] = str(prompt_error)
     audit_fn(
         audit_action,
-        f"Dispatched implementation actor turn via {runtime_kind or 'acpx-codex'} session {session_name}",
+        f"Dispatched implementation actor turn via {runtime_kind or 'codex-app-server'} session {session_name}",
         issueNumber=issue.get('number'),
         sessionName=session_name,
         sessionRecordId=result.get('sessionRecordId'),

--- a/daedalus/workflows/change_delivery/preflight.py
+++ b/daedalus/workflows/change_delivery/preflight.py
@@ -58,7 +58,7 @@ def run_preflight(config: Mapping[str, Any]) -> PreflightResult:
     # Codex P2 on PR #21: walk the actual schema field paths.
     # Change-delivery workflow contract shape:
     #   runtimes:
-    #     <name>: { kind: acpx-codex | claude-cli | hermes-agent, ... }
+    #     <name>: { kind: codex-app-server | hermes-agent | acpx-codex | claude-cli, ... }
     #     <name>: { ... }
     #   actors:
     #     <name>: { model: ..., runtime: <runtimes key> }

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -298,7 +298,7 @@ definitions:
     properties:
       name: {type: string}
       model: {type: string}
-      runtime: {type: string}
+      runtime: {type: string, default: codex-app-server}
       required-capabilities:
         $ref: "#/definitions/runtime-capability-list"
       command:

--- a/daedalus/workflows/change_delivery/status.py
+++ b/daedalus/workflows/change_delivery/status.py
@@ -128,7 +128,7 @@ def normalize_implementation_for_active_lane(
     open_pr: dict[str, Any] | None,
     implementation_actor: dict[str, Any] | None,
     runtime_name: str | None = None,
-    runtime_kind: str = "acpx-codex",
+    runtime_kind: str = "codex-app-server",
     session_name: str | None = None,
     resume_session_id: str | None = None,
 ) -> dict[str, Any]:
@@ -146,7 +146,7 @@ def normalize_implementation_for_active_lane(
         if expected_branch:
             impl["branch"] = expected_branch
         impl["runtimeName"] = runtime_name or impl.get("runtimeName")
-        impl["runtimeKind"] = runtime_kind or impl.get("runtimeKind") or "acpx-codex"
+        impl["runtimeKind"] = runtime_kind or impl.get("runtimeKind") or "codex-app-server"
         impl["sessionName"] = expected_session_name
         impl["actorKey"] = actor.get("key")
         impl["actorName"] = actor.get("name")
@@ -163,7 +163,7 @@ def normalize_implementation_for_active_lane(
         "branch": expected_branch,
         "status": "implementing" if not open_pr else impl.get("status"),
         "runtimeName": runtime_name,
-        "runtimeKind": runtime_kind or "acpx-codex",
+        "runtimeKind": runtime_kind or "codex-app-server",
         "sessionName": expected_session_name,
         "actorKey": actor.get("key"),
         "actorName": actor.get("name"),

--- a/daedalus/workflows/change_delivery/workflow.template.md
+++ b/daedalus/workflows/change_delivery/workflow.template.md
@@ -24,32 +24,35 @@ code-host:
   github_slug: your-org/your-repo
 
 runtimes:
-  coder-runtime:
-    kind: acpx-codex
-    session-idle-freshness-seconds: 900
-    session-idle-grace-seconds: 1800
-    session-nudge-cooldown-seconds: 600
-
-  reviewer-runtime:
-    kind: claude-cli
-    max-turns-per-invocation: 24
-    timeout-seconds: 1200
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    healthcheck_path: /readyz
+    ephemeral: false
+    keep_alive: true
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+    turn_timeout_ms: 3600000
+    read_timeout_ms: 5000
+    stall_timeout_ms: 300000
 
 actors:
   implementer:
     name: Change_Implementer
-    model: gpt-5.3-codex-spark/high
-    runtime: coder-runtime
+    model: gpt-5.4
+    runtime: codex-app-server
 
   implementer-high-effort:
     name: Change_Implementer_High_Effort
     model: gpt-5.4
-    runtime: coder-runtime
+    runtime: codex-app-server
 
   reviewer:
     name: Change_Reviewer
-    model: claude-sonnet-4-6
-    runtime: reviewer-runtime
+    model: gpt-5.4
+    runtime: codex-app-server
 
 stages:
   implement:

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -748,22 +748,19 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     _review_policy = config.get("reviewPolicy", {}) or {}
 
     _default_runtimes_cfg = {
-        "acpx-codex": {
-            "kind": "acpx-codex",
-            "session-idle-freshness-seconds": int(
-                _session_policy.get("codexSessionFreshnessSeconds", 900)
-            ),
-            "session-idle-grace-seconds": int(
-                _session_policy.get("codexSessionPokeGraceSeconds", 1800)
-            ),
-            "session-nudge-cooldown-seconds": int(
-                _session_policy.get("codexSessionNudgeCooldownSeconds", 600)
-            ),
-        },
-        "claude-cli": {
-            "kind": "claude-cli",
-            "max-turns-per-invocation": int(_review_policy.get("internalReviewMaxTurns", 24)),
-            "timeout-seconds": int(_review_policy.get("internalReviewTimeoutSeconds", 1200)),
+        "codex-app-server": {
+            "kind": "codex-app-server",
+            "mode": "external",
+            "endpoint": "ws://127.0.0.1:4500",
+            "healthcheck_path": "/readyz",
+            "ephemeral": False,
+            "keep_alive": True,
+            "approval_policy": "never",
+            "thread_sandbox": "workspace-write",
+            "turn_sandbox_policy": "workspace-write",
+            "turn_timeout_ms": 3600000,
+            "read_timeout_ms": 5000,
+            "stall_timeout_ms": 300000,
         },
     }
     _runtimes_cfg = {
@@ -1450,7 +1447,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         default_tier = tiers.get("default") if isinstance(tiers, dict) else {}
         if isinstance(default_tier, dict) and default_tier.get("runtime"):
             return str(default_tier.get("runtime"))
-        return "acpx-codex"
+        return "codex-app-server"
 
     def _runtime_kind(runtime_name):
         return str(((getattr(ns, "RUNTIME_PROFILES", {}) or {}).get(runtime_name) or {}).get("kind") or runtime_name)
@@ -1722,12 +1719,12 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         agent_cfg = {
             "name": ns.INTERNAL_REVIEWER_AGENT_NAME,
             "model": ns.INTERNAL_REVIEW_MODEL,
-            "runtime": "claude-cli",
+            "runtime": "codex-app-server",
         }
         agent_cfg.update(
             (((getattr(ns, "WORKFLOW_YAML", {}) or {}).get("agents") or {}).get("internal-reviewer") or {})
         )
-        runtime_name = str(agent_cfg.get("runtime") or "claude-cli")
+        runtime_name = str(agent_cfg.get("runtime") or "codex-app-server")
         runtime_cfg = dict(((getattr(ns, "RUNTIME_PROFILES", {}) or {}).get(runtime_name) or {}))
         session_name = f"internal-review-{(issue or {}).get('number') or str(head_sha or '')[:12] or 'lane'}"
         try:

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -113,7 +113,7 @@ properties:
     properties:
       name: {type: string}
       model: {type: string}
-      runtime: {type: string}
+      runtime: {type: string, default: codex-app-server}
       required-capabilities:
         $ref: "#/definitions/runtime-capability-list"
       command:

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -51,30 +51,26 @@ hooks:
 
 agent:
   name: Issue_Runner_Agent
-  model: claude-sonnet-4-6
-  runtime: default
+  model: gpt-5.4
+  runtime: codex-app-server
   max_concurrent_agents: 1
   max_turns: 20
   max_retry_backoff_ms: 300000
 
-codex:
-  command: codex app-server
-  ephemeral: false
-  approval_policy: never
-  thread_sandbox: workspace-write
-  turn_sandbox_policy: workspace-write
-  turn_timeout_ms: 3600000
-  read_timeout_ms: 5000
-  stall_timeout_ms: 300000
-
 runtimes:
-  default:
-    kind: hermes-agent
-    command:
-      - python3
-      - -c
-      - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
-      - "{prompt_path}"
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    healthcheck_path: /readyz
+    ephemeral: false
+    keep_alive: true
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+    turn_timeout_ms: 3600000
+    read_timeout_ms: 5000
+    stall_timeout_ms: 300000
 
 storage:
   status: memory/workflow-status.json

--- a/daedalus/workflows/readiness.py
+++ b/daedalus/workflows/readiness.py
@@ -159,9 +159,9 @@ def _preflight_recommendation(*, check: dict[str, Any], workflow: str | None) ->
 
 def _runtime_binding_recommendation(*, workflow: str | None) -> str:
     if workflow == "issue-runner":
-        return "Run `hermes daedalus configure-runtime --runtime hermes-final --role agent`, or define the referenced runtime profile manually."
+        return "Run `hermes daedalus configure-runtime --runtime codex-app-server --role agent`, or define the referenced runtime profile manually."
     if workflow == "change-delivery":
-        return "Run `hermes daedalus configure-runtime --runtime hermes-final --role implementer`, or define the referenced runtime profile manually."
+        return "Run `hermes daedalus configure-runtime --runtime codex-app-server --role implementer`, or define the referenced runtime profile manually."
     return "Run `hermes daedalus configure-runtime` for the affected role, or define the referenced runtime profile manually."
 
 

--- a/daedalus/workflows/runtime_matrix.py
+++ b/daedalus/workflows/runtime_matrix.py
@@ -15,6 +15,7 @@ from workflows.runtime_presets import (
     runtime_binding_checks,
     runtime_capability_checks,
     runtime_role_bindings,
+    runtime_stage_bindings,
     runtime_stage_checks,
 )
 
@@ -46,6 +47,7 @@ def build_runtime_matrix_report(
     runtime_filter = _normalized_filter(runtimes)
 
     binding_checks = runtime_binding_checks(config)
+    stage_bindings = runtime_stage_bindings(config)
     stage_checks = runtime_stage_checks(config)
     capability_checks = runtime_capability_checks(config)
     availability_checks = runtime_availability_checks(config)
@@ -129,6 +131,7 @@ def build_runtime_matrix_report(
             if isinstance(cfg, dict)
         },
         "bindings": bindings,
+        "stage_bindings": stage_bindings,
         "stage_checks": stage_checks,
         "binding_checks": binding_checks,
         "capability_checks": capability_checks,

--- a/daedalus/workflows/runtime_presets.py
+++ b/daedalus/workflows/runtime_presets.py
@@ -29,6 +29,13 @@ from runtimes.capabilities import (
 
 
 RUNTIME_PRESETS: dict[str, dict[str, Any]] = {
+    "codex-app-server": {
+        "kind": "codex-app-server",
+        "mode": "external",
+        "endpoint": "ws://127.0.0.1:4500",
+        "ephemeral": False,
+        "keep_alive": True,
+    },
     "hermes-final": {
         "kind": "hermes-agent",
         "mode": "final",
@@ -37,13 +44,6 @@ RUNTIME_PRESETS: dict[str, dict[str, Any]] = {
         "kind": "hermes-agent",
         "mode": "chat",
         "source": "daedalus",
-    },
-    "codex-service": {
-        "kind": "codex-app-server",
-        "mode": "external",
-        "endpoint": "ws://127.0.0.1:4500",
-        "ephemeral": False,
-        "keep_alive": True,
     },
 }
 
@@ -158,7 +158,15 @@ def runtime_role_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
     if workflow_name == "change-delivery":
         actors = config.get("actors") if isinstance(config.get("actors"), dict) else {}
         if actors:
+            actor_names = []
+            for stage_binding in runtime_stage_bindings(config):
+                role = str(stage_binding.get("role") or "").strip()
+                if role and role not in actor_names:
+                    actor_names.append(role)
             for actor_name in change_delivery_actor_names(config):
+                if actor_name not in actor_names:
+                    actor_names.append(actor_name)
+            for actor_name in actor_names:
                 actor = change_delivery_actor_config(config, actor_name)
                 if isinstance(actor, dict):
                     _append_binding(
@@ -169,6 +177,15 @@ def runtime_role_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
                     )
             return bindings
     return bindings
+
+
+def runtime_stage_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
+    workflow_name = str(config.get("workflow") or "").strip()
+    if workflow_name == "issue-runner":
+        return _issue_runner_stage_bindings(config)
+    if workflow_name == "change-delivery":
+        return _change_delivery_stage_bindings(config)
+    return []
 
 
 def runtime_binding_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
@@ -237,12 +254,47 @@ def runtime_binding_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def runtime_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
-    workflow_name = str(config.get("workflow") or "").strip()
-    if workflow_name == "issue-runner":
-        return _issue_runner_stage_checks(config)
-    if workflow_name == "change-delivery":
-        return _change_delivery_stage_checks(config)
-    return []
+    checks: list[dict[str, Any]] = []
+    for binding in runtime_stage_bindings(config):
+        name = str(binding.get("name") or f"runtime-stage:{binding.get('path') or binding.get('stage')}")
+        role = str(binding.get("role") or "").strip()
+        runtime_name = str(binding.get("runtime") or "").strip()
+        if not binding.get("role_exists"):
+            checks.append(
+                {
+                    "name": name,
+                    "status": "fail",
+                    "detail": str(binding.get("missing_detail") or f"{binding.get('path')} references missing role"),
+                    "stage": binding.get("stage"),
+                    "path": binding.get("path"),
+                    "role": role or None,
+                }
+            )
+            continue
+        if not runtime_name:
+            checks.append(
+                {
+                    "name": name,
+                    "status": "fail",
+                    "detail": f"{binding.get('path')} role {role!r} has no runtime profile",
+                    "stage": binding.get("stage"),
+                    "path": binding.get("path"),
+                    "role": role or None,
+                }
+            )
+            continue
+        checks.append(
+            {
+                "name": name,
+                "status": "pass",
+                "detail": f"{binding.get('stage')} -> role {role} -> runtime {runtime_name}",
+                "stage": binding.get("stage"),
+                "path": binding.get("path"),
+                "role": role,
+                "runtime": runtime_name,
+            }
+        )
+    return checks
 
 
 def runtime_capability_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
@@ -448,78 +500,68 @@ def _runtime_capability_failures_for_roles(
     ]
 
 
-def _issue_runner_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+def _issue_runner_stage_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
     agent = config.get("agent")
     if not isinstance(agent, dict):
         return [
             {
                 "name": "runtime-stage:agent",
-                "status": "fail",
-                "detail": "issue-runner agent must be a mapping",
+                "workflow": "issue-runner",
+                "stage": "run",
+                "path": "agent",
                 "role": "agent",
+                "role_exists": False,
+                "runtime": None,
+                "missing_detail": "issue-runner agent must be a mapping",
             }
         ]
     runtime_name = str(agent.get("runtime") or "").strip()
-    if runtime_name:
-        return [
-            {
-                "name": "runtime-stage:agent",
-                "status": "pass",
-                "detail": f"agent dispatches through runtime profile {runtime_name!r}",
-                "role": "agent",
-                "runtime": runtime_name,
-            }
-        ]
     return [
         {
             "name": "runtime-stage:agent",
-            "status": "fail",
-            "detail": "issue-runner agent requires runtime",
+            "workflow": "issue-runner",
+            "stage": "run",
+            "path": "agent",
             "role": "agent",
+            "role_exists": True,
+            "runtime": runtime_name or None,
         }
     ]
 
 
-def _change_delivery_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]]:
+def _change_delivery_stage_bindings(config: dict[str, Any]) -> list[dict[str, Any]]:
     actors = config.get("actors") if isinstance(config.get("actors"), dict) else {}
-    checks: list[dict[str, Any]] = []
+    bindings: list[dict[str, Any]] = []
 
-    def append_actor_ref(path: str, actor_name: Any) -> None:
+    def append_actor_ref(stage: str, path: str, actor_name: Any) -> None:
         actor = str(actor_name or "").strip()
         if not actor:
             return
         actor_cfg = actors.get(actor) if isinstance(actors, dict) else None
         if not isinstance(actor_cfg, dict):
-            checks.append(
+            bindings.append(
                 {
                     "name": f"runtime-stage:{path}",
-                    "status": "fail",
-                    "detail": f"{path} references missing actor {actor!r}",
+                    "workflow": "change-delivery",
+                    "stage": stage,
                     "path": path,
                     "role": actor,
+                    "role_exists": False,
+                    "runtime": None,
+                    "missing_detail": f"{path} references missing actor {actor!r}",
                 }
             )
             return
         runtime_name = str(actor_cfg.get("runtime") or "").strip()
-        if not runtime_name:
-            checks.append(
-                {
-                    "name": f"runtime-stage:{path}",
-                    "status": "fail",
-                    "detail": f"{path} actor {actor!r} has no runtime profile",
-                    "path": path,
-                    "role": actor,
-                }
-            )
-            return
-        checks.append(
+        bindings.append(
             {
                 "name": f"runtime-stage:{path}",
-                "status": "pass",
-                "detail": f"{path} -> actor {actor} -> runtime {runtime_name}",
+                "workflow": "change-delivery",
+                "stage": stage,
                 "path": path,
                 "role": actor,
-                "runtime": runtime_name,
+                "role_exists": True,
+                "runtime": runtime_name or None,
             }
         )
 
@@ -527,19 +569,23 @@ def _change_delivery_stage_checks(config: dict[str, Any]) -> list[dict[str, Any]
     for stage_name, stage_cfg in stages.items():
         if not isinstance(stage_cfg, dict):
             continue
-        append_actor_ref(f"stages.{stage_name}.actor", stage_cfg.get("actor"))
+        append_actor_ref(str(stage_name), f"stages.{stage_name}.actor", stage_cfg.get("actor"))
         escalation = stage_cfg.get("escalation")
         if isinstance(escalation, dict):
-            append_actor_ref(f"stages.{stage_name}.escalation.actor", escalation.get("actor"))
+            append_actor_ref(
+                f"{stage_name}.escalation",
+                f"stages.{stage_name}.escalation.actor",
+                escalation.get("actor"),
+            )
 
     gates = config.get("gates") if isinstance(config.get("gates"), dict) else {}
     for gate_name, gate_cfg in gates.items():
         if not isinstance(gate_cfg, dict):
             continue
         if str(gate_cfg.get("type") or "").strip() == "agent-review":
-            append_actor_ref(f"gates.{gate_name}.actor", gate_cfg.get("actor"))
+            append_actor_ref(f"gate:{gate_name}", f"gates.{gate_name}.actor", gate_cfg.get("actor"))
 
-    return checks
+    return bindings
 
 
 def _runtime_availability_check(*, name: str, kind: str, runtime_cfg: dict[str, Any]) -> dict[str, Any]:
@@ -627,5 +673,6 @@ __all__ = [
     "runtime_capability_checks",
     "runtime_preset_config",
     "runtime_role_bindings",
+    "runtime_stage_bindings",
     "runtime_stage_checks",
 ]

--- a/docs/assets/daedalus-architecture-diagram.svg
+++ b/docs/assets/daedalus-architecture-diagram.svg
@@ -86,12 +86,12 @@
   <text x="1020" y="305" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">publish · merge · promote rules</text>
 
   <rect x="650" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="720" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Internal Coder</text>
+  <text x="720" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Implementer</text>
   <text x="720" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Codex · acpx</text>
 
   <rect x="820" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="890" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Internal Reviewer</text>
-  <text x="890" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Claude · claude-cli</text>
+  <text x="890" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Reviewer</text>
+  <text x="890" y="390" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Runtime profile</text>
 
   <rect x="990" y="350" width="140" height="55" rx="8" fill="rgba(120,53,15,0.3)" stroke="#fbbf24" stroke-width="1.5"/>
   <text x="1060" y="372" fill="white" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">External Reviewer</text>
@@ -103,7 +103,7 @@
   <text x="890" y="492" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">→ under_review → findings_open → approved → merged</text>
 
   <rect x="650" y="535" width="480" height="55" rx="8" fill="rgba(6,78,59,0.15)" stroke="#34d399" stroke-width="1" stroke-dasharray="4,4"/>
-  <text x="890" y="555" fill="#34d399" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Handoffs: Orchestrator → Coder → Reviewer → Publish → Merge</text>
+  <text x="890" y="555" fill="#34d399" font-family="monospace" font-size="11" font-weight="600" text-anchor="middle">Handoffs: Orchestrator → Implementer → Reviewer → Publish → Merge</text>
   <text x="890" y="575" fill="#94a3b8" font-family="monospace" font-size="9" text-anchor="middle">Explicit role handoffs, not vibes. Every handoff survives restarts.</text>
 
   <rect x="50" y="650" width="520" height="120" rx="16" fill="rgba(136,19,55,0.06)" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="8,4"/>

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -48,6 +48,21 @@ Important: for `codex-app-server`, `runtime.command` starts or connects the
 app-server transport. It is not treated as a per-stage command. Use
 `agent.command` only when a role should run a command-backed adapter.
 
+## Stage Contract
+
+Daedalus validates runtime wiring through a shared stage contract before the
+service starts:
+
+| Workflow | Runtime-backed stages |
+|---|---|
+| `issue-runner` | `run -> agent -> agent.runtime` |
+| `change-delivery` | `implement -> actors.implementer.runtime`, `implement.escalation -> actors.implementer-high-effort.runtime`, `gate:pre-publish-review -> actors.reviewer.runtime` |
+
+Action-only stages such as PR publish/merge are engine actions, not runtime
+turns. This is the boundary: workflows declare stages and actors, runtimes
+declare execution capabilities, and the engine rejects invalid wiring instead
+of choosing a fallback runtime.
+
 ## Adapter shape comparison
 
 | Runtime kind | Execution model | Session behavior | Strongest capabilities |
@@ -78,7 +93,7 @@ actors:
   implementer:
     name: Change_Implementer
     model: gpt-5.4
-    runtime: codex-service
+    runtime: codex-app-server
     required-capabilities:
       - persistent-session
       - resume
@@ -90,6 +105,26 @@ validate`, `doctor`, `runtime-matrix`, and `configure-runtime` fail instead of
 silently falling back.
 
 ## Selection in `WORKFLOW.md`
+
+The bundled templates default executable roles to `codex-app-server`:
+
+```yaml
+runtimes:
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    ephemeral: false
+    keep_alive: true
+
+agent:
+  name: Issue_Runner_Agent
+  model: gpt-5.4
+  runtime: codex-app-server
+```
+
+You can bind any role to another declared runtime profile when that runtime has
+the capabilities the stage requires:
 
 ```yaml
 runtimes:
@@ -124,7 +159,7 @@ For common choices, let Daedalus edit the repo-owned workflow contract:
 ```bash
 hermes daedalus configure-runtime --runtime hermes-final --role agent
 hermes daedalus configure-runtime --runtime hermes-chat --role reviewer
-hermes daedalus configure-runtime --runtime codex-service --role implementer
+hermes daedalus configure-runtime --runtime codex-app-server --role implementer
 ```
 
 The command writes a named profile under `runtimes:` and updates the selected
@@ -148,13 +183,13 @@ with a tiny prompt, run:
 ```bash
 hermes daedalus runtime-matrix --execute
 hermes daedalus runtime-matrix --role agent --execute
-hermes daedalus runtime-matrix --runtime codex-service --execute --format json
+hermes daedalus runtime-matrix --runtime codex-app-server --execute --format json
 ```
 
 `--execute` does not mutate trackers or code hosts. It only creates a temporary
 worktree under the workflow root and dispatches one minimal prompt through the
-configured runtime profile. For `codex-service`, start the shared Codex listener
-first with `hermes daedalus codex-app-server up`.
+configured runtime profile. For `codex-app-server`, start the shared Codex
+listener first with `hermes daedalus codex-app-server up`.
 
 ### `hermes-agent` runtime
 

--- a/docs/examples/change-delivery.workflow.md
+++ b/docs/examples/change-delivery.workflow.md
@@ -24,32 +24,35 @@ code-host:
   github_slug: your-org/your-repo
 
 runtimes:
-  coder-runtime:
-    kind: acpx-codex
-    session-idle-freshness-seconds: 900
-    session-idle-grace-seconds: 1800
-    session-nudge-cooldown-seconds: 600
-
-  reviewer-runtime:
-    kind: claude-cli
-    max-turns-per-invocation: 24
-    timeout-seconds: 1200
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    healthcheck_path: /readyz
+    ephemeral: false
+    keep_alive: true
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+    turn_timeout_ms: 3600000
+    read_timeout_ms: 5000
+    stall_timeout_ms: 300000
 
 actors:
   implementer:
     name: Change_Implementer
-    model: gpt-5.3-codex-spark/high
-    runtime: coder-runtime
+    model: gpt-5.4
+    runtime: codex-app-server
 
   implementer-high-effort:
     name: Change_Implementer_High_Effort
     model: gpt-5.4
-    runtime: coder-runtime
+    runtime: codex-app-server
 
   reviewer:
     name: Change_Reviewer
-    model: claude-sonnet-4-6
-    runtime: reviewer-runtime
+    model: gpt-5.4
+    runtime: codex-app-server
 
 stages:
   implement:

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -51,30 +51,26 @@ hooks:
 
 agent:
   name: Issue_Runner_Agent
-  model: claude-sonnet-4-6
-  runtime: default
+  model: gpt-5.4
+  runtime: codex-app-server
   max_concurrent_agents: 1
   max_turns: 20
   max_retry_backoff_ms: 300000
 
-codex:
-  command: codex app-server
-  ephemeral: false
-  approval_policy: never
-  thread_sandbox: workspace-write
-  turn_sandbox_policy: workspace-write
-  turn_timeout_ms: 3600000
-  read_timeout_ms: 5000
-  stall_timeout_ms: 300000
-
 runtimes:
-  default:
-    kind: hermes-agent
-    command:
-      - python3
-      - -c
-      - "from pathlib import Path; import sys; prompt = Path(sys.argv[1]).read_text(encoding='utf-8'); print('Daedalus demo signoff: runtime received the issue prompt.'); print(prompt)"
-      - "{prompt_path}"
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
+    healthcheck_path: /readyz
+    ephemeral: false
+    keep_alive: true
+    approval_policy: never
+    thread_sandbox: workspace-write
+    turn_sandbox_policy: workspace-write
+    turn_timeout_ms: 3600000
+    read_timeout_ms: 5000
+    stall_timeout_ms: 300000
 
 storage:
   status: memory/workflow-status.json

--- a/docs/operator/cheat-sheet.md
+++ b/docs/operator/cheat-sheet.md
@@ -189,9 +189,9 @@ under_review → findings_open → approved → merged
 
 | Role | Model | Purpose |
 |:---|:---|:---|
-| Internal Coder | `gpt-5.3-codex-spark/high` | Default implementation |
-| Escalation Coder | `gpt-5.4` | Large-effort / complex tasks |
-| Internal Reviewer | `claude-sonnet-4-6` | Local unpublished branch gate |
+| Implementer | `gpt-5.4` | Default implementation |
+| High-effort implementer | `gpt-5.4` | Large-effort / complex tasks |
+| Reviewer | `gpt-5.4` | Local unpublished branch gate |
 | External Reviewer | external review | Published PR review |
 | Advisory Reviewer | Rock Claw | Optional additional eyes |
 
@@ -200,7 +200,7 @@ under_review → findings_open → approved → merged
 ## Handoff Map
 
 ```
-Orchestrator ──► Coder ──► Internal Reviewer ──► Publish ──► External Reviewer (external review) ──► Merge
+Orchestrator ──► Implementer ──► Reviewer ──► Publish ──► External Review ──► Merge
      │              │                    │                                    │                          │
      │              │                    └─► repair ──────────────────────────┘                          │
      │              │                                                                                    │
@@ -211,12 +211,12 @@ Orchestrator ──► Coder ──► Internal Reviewer ──► Publish ─�
 
 | Step | Workflow Action | Daedalus Action |
 |:---|:---|:---|
-| 1. Orchestrator → Coder | `dispatch-implementation-turn` | `dispatch_implementation_turn` |
-| 2. Coder → Internal Reviewer | `run_internal_review` | `request_internal_review` |
-| 3. Internal Reviewer → Coder repair | local findings → lane session | `dispatch_repair_handoff` |
-| 4. Internal Reviewer → Publish | workflow derives publish | `publish_pr` |
+| 1. Orchestrator → Implementer | `dispatch-implementation-turn` | `dispatch_implementation_turn` |
+| 2. Implementer → Reviewer | `run_internal_review` | `request_internal_review` |
+| 3. Reviewer → Implementer repair | local findings → lane session | `dispatch_repair_handoff` |
+| 4. Reviewer → Publish | workflow derives publish | `publish_pr` |
 | 5. Publish → external review | external review triggered | — |
-| 6. external review → Coder repair | post-publish findings | `dispatch_repair_handoff` |
+| 6. external review → Implementer repair | post-publish findings | `dispatch_repair_handoff` |
 | 7. Clean → Merge | `merge_and_promote` | `merge_pr` |
 
 ---
@@ -380,10 +380,9 @@ Tracker feedback is configured in `WORKFLOW.md` under `tracker-feedback`.
 
 | Knob | Value |
 |:---|:---|
-| Coder default model | `gpt-5.3-codex-spark/high` |
-| Coder large-effort model | `gpt-5.3-codex` |
-| Coder escalation model | `gpt-5.4` |
-| Internal reviewer model | `claude-sonnet-4-6` |
+| Implementer default model | `gpt-5.4` |
+| Implementer high-effort model | `gpt-5.4` |
+| Reviewer model | `gpt-5.4` |
 | Internal review pass-with-findings reviews | `1` |
 | Internal review max turns | `12` |
 | Lane failure retry budget | `3` |

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -13,12 +13,10 @@ The default managed path is for the bundled `issue-runner` workflow. Use
 - `systemd --user` for supervised active/shadow mode
 - the host CLIs required by the runtimes named in `WORKFLOW.md`
 
-The bundled `change-delivery` template defaults to:
-
-- `acpx-codex` for the implementation actor runtime
-- `claude-cli` for the internal reviewer runtime
-
-If your host does not have those runtimes, edit `WORKFLOW.md` before starting the service.
+The bundled templates default runtime-backed stages to `codex-app-server`.
+Start the shared listener with `hermes daedalus codex-app-server up`, or edit
+`WORKFLOW.md` / run `configure-runtime` if a stage should use Hermes Agent
+instead.
 
 The bundled `issue-runner` template defaults to `tracker.kind: local-json` so
 it is runnable without an external tracker. For first-class tracker operation,
@@ -65,6 +63,10 @@ hermes plugins enable daedalus
 ```bash
 cd /path/to/your/repo
 hermes daedalus bootstrap
+$EDITOR WORKFLOW.md
+hermes daedalus codex-app-server up
+hermes daedalus validate
+hermes daedalus service-up
 ```
 
 This bootstraps the generic `issue-runner` workflow by default. To bootstrap
@@ -155,6 +157,11 @@ The YAML front matter is the structured config. The Markdown body below it is
 the workflow policy contract. `change-delivery` composes it into actor prompts;
 `issue-runner` renders it as the issue prompt template.
 
+The bundled workflow templates bind runtime-backed stages to
+`codex-app-server` by default. Start the shared Codex listener with
+`hermes daedalus codex-app-server up`, or use `configure-runtime` to bind a
+stage to Hermes Agent instead.
+
 For common runtime choices, use the preset command instead of hand-editing the
 runtime block:
 
@@ -163,7 +170,7 @@ runtime block:
 hermes daedalus configure-runtime --runtime hermes-final --role agent
 
 # change-delivery implementer actor backed by the shared Codex listener
-hermes daedalus configure-runtime --runtime codex-service --role implementer
+hermes daedalus configure-runtime --runtime codex-app-server --role implementer
 ```
 
 `configure-runtime` edits the repo-owned `WORKFLOW.md` contract, writes the

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -12,6 +12,9 @@ its own lifecycle, prompts, gates, and operator commands.
 | [`change-delivery`](change-delivery.md) | you want issue -> actor implementation -> gates -> PR -> merge delivery with GitHub as the first-class tracker/code-host path | [`docs/examples/change-delivery.workflow.md`](../examples/change-delivery.workflow.md) | yes — `bootstrap --workflow change-delivery` + `service-up` |
 
 For the contract file itself, see the [`WORKFLOW.md` guide](workflow-contract.md).
+Both bundled templates default runtime-backed stages to `codex-app-server`;
+bind individual roles to Hermes Agent or another runtime profile when that is a
+better fit for the stage.
 
 ## The boundary
 

--- a/docs/workflows/change-delivery-contract.md
+++ b/docs/workflows/change-delivery-contract.md
@@ -23,8 +23,8 @@ overrides, and prompt overrides.
 actors:
   implementer:
     name: Change_Implementer
-    model: gpt-5.3-codex-spark/high
-    runtime: coder-runtime
+    model: gpt-5.4
+    runtime: codex-app-server
 ```
 
 `stages` are lifecycle steps. A stage either calls an actor or invokes an engine
@@ -74,9 +74,9 @@ or depend on that view.
 `hermes daedalus configure-runtime` binds runtime presets to actor names:
 
 ```bash
-hermes daedalus configure-runtime --runtime codex-service --role implementer
+hermes daedalus configure-runtime --runtime codex-app-server --role implementer
 hermes daedalus configure-runtime --runtime hermes-chat --role reviewer
-hermes daedalus configure-runtime --runtime codex-service --role all
+hermes daedalus configure-runtime --runtime codex-app-server --role all
 ```
 
 The runtime matrix reports the same actor names, so every configured actor can

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -54,16 +54,16 @@ the workflow owns prompts and gates, while the runtime profile owns execution.
 See the detailed [change-delivery contract spec](change-delivery-contract.md)
 for the actor/stage/gate mapping.
 
-## Codex Runtime Options
+## Runtime Options
 
-The default template uses `acpx-codex` for the implementer actor and
-`claude-cli` for the reviewer actor. To run either actor through Codex
-app-server instead, change only `runtimes` and the matching
-`actors.*.runtime` binding in `WORKFLOW.md`:
+The default template binds every runtime-backed actor to the shared
+`codex-app-server` profile. To run any stage through Hermes Agent instead,
+change only `runtimes` and the matching `actors.*.runtime` binding in
+`WORKFLOW.md`:
 
 ```yaml
 runtimes:
-  codex-runtime:
+  codex-app-server:
     kind: codex-app-server
     mode: external
     endpoint: ws://127.0.0.1:4500
@@ -73,15 +73,19 @@ runtimes:
     thread_sandbox: workspace-write
     turn_sandbox_policy: workspace-write
 
+  hermes-review:
+    kind: hermes-agent
+    mode: final
+
 actors:
   implementer:
     name: Change_Implementer
     model: gpt-5.5
-    runtime: codex-runtime
+    runtime: codex-app-server
   reviewer:
     name: Change_Reviewer
     model: gpt-5.5
-    runtime: codex-runtime
+    runtime: hermes-review
 ```
 
 When `codex-app-server` is selected, Daedalus stores
@@ -102,6 +106,8 @@ Onboarding:
 cd /path/to/repo
 hermes daedalus bootstrap --workflow change-delivery
 $EDITOR /path/to/repo/WORKFLOW.md
+hermes daedalus codex-app-server up
+hermes daedalus validate
 hermes daedalus service-up
 ```
 

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -37,7 +37,6 @@ For each eligible tracker issue:
 - `workspace`: per-issue workspace root
 - `hooks`: `after_create`, `before_run`, `after_run`, `before_remove`
 - `agent`: model/runtime plus scheduler-facing limits
-- `codex`: spec-shaped Codex runner settings; set `mode: external` and `endpoint: ws://127.0.0.1:<port>` to connect to an already-running app-server, and keep `ephemeral: false` if you want Codex threads to remain inspectable
 - `runtimes`: shared runtime backend profiles; `agent.runtime` selects one profile for the issue execution stage
 
 The issue execution stage uses the shared runtime stage dispatcher. Hermes can
@@ -53,10 +52,10 @@ External Codex app-server example:
 ```yaml
 agent:
   model: gpt-5.5
-  runtime: codex
+  runtime: codex-app-server
 
 runtimes:
-  codex:
+  codex-app-server:
     kind: codex-app-server
     mode: external
     endpoint: ws://127.0.0.1:4500
@@ -158,6 +157,8 @@ Then edit:
 Then bring it up:
 
 ```bash
+hermes daedalus codex-app-server up
+hermes daedalus validate
 hermes daedalus service-up
 ```
 

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -46,7 +46,13 @@ tracker:
 agent:
   name: Issue_Runner_Agent
   model: gpt-5.5
-  runtime: codex
+  runtime: codex-app-server
+
+runtimes:
+  codex-app-server:
+    kind: codex-app-server
+    mode: external
+    endpoint: ws://127.0.0.1:4500
 ---
 
 # Workflow Policy
@@ -63,7 +69,7 @@ The YAML front matter is structured operator configuration:
 - `repository` identifies the target checkout, `tracker` selects the issue source,
   and workflows that publish PRs use `code-host` for branch/PR/merge operations.
 - `tracker-feedback` controls tracker-facing comments and optional state updates.
-- `runtimes` and `agents` bind workflow roles to execution backends.
+- `runtimes` and `agent` / `actors` bind workflow roles to execution backends.
 - `hooks`, `gates`, `webhooks`, and `server` configure workflow-specific behavior.
 
 Each workflow validates this section against its own schema before dispatch.
@@ -96,10 +102,10 @@ for a known runtime shape instead of editing role bindings by hand:
 ```bash
 hermes daedalus configure-runtime --runtime hermes-final --role agent
 hermes daedalus configure-runtime --runtime hermes-chat --role reviewer
-hermes daedalus configure-runtime --runtime codex-service --role implementer
+hermes daedalus configure-runtime --runtime codex-app-server --role implementer
 ```
 
-Built-in presets are `hermes-final`, `hermes-chat`, and `codex-service`.
+Built-in presets are `codex-app-server`, `hermes-final`, and `hermes-chat`.
 `issue-runner` supports `agent`; `change-delivery` supports the actor names in
 `actors:` such as `implementer`, `implementer-high-effort`, `reviewer`, and
 `all`.

--- a/tests/test_change_delivery_contract_model.py
+++ b/tests/test_change_delivery_contract_model.py
@@ -75,9 +75,9 @@ def test_change_delivery_actor_names_are_stage_order_then_remaining_actors():
 def test_bind_actor_runtime_updates_named_actor_and_rejects_unknown_role():
     contract = _contract()
 
-    changed = bind_actor_runtime(contract, role="reviewer", runtime_name="codex-service")
+    changed = bind_actor_runtime(contract, role="reviewer", runtime_name="codex-app-server")
 
     assert changed == ["reviewer"]
-    assert contract["actors"]["reviewer"]["runtime"] == "codex-service"
+    assert contract["actors"]["reviewer"]["runtime"] == "codex-app-server"
     with pytest.raises(ValueError, match="change-delivery supports"):
-        bind_actor_runtime(contract, role="coder.default", runtime_name="codex-service")
+        bind_actor_runtime(contract, role="coder.default", runtime_name="codex-app-server")

--- a/tests/test_public_onboarding_smoke.py
+++ b/tests/test_public_onboarding_smoke.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -58,6 +59,31 @@ def test_public_onboarding_path_install_bootstrap_defaults_to_issue_runner_and_s
     assert (repo / ".hermes" / "daedalus" / "workflow-root").read_text(encoding="utf-8").strip() == str(workflow_root)
     assert (repo / "WORKFLOW.md").exists()
     assert ["git", "checkout", "-b", "daedalus/bootstrap-issue-runner"] in captured_commands
+    from test_workflows_issue_runner_workspace import _write_fake_codex_app_server
+    from workflows.contract import load_workflow_contract_file, render_workflow_markdown
+
+    contract = load_workflow_contract_file(repo / "WORKFLOW.md")
+    assert contract.config["agent"]["runtime"] == "codex-app-server"
+    assert contract.config["runtimes"]["codex-app-server"]["kind"] == "codex-app-server"
+
+    fake_codex = tmp_path / "fake_codex_app_server.py"
+    _write_fake_codex_app_server(fake_codex, requests_path=tmp_path / "codex-requests.jsonl")
+    cfg = dict(contract.config)
+    cfg["runtimes"]["codex-app-server"] = {
+        "kind": "codex-app-server",
+        "command": [sys.executable, str(fake_codex)],
+        "ephemeral": False,
+        "approval_policy": "never",
+        "thread_sandbox": "workspace-write",
+        "turn_sandbox_policy": "workspace-write",
+        "turn_timeout_ms": 3600000,
+        "read_timeout_ms": 5000,
+        "stall_timeout_ms": 300000,
+    }
+    (repo / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template=contract.prompt_template),
+        encoding="utf-8",
+    )
 
     service_up_out = tools.execute_raw_args("service-up --json")
     service_up_payload = json.loads(service_up_out)
@@ -116,7 +142,7 @@ def test_public_onboarding_path_install_bootstrap_defaults_to_issue_runner_and_s
     assert completed_status["selectedIssue"] is None
     assert completed_status["lastRun"]["ok"] is True
     assert completed_status["lastRun"]["issue"]["id"] == "ISSUE-1"
-    assert completed_status["lastRun"]["results"][0]["runtimeKind"] == "hermes-agent"
+    assert completed_status["lastRun"]["results"][0]["runtimeKind"] == "codex-app-server"
 
     runs_payload = json.loads(tools.execute_raw_args("runs --json"))
     assert runs_payload["workflow"] == "issue-runner"

--- a/tests/test_readiness_recommendations.py
+++ b/tests/test_readiness_recommendations.py
@@ -15,7 +15,7 @@ def test_readiness_recommends_configure_runtime_for_issue_runner_binding_failure
     )
 
     assert recommendations == [
-        "Run `hermes daedalus configure-runtime --runtime hermes-final --role agent`, or define the referenced runtime profile manually."
+        "Run `hermes daedalus configure-runtime --runtime codex-app-server --role agent`, or define the referenced runtime profile manually."
     ]
 
 
@@ -23,7 +23,7 @@ def test_readiness_recommends_codex_service_doctor_for_external_listener_warning
     recommendations = build_readiness_recommendations(
         [
             {
-                "name": "runtime-availability:codex-service",
+                "name": "runtime-availability:codex-app-server",
                 "status": "warn",
                 "detail": "ws://127.0.0.1:4500 is not reachable yet: connection refused",
             }

--- a/tests/test_runtime_matrix.py
+++ b/tests/test_runtime_matrix.py
@@ -82,7 +82,7 @@ def test_runtime_matrix_reports_change_delivery_role_bindings(tmp_path):
             "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
             "runtimes": {
                 "hermes-final": {"kind": "hermes-agent", "mode": "final"},
-                "codex-service": {
+                "codex-app-server": {
                     "kind": "codex-app-server",
                     "mode": "external",
                     "endpoint": "ws://127.0.0.1:4500",
@@ -91,9 +91,9 @@ def test_runtime_matrix_reports_change_delivery_role_bindings(tmp_path):
                 },
             },
             "actors": {
-                "implementer": {"name": "coder", "model": "gpt-5", "runtime": "codex-service"},
+                "implementer": {"name": "coder", "model": "gpt-5", "runtime": "codex-app-server"},
                 "implementer-high-effort": {"name": "coder-hi", "model": "gpt-5.5", "runtime": "hermes-final"},
-                "reviewer": {"name": "reviewer", "model": "gpt-5", "runtime": "codex-service"},
+                "reviewer": {"name": "reviewer", "model": "gpt-5", "runtime": "codex-app-server"},
             },
             "stages": {
                 "implement": {
@@ -118,7 +118,7 @@ def test_runtime_matrix_reports_change_delivery_role_bindings(tmp_path):
     assert set(roles) == {"implementer", "implementer-high-effort", "reviewer"}
     assert roles["implementer"]["kind"] == "codex-app-server"
     assert roles["implementer-high-effort"]["kind"] == "hermes-agent"
-    assert roles["reviewer"]["runtime"] == "codex-service"
+    assert roles["reviewer"]["runtime"] == "codex-app-server"
     assert all(check["status"] == "pass" for check in report["binding_checks"])
 
 
@@ -211,10 +211,10 @@ def test_runtime_matrix_real_codex_service_issue_runner_smoke(tmp_path):
             "agent": {
                 "name": "runner",
                 "model": os.environ.get("DAEDALUS_REAL_CODEX_MODEL", ""),
-                "runtime": "codex-service",
+                "runtime": "codex-app-server",
             },
             "runtimes": {
-                "codex-service": {
+                "codex-app-server": {
                     "kind": "codex-app-server",
                     "mode": "external",
                     "endpoint": os.environ.get("DAEDALUS_REAL_CODEX_ENDPOINT", "ws://127.0.0.1:4500"),

--- a/tests/test_runtime_presets.py
+++ b/tests/test_runtime_presets.py
@@ -9,7 +9,7 @@ from workflows.contract import (
     render_workflow_markdown,
     write_workflow_contract_pointer,
 )
-from workflows.runtime_presets import RuntimePresetError, configure_runtime_contract
+from workflows.runtime_presets import RuntimePresetError, configure_runtime_contract, runtime_stage_bindings
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1] / "daedalus"
@@ -66,6 +66,26 @@ def test_configure_runtime_binds_issue_runner_agent_and_preserves_body(tmp_path)
     assert contract.prompt_template == "# Policy\n\nDo the work."
 
 
+def test_issue_runner_stage_contract_maps_run_stage_to_agent_runtime(tmp_path):
+    config = {
+        "workflow": "issue-runner",
+        "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "codex-app-server"},
+        "runtimes": {"codex-app-server": {"kind": "codex-app-server"}},
+    }
+
+    assert runtime_stage_bindings(config) == [
+        {
+            "name": "runtime-stage:agent",
+            "workflow": "issue-runner",
+            "stage": "run",
+            "path": "agent",
+            "role": "agent",
+            "role_exists": True,
+            "runtime": "codex-app-server",
+        }
+    ]
+
+
 def test_configure_runtime_uses_workflow_root_pointer_for_change_delivery(tmp_path):
     workflow_root = tmp_path / "attmous-daedalus-change-delivery"
     repo_root = tmp_path / "repo"
@@ -110,7 +130,7 @@ def test_configure_runtime_uses_workflow_root_pointer_for_change_delivery(tmp_pa
 
     result = configure_runtime_contract(
         workflow_root=workflow_root,
-        preset_name="codex-service",
+        preset_name="codex-app-server",
         role="implementer",
         runtime_name="codex",
     )
@@ -126,6 +146,40 @@ def test_configure_runtime_uses_workflow_root_pointer_for_change_delivery(tmp_pa
         "ephemeral": False,
         "keep_alive": True,
     }
+
+
+def test_change_delivery_stage_contract_maps_stages_and_gates_to_actor_runtimes():
+    config = {
+        "workflow": "change-delivery",
+        "runtimes": {"codex-app-server": {"kind": "codex-app-server"}},
+        "actors": {
+            "implementer": {"name": "impl", "model": "gpt-5.4", "runtime": "codex-app-server"},
+            "implementer-high-effort": {"name": "impl-hi", "model": "gpt-5.4", "runtime": "codex-app-server"},
+            "reviewer": {"name": "review", "model": "gpt-5.4", "runtime": "codex-app-server"},
+        },
+        "stages": {
+            "implement": {
+                "actor": "implementer",
+                "escalation": {"after-attempts": 2, "actor": "implementer-high-effort"},
+            },
+            "publish": {"action": "pr.publish"},
+            "merge": {"action": "pr.merge"},
+        },
+        "gates": {
+            "pre-publish-review": {"type": "agent-review", "actor": "reviewer"},
+            "maintainer-approval": {"type": "pr-comment-approval"},
+            "ci-green": {"type": "code-host-checks"},
+        },
+    }
+
+    assert [
+        (item["stage"], item["role"], item["runtime"])
+        for item in runtime_stage_bindings(config)
+    ] == [
+        ("implement", "implementer", "codex-app-server"),
+        ("implement.escalation", "implementer-high-effort", "codex-app-server"),
+        ("gate:pre-publish-review", "reviewer", "codex-app-server"),
+    ]
 
 
 def test_configure_runtime_rejects_unknown_role(tmp_path):
@@ -234,9 +288,9 @@ def test_issue_runner_preflight_accepts_external_codex_service_without_command(t
             "repository": {"local-path": str(repo), "slug": "attmous/daedalus"},
             "tracker": {"kind": "local-json", "path": "config/issues.json"},
             "workspace": {"root": "workspace/issues"},
-            "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "codex-service"},
+            "agent": {"name": "runner", "model": "gpt-5.4", "runtime": "codex-app-server"},
             "runtimes": {
-                "codex-service": {
+                "codex-app-server": {
                     "kind": "codex-app-server",
                     "mode": "external",
                     "endpoint": "ws://127.0.0.1:4500",

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -33,8 +33,16 @@ def _write_issue_runner_contract(root: Path, repo: Path, *, overrides: dict | No
         "repository": {"local-path": str(repo), "slug": "attmous/daedalus"},
         "tracker": {"kind": "local-json", "path": "config/issues.json"},
         "workspace": {"root": "workspace/issues"},
-        "agent": {"name": "Issue_Runner_Agent", "model": "gpt-5.4", "runtime": "default"},
-        "daedalus": {"runtimes": {"default": {"kind": "hermes-agent", "command": ["echo", "{prompt_path}"]}}},
+        "agent": {"name": "Issue_Runner_Agent", "model": "gpt-5.4", "runtime": "codex-app-server"},
+        "runtimes": {
+            "codex-app-server": {
+                "kind": "codex-app-server",
+                "mode": "external",
+                "endpoint": "ws://127.0.0.1:4500",
+                "ephemeral": False,
+                "keep_alive": True,
+            }
+        },
         "storage": {
             "status": "memory/workflow-status.json",
             "health": "memory/workflow-health.json",

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -353,10 +353,8 @@ def test_workspace_lane_operator_attention_reasons(tmp_path):
 def test_workspace_exposes_runtime_accessor_with_named_profiles(tmp_path):
     """make_workspace instantiates runtimes from the (bridged) config.
 
-    In Phase 3 the runtime configs are derived from the old JSON shape's
-    sessionPolicy / reviewPolicy; Phase 4 will swap the source to YAML
-    runtimes: section. Either way, ws.runtime('acpx-codex') must return
-    an object implementing the Runtime protocol.
+    The private JSON-shape config still gets a runtime profile for tests and
+    local diagnostics. The hard default is now codex-app-server.
     """
     import importlib
     import sys
@@ -394,15 +392,13 @@ def test_workspace_exposes_runtime_accessor_with_named_profiles(tmp_path):
 
     assert hasattr(ws, "runtime"), "workspace must expose `runtime(name)` accessor"
 
-    acpx = ws.runtime("acpx-codex")
-    claude = ws.runtime("claude-cli")
+    codex = ws.runtime("codex-app-server")
 
-    # Duck-type: both respond to the protocol's four methods.
-    for r in (acpx, claude):
-        assert callable(getattr(r, "ensure_session", None))
-        assert callable(getattr(r, "run_prompt", None))
-        assert callable(getattr(r, "assess_health", None))
-        assert callable(getattr(r, "close_session", None))
+    # Duck-type: responds to the protocol's four core methods.
+    assert callable(getattr(codex, "ensure_session", None))
+    assert callable(getattr(codex, "run_prompt", None))
+    assert callable(getattr(codex, "assess_health", None))
+    assert callable(getattr(codex, "close_session", None))
 
 
 def test_workspace_runtime_accessor_errors_on_unknown_name(tmp_path):
@@ -438,7 +434,7 @@ def test_workspace_runtime_accessor_errors_on_unknown_name(tmp_path):
         ws.runtime("nonexistent-runtime")
     assert "nonexistent-runtime" in str(exc.value)
     # Error message names the known runtime profiles
-    assert "acpx-codex" in str(exc.value) or "claude-cli" in str(exc.value)
+    assert "codex-app-server" in str(exc.value)
 
 
 def test_workspace_from_yaml_exposes_same_surface_as_legacy_json(tmp_path):

--- a/tests/test_workflows_issue_runner_schema.py
+++ b/tests/test_workflows_issue_runner_schema.py
@@ -22,29 +22,26 @@ def _config() -> dict:
         "workspace": {"root": "workspace/issues"},
         "agent": {
             "name": "runner",
-            "model": "claude-sonnet-4-6",
-            "runtime": "default",
+            "model": "gpt-5.4",
+            "runtime": "codex-app-server",
             "max_concurrent_agents": 1,
             "max_turns": 20,
             "max_retry_backoff_ms": 300000,
         },
-        "codex": {
-            "command": "codex app-server",
-            "ephemeral": False,
-            "approval_policy": "never",
-            "thread_sandbox": "workspace-write",
-            "turn_sandbox_policy": "workspace-write",
-            "turn_timeout_ms": 3600000,
-            "read_timeout_ms": 5000,
-            "stall_timeout_ms": 300000,
-        },
-        "daedalus": {
-            "runtimes": {
-                "default": {
-                    "kind": "claude-cli",
-                    "max-turns-per-invocation": 8,
-                    "timeout-seconds": 60,
-                }
+        "runtimes": {
+            "codex-app-server": {
+                "kind": "codex-app-server",
+                "mode": "external",
+                "endpoint": "ws://127.0.0.1:4500",
+                "healthcheck_path": "/readyz",
+                "ephemeral": False,
+                "keep_alive": True,
+                "approval_policy": "never",
+                "thread_sandbox": "workspace-write",
+                "turn_sandbox_policy": "workspace-write",
+                "turn_timeout_ms": 3600000,
+                "read_timeout_ms": 5000,
+                "stall_timeout_ms": 300000,
             }
         },
         "storage": {


### PR DESCRIPTION
## Summary

Make workflow runtime wiring stage-aware and default both bundled workflows to Codex app-server for runtime-backed actors.

This adds shared stage-to-runtime bindings, hard-cuts the public Codex preset name to `codex-app-server`, and updates the issue-runner/change-delivery templates, examples, docs, readiness hints, and tests around the new default.

## Impact

Operators get a single default runtime profile name across both workflows. Validation and runtime-matrix output now expose the stage -> actor/agent -> runtime contract before the service starts, while Hermes remains opt-in per role through `configure-runtime` or manual `WORKFLOW.md` edits.

## Validation

- `pytest -q` -> `890 passed, 7 skipped`
- `git diff --cached --check` -> clean

## Note

There are unrelated local unstaged changes in `daedalus/engine/*` and `tests/test_engine_primitives.py`; they were intentionally left out of this PR.