### PR TITLE
[codex] fix engine lease races

### DIFF
--- a/daedalus/engine/leases.py
+++ b/daedalus/engine/leases.py
@@ -60,6 +60,66 @@ def acquire_engine_lease(
     now_epoch = iso_to_epoch(now_iso) or int(time.time())
     expires_iso = epoch_to_iso(now_epoch + ttl_seconds)
     lease_id = f"lease:{lease_scope}:{lease_key}"
+    metadata_json = json.dumps(metadata, sort_keys=True) if metadata else None
+
+    inserted = conn.execute(
+        """
+        INSERT OR IGNORE INTO leases (
+          lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
+          acquired_at, expires_at, released_at, release_reason, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+        """,
+        (
+            lease_id,
+            lease_scope,
+            lease_key,
+            owner_instance_id,
+            owner_role,
+            now_iso,
+            expires_iso,
+            metadata_json,
+        ),
+    )
+    if inserted.rowcount == 1:
+        return {
+            "acquired": True,
+            "lease_id": lease_id,
+            "owner_instance_id": owner_instance_id,
+            "expires_at": expires_iso,
+        }
+
+    updated = conn.execute(
+        """
+        UPDATE leases
+        SET owner_instance_id=?, owner_role=?, acquired_at=?, expires_at=?,
+            released_at=NULL, release_reason=NULL, metadata_json=?
+        WHERE lease_scope=? AND lease_key=?
+          AND (
+            owner_instance_id=?
+            OR released_at IS NOT NULL
+            OR expires_at <= ?
+          )
+        """,
+        (
+            owner_instance_id,
+            owner_role,
+            now_iso,
+            expires_iso,
+            metadata_json,
+            lease_scope,
+            lease_key,
+            owner_instance_id,
+            now_iso,
+        ),
+    )
+    if updated.rowcount == 1:
+        return {
+            "acquired": True,
+            "lease_id": lease_id,
+            "owner_instance_id": owner_instance_id,
+            "expires_at": expires_iso,
+        }
+
     row = conn.execute(
         "SELECT owner_instance_id, expires_at, released_at FROM leases WHERE lease_scope=? AND lease_key=?",
         (lease_scope, lease_key),
@@ -67,44 +127,42 @@ def acquire_engine_lease(
     if row:
         current_owner, expires_at, released_at = row
         expires_at_epoch = iso_to_epoch(expires_at)
-        if not released_at and expires_at_epoch and expires_at_epoch > now_epoch and current_owner != owner_instance_id:
+        if expires_at_epoch is None:
+            fallback = conn.execute(
+                """
+                UPDATE leases
+                SET owner_instance_id=?, owner_role=?, acquired_at=?, expires_at=?,
+                    released_at=NULL, release_reason=NULL, metadata_json=?
+                WHERE lease_scope=? AND lease_key=? AND owner_instance_id=? AND expires_at=?
+                """,
+                (
+                    owner_instance_id,
+                    owner_role,
+                    now_iso,
+                    expires_iso,
+                    metadata_json,
+                    lease_scope,
+                    lease_key,
+                    current_owner,
+                    expires_at,
+                ),
+            )
+            if fallback.rowcount == 1:
+                return {
+                    "acquired": True,
+                    "lease_id": lease_id,
+                    "owner_instance_id": owner_instance_id,
+                    "expires_at": expires_iso,
+                }
+            row = conn.execute(
+                "SELECT owner_instance_id FROM leases WHERE lease_scope=? AND lease_key=?",
+                (lease_scope, lease_key),
+            ).fetchone()
+            current_owner = row[0] if row else current_owner
+        if not released_at and current_owner != owner_instance_id:
             return {"acquired": False, "lease_id": lease_id, "owner_instance_id": current_owner}
-        conn.execute(
-            """
-            UPDATE leases
-            SET owner_instance_id=?, owner_role=?, acquired_at=?, expires_at=?,
-                released_at=NULL, release_reason=NULL, metadata_json=?
-            WHERE lease_scope=? AND lease_key=?
-            """,
-            (
-                owner_instance_id,
-                owner_role,
-                now_iso,
-                expires_iso,
-                json.dumps(metadata, sort_keys=True) if metadata else None,
-                lease_scope,
-                lease_key,
-            ),
-        )
     else:
-        conn.execute(
-            """
-            INSERT INTO leases (
-              lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
-              acquired_at, expires_at, released_at, release_reason, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
-            """,
-            (
-                lease_id,
-                lease_scope,
-                lease_key,
-                owner_instance_id,
-                owner_role,
-                now_iso,
-                expires_iso,
-                json.dumps(metadata, sort_keys=True) if metadata else None,
-            ),
-        )
+        return {"acquired": False, "lease_id": lease_id, "owner_instance_id": None}
     return {
         "acquired": True,
         "lease_id": lease_id,
@@ -123,24 +181,29 @@ def release_engine_lease(
     release_reason: str | None = None,
 ) -> dict[str, Any]:
     init_engine_leases(conn)
+    updated = conn.execute(
+        """
+        UPDATE leases
+        SET released_at=?, release_reason=?
+        WHERE lease_scope=? AND lease_key=? AND owner_instance_id=?
+        """,
+        (now_iso, release_reason, lease_scope, lease_key, owner_instance_id),
+    )
+    if updated.rowcount == 1:
+        return {
+            "released": True,
+            "lease_id": f"lease:{lease_scope}:{lease_key}",
+            "owner_instance_id": owner_instance_id,
+        }
+
     row = conn.execute(
         "SELECT owner_instance_id FROM leases WHERE lease_scope=? AND lease_key=?",
         (lease_scope, lease_key),
     ).fetchone()
-    if not row or row[0] != owner_instance_id:
-        return {"released": False, "reason": "not-owner"}
-    conn.execute(
-        """
-        UPDATE leases
-        SET released_at=?, release_reason=?
-        WHERE lease_scope=? AND lease_key=?
-        """,
-        (now_iso, release_reason, lease_scope, lease_key),
-    )
     return {
-        "released": True,
-        "lease_id": f"lease:{lease_scope}:{lease_key}",
-        "owner_instance_id": owner_instance_id,
+        "released": False,
+        "reason": "not-owner",
+        "owner_instance_id": row[0] if row else None,
     }
 
 

--- a/daedalus/engine/scheduler.py
+++ b/daedalus/engine/scheduler.py
@@ -81,7 +81,7 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
         retry_entries=retry_entries,
         recovered_running=recovered_running,
         codex_totals=dict(payload.get("codex_totals") or payload.get("codexTotals") or {}),
-        codex_threads=restore_codex_threads(payload.get("codex_threads") or {}),
+        codex_threads=restore_codex_threads(payload.get("codex_threads") or payload.get("codexThreads") or {}),
     )
 
 

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -973,7 +973,7 @@ def append_engine_event_to_connection(
         f"{workflow}:{safe_event_type}:{int(float(created_at_epoch) * 1000)}:{uuid.uuid4().hex[:8]}"
     )
     event_payload = dict(payload or {})
-    conn.execute(
+    inserted = conn.execute(
         """
         INSERT OR IGNORE INTO engine_events (
           workflow, event_id, run_id, work_id, event_type, severity,
@@ -992,6 +992,18 @@ def append_engine_event_to_connection(
             _json_dumps(event_payload),
         ),
     )
+    if inserted.rowcount == 0:
+        row = conn.execute(
+            """
+            SELECT workflow, event_id, run_id, work_id, event_type, severity,
+                   created_at, created_at_epoch, payload_json
+            FROM engine_events
+            WHERE event_id=?
+            """,
+            (safe_event_id,),
+        ).fetchone()
+        if row is not None:
+            return {**_event_row_to_dict(row), "inserted": False}
     return {
         "workflow": workflow,
         "event_id": safe_event_id,
@@ -1002,6 +1014,7 @@ def append_engine_event_to_connection(
         "created_at": created_at,
         "created_at_epoch": float(created_at_epoch),
         "payload": event_payload,
+        "inserted": True,
     }
 
 

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import threading
 
 
 def test_engine_storage_writes_json_and_jsonl(tmp_path):
@@ -48,7 +49,7 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
                 }
             ],
             "codexTotals": {"total_tokens": 5},
-            "codex_threads": {"42": {"thread_id": "thread-1", "turn_id": "turn-1"}},
+            "codexThreads": {"42": {"thread_id": "thread-1", "turn_id": "turn-1"}},
         },
         now_epoch=200.0,
     )
@@ -356,10 +357,21 @@ def test_engine_store_tracks_event_ledger_and_doctor_orphans(tmp_path):
     checks = {check["name"]: check for check in store.doctor()}
 
     assert event["event_type"] == "issue_runner.tick.completed"
+    assert event["inserted"] is True
     assert event["work_id"] == "ISSUE-1"
     assert events[0]["event_id"] == event["event_id"]
     assert events[0]["payload"]["issue_id"] == "ISSUE-1"
     assert checks["engine-events"]["status"] == "pass"
+
+    duplicate = store.append_event(
+        event_id=event["event_id"],
+        event_type="changed",
+        payload={"run_id": run["run_id"], "issue_id": "ISSUE-2"},
+    )
+    assert duplicate["inserted"] is False
+    assert duplicate["event_type"] == "issue_runner.tick.completed"
+    assert duplicate["work_id"] == "ISSUE-1"
+    assert len(store.events_for_run(run["run_id"])) == 1
 
     clock.update({"iso": "2026-04-30T00:00:01Z", "epoch": 101.0})
     orphaned = store.append_event(event_type="runtime.error", payload={"run_id": "missing-run"})
@@ -472,3 +484,195 @@ def test_engine_store_lease_lifecycle_and_stale_status(tmp_path):
     assert released_status["stale"] is True
     assert "lease-released" in released_status["stale_reasons"]
     assert "heartbeat-old" in released_status["stale_reasons"]
+
+
+def test_engine_lease_acquire_allows_only_one_contender_for_expired_lease(tmp_path):
+    from engine.leases import acquire_engine_lease, init_engine_leases
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    db_path.parent.mkdir(parents=True)
+    seed = sqlite3.connect(db_path)
+    try:
+        init_engine_leases(seed)
+        seed.execute(
+            """
+            INSERT INTO leases (
+              lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
+              acquired_at, expires_at, released_at, release_reason, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
+            """,
+            (
+                "lease:runtime:primary",
+                "runtime",
+                "primary",
+                "old-owner",
+                "Workflow_Orchestrator",
+                "2026-04-30T00:00:00Z",
+                "2026-04-30T00:00:01Z",
+            ),
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    barrier = threading.Barrier(2)
+
+    class ContendedAcquireConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=(), /):
+            normalized = sql.lstrip()
+            waits_before_first_write = normalized.startswith("INSERT OR IGNORE INTO leases")
+            waits_before_legacy_read = normalized.startswith(
+                "SELECT owner_instance_id, expires_at, released_at FROM leases"
+            )
+            if not getattr(self, "_lease_barrier_waited", False) and (
+                waits_before_first_write or waits_before_legacy_read
+            ):
+                self._lease_barrier_waited = True
+                barrier.wait(timeout=5)
+            return super().execute(sql, parameters)
+
+    results: list[dict] = []
+    errors: list[str] = []
+
+    def acquire(owner: str) -> None:
+        conn = sqlite3.connect(db_path, timeout=5, factory=ContendedAcquireConnection)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        try:
+            results.append(
+                acquire_engine_lease(
+                    conn,
+                    lease_scope="runtime",
+                    lease_key="primary",
+                    owner_instance_id=owner,
+                    owner_role="Workflow_Orchestrator",
+                    now_iso="2026-04-30T00:02:00Z",
+                    ttl_seconds=60,
+                )
+            )
+            conn.commit()
+        except Exception as exc:
+            errors.append(f"{owner}: {type(exc).__name__}: {exc}")
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=acquire, args=(owner,)) for owner in ("owner-a", "owner-b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert len(results) == 2
+    acquired = [result for result in results if result["acquired"]]
+    blocked = [result for result in results if not result["acquired"]]
+    assert len(acquired) == 1
+    assert len(blocked) == 1
+    assert blocked[0]["owner_instance_id"] == acquired[0]["owner_instance_id"]
+
+    final = sqlite3.connect(db_path)
+    try:
+        row = final.execute(
+            "SELECT owner_instance_id, released_at FROM leases WHERE lease_scope=? AND lease_key=?",
+            ("runtime", "primary"),
+        ).fetchone()
+    finally:
+        final.close()
+    assert row == (acquired[0]["owner_instance_id"], None)
+
+
+def test_engine_lease_release_cannot_release_new_owner_after_reclaim(tmp_path):
+    from engine.leases import acquire_engine_lease, init_engine_leases, release_engine_lease
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    db_path.parent.mkdir(parents=True)
+    seed = sqlite3.connect(db_path)
+    try:
+        init_engine_leases(seed)
+        seed.execute(
+            """
+            INSERT INTO leases (
+              lease_id, lease_scope, lease_key, owner_instance_id, owner_role,
+              acquired_at, expires_at, released_at, release_reason, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
+            """,
+            (
+                "lease:runtime:primary",
+                "runtime",
+                "primary",
+                "owner-a",
+                "Workflow_Orchestrator",
+                "2026-04-30T00:00:00Z",
+                "2026-04-30T00:00:01Z",
+            ),
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    release_ready = threading.Event()
+    release_continue = threading.Event()
+
+    class DelayedReleaseConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=(), /):
+            if sql.lstrip().startswith("UPDATE leases") and "release_reason" in sql:
+                release_ready.set()
+                assert release_continue.wait(timeout=5)
+            return super().execute(sql, parameters)
+
+    release_result: dict[str, dict] = {}
+    errors: list[str] = []
+
+    def release_stale_owner() -> None:
+        conn = sqlite3.connect(db_path, timeout=5, factory=DelayedReleaseConnection)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        try:
+            release_result["value"] = release_engine_lease(
+                conn,
+                lease_scope="runtime",
+                lease_key="primary",
+                owner_instance_id="owner-a",
+                now_iso="2026-04-30T00:02:00Z",
+                release_reason="shutdown",
+            )
+            conn.commit()
+        except Exception as exc:
+            errors.append(f"release: {type(exc).__name__}: {exc}")
+        finally:
+            conn.close()
+
+    thread = threading.Thread(target=release_stale_owner)
+    thread.start()
+    assert release_ready.wait(timeout=5)
+    try:
+        conn = sqlite3.connect(db_path, timeout=5)
+        try:
+            acquired = acquire_engine_lease(
+                conn,
+                lease_scope="runtime",
+                lease_key="primary",
+                owner_instance_id="owner-b",
+                owner_role="Workflow_Orchestrator",
+                now_iso="2026-04-30T00:02:00Z",
+                ttl_seconds=60,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    finally:
+        release_continue.set()
+    thread.join(timeout=10)
+
+    assert errors == []
+    assert acquired["acquired"] is True
+    assert release_result["value"]["released"] is False
+    assert release_result["value"]["owner_instance_id"] == "owner-b"
+
+    final = sqlite3.connect(db_path)
+    try:
+        row = final.execute(
+            "SELECT owner_instance_id, released_at FROM leases WHERE lease_scope=? AND lease_key=?",
+            ("runtime", "primary"),
+        ).fetchone()
+    finally:
+        final.close()
+    assert row == ("owner-b", None)


### PR DESCRIPTION
## Summary

Fixes engine lease race conditions found during the Daedalus engine audit.

- Makes lease acquisition and release use conditional SQL writes so stale reads cannot grant or release ownership incorrectly.
- Preserves legacy scheduler `codexThreads` mappings during restore.
- Returns explicit duplicate event status from engine event inserts instead of reporting ignored writes as new events.
- Adds concurrency regression coverage for lease acquire/release races plus scheduler and event regressions.

## Root Cause

Lease acquire/release previously used a read-then-write sequence. Under contention, two owners could both observe an expired lease and both return `acquired: true`, or an old owner could release a row after a new owner reclaimed it.

## Validation

- `pytest tests/test_engine_primitives.py`
- `pytest tests/test_daedalus_watch_sources.py tests/test_workflows_issue_runner_workspace.py tests/test_tools_run_cli_command_dispatch.py tests/test_runtime_tools_alerts.py tests/test_status_server.py`