### PR TITLE
[codex] harden engine scheduler and ledger semantics

### DIFF
--- a/daedalus/engine/scheduler.py
+++ b/daedalus/engine/scheduler.py
@@ -13,6 +13,17 @@ class RestoredSchedulerState:
     codex_threads: dict[str, dict[str, Any]]
 
 
+def _value_or_default(value: Any, default: Any) -> Any:
+    return default if value in (None, "") else value
+
+
+def _first_value_or_default(default: Any, *values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return default
+
+
 def retry_due_at(
     entry: dict[str, Any] | None,
     *,
@@ -44,7 +55,7 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
             "identifier": item.get("identifier"),
             "attempt": int(item.get("attempt") or 0),
             "error": item.get("error"),
-            "due_at_epoch": float(item.get("due_at_epoch") or item.get("dueAtEpoch") or now_epoch),
+            "due_at_epoch": float(_first_value_or_default(now_epoch, item.get("due_at_epoch"), item.get("dueAtEpoch"))),
             "current_attempt": item.get("current_attempt") or item.get("currentAttempt"),
             "run_id": item.get("run_id") or item.get("runId"),
         }
@@ -56,7 +67,9 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
         issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
         if not issue_id:
             continue
-        started_at_epoch = float(item.get("started_at_epoch") or item.get("startedAtEpoch") or now_epoch)
+        started_at_epoch = float(
+            _first_value_or_default(now_epoch, item.get("started_at_epoch"), item.get("startedAtEpoch"))
+        )
         recovered_running.append(
             {
                 "issue_id": issue_id,
@@ -67,9 +80,11 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
                 "worker_status": item.get("worker_status") or item.get("workerStatus") or "recovered",
                 "started_at_epoch": started_at_epoch,
                 "heartbeat_at_epoch": float(
-                    item.get("heartbeat_at_epoch")
-                    or item.get("heartbeatAtEpoch")
-                    or started_at_epoch
+                    _first_value_or_default(
+                        started_at_epoch,
+                        item.get("heartbeat_at_epoch"),
+                        item.get("heartbeatAtEpoch"),
+                    )
                 ),
                 "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
                 "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
@@ -92,8 +107,8 @@ def running_snapshot(
 ) -> list[dict[str, Any]]:
     running = []
     for issue_id, entry in running_entries.items():
-        started_at_epoch = float(entry.get("started_at_epoch") or now_epoch)
-        heartbeat_at_epoch = float(entry.get("heartbeat_at_epoch") or started_at_epoch)
+        started_at_epoch = float(_value_or_default(entry.get("started_at_epoch"), now_epoch))
+        heartbeat_at_epoch = float(_value_or_default(entry.get("heartbeat_at_epoch"), started_at_epoch))
         running.append(
             {
                 "issue_id": issue_id,

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -44,6 +44,17 @@ def _json_loads(value: Any) -> Any:
     return None
 
 
+def _value_or_default(value: Any, default: Any) -> Any:
+    return default if value in (None, "") else value
+
+
+def _first_value_or_default(default: Any, *values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return default
+
+
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
@@ -64,6 +75,40 @@ def _ensure_column(conn: sqlite3.Connection, table_name: str, column_sql: str) -
     column_name = column_sql.split()[0]
     if _table_exists(conn, table_name) and not _column_exists(conn, table_name, column_name):
         conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_sql}")
+
+
+def _primary_key_columns(conn: sqlite3.Connection, table_name: str) -> list[str]:
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    except sqlite3.OperationalError:
+        return []
+    pk_rows = sorted((row for row in rows if int(row[5] or 0) > 0), key=lambda row: int(row[5] or 0))
+    return [str(row[1]) for row in pk_rows]
+
+
+def _rebuild_table_for_primary_key(
+    conn: sqlite3.Connection,
+    *,
+    table_name: str,
+    expected_primary_key: list[str],
+    create_sql: str,
+    copy_columns: list[str],
+    indexes: list[str],
+) -> None:
+    if not _table_exists(conn, table_name):
+        return
+    if _primary_key_columns(conn, table_name) == expected_primary_key:
+        return
+    for index_name in indexes:
+        conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+    old_table_name = f"{table_name}__old_primary_key_{uuid.uuid4().hex}"
+    conn.execute(f"ALTER TABLE {table_name} RENAME TO {old_table_name}")
+    conn.execute(create_sql)
+    columns = ", ".join(copy_columns)
+    conn.execute(
+        f"INSERT OR IGNORE INTO {table_name} ({columns}) SELECT {columns} FROM {old_table_name}"
+    )
+    conn.execute(f"DROP TABLE {old_table_name}")
 
 
 def engine_state_tables_exist(conn: sqlite3.Connection) -> bool:
@@ -160,7 +205,7 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
 
         CREATE TABLE IF NOT EXISTS engine_runs (
           workflow TEXT NOT NULL,
-          run_id TEXT PRIMARY KEY,
+          run_id TEXT NOT NULL,
           mode TEXT NOT NULL,
           status TEXT NOT NULL,
           started_at TEXT NOT NULL,
@@ -170,19 +215,21 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           selected_count INTEGER NOT NULL DEFAULT 0,
           completed_count INTEGER NOT NULL DEFAULT 0,
           error TEXT,
-          metadata_json TEXT
+          metadata_json TEXT,
+          PRIMARY KEY (workflow, run_id)
         );
 
         CREATE TABLE IF NOT EXISTS engine_events (
           workflow TEXT NOT NULL,
-          event_id TEXT PRIMARY KEY,
+          event_id TEXT NOT NULL,
           run_id TEXT,
           work_id TEXT,
           event_type TEXT NOT NULL,
           severity TEXT NOT NULL DEFAULT 'info',
           created_at TEXT NOT NULL,
           created_at_epoch REAL NOT NULL,
-          payload_json TEXT
+          payload_json TEXT,
+          PRIMARY KEY (workflow, event_id)
         );
 
         CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_status
@@ -205,11 +252,102 @@ def init_engine_state(conn: sqlite3.Connection) -> None:
           ON engine_events(workflow, created_at_epoch);
         """
     )
+    _rebuild_table_for_primary_key(
+        conn,
+        table_name="engine_runs",
+        expected_primary_key=["workflow", "run_id"],
+        create_sql="""
+        CREATE TABLE engine_runs (
+          workflow TEXT NOT NULL,
+          run_id TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          status TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          started_at_epoch REAL NOT NULL,
+          completed_at TEXT,
+          completed_at_epoch REAL,
+          selected_count INTEGER NOT NULL DEFAULT 0,
+          completed_count INTEGER NOT NULL DEFAULT 0,
+          error TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY (workflow, run_id)
+        )
+        """,
+        copy_columns=[
+            "workflow",
+            "run_id",
+            "mode",
+            "status",
+            "started_at",
+            "started_at_epoch",
+            "completed_at",
+            "completed_at_epoch",
+            "selected_count",
+            "completed_count",
+            "error",
+            "metadata_json",
+        ],
+        indexes=["idx_engine_runs_workflow_started", "idx_engine_runs_workflow_status"],
+    )
+    _rebuild_table_for_primary_key(
+        conn,
+        table_name="engine_events",
+        expected_primary_key=["workflow", "event_id"],
+        create_sql="""
+        CREATE TABLE engine_events (
+          workflow TEXT NOT NULL,
+          event_id TEXT NOT NULL,
+          run_id TEXT,
+          work_id TEXT,
+          event_type TEXT NOT NULL,
+          severity TEXT NOT NULL DEFAULT 'info',
+          created_at TEXT NOT NULL,
+          created_at_epoch REAL NOT NULL,
+          payload_json TEXT,
+          PRIMARY KEY (workflow, event_id)
+        )
+        """,
+        copy_columns=[
+            "workflow",
+            "event_id",
+            "run_id",
+            "work_id",
+            "event_type",
+            "severity",
+            "created_at",
+            "created_at_epoch",
+            "payload_json",
+        ],
+        indexes=[
+            "idx_engine_events_workflow_run",
+            "idx_engine_events_workflow_work",
+            "idx_engine_events_workflow_type",
+            "idx_engine_events_workflow_created",
+        ],
+    )
     _ensure_column(conn, "engine_running_work", "run_id TEXT")
     _ensure_column(conn, "engine_retry_queue", "run_id TEXT")
     _ensure_column(conn, "engine_runtime_sessions", "run_id TEXT")
     conn.executescript(
         """
+        CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_status
+          ON engine_running_work(workflow, worker_status);
+        CREATE INDEX IF NOT EXISTS idx_engine_retry_workflow_due
+          ON engine_retry_queue(workflow, due_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_runtime_sessions_thread
+          ON engine_runtime_sessions(workflow, thread_id);
+        CREATE INDEX IF NOT EXISTS idx_engine_runs_workflow_started
+          ON engine_runs(workflow, started_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_runs_workflow_status
+          ON engine_runs(workflow, status);
+        CREATE INDEX IF NOT EXISTS idx_engine_events_workflow_run
+          ON engine_events(workflow, run_id, created_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_events_workflow_work
+          ON engine_events(workflow, work_id, created_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_events_workflow_type
+          ON engine_events(workflow, event_type, created_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_engine_events_workflow_created
+          ON engine_events(workflow, created_at_epoch);
         CREATE INDEX IF NOT EXISTS idx_engine_running_workflow_run
           ON engine_running_work(workflow, run_id);
         CREATE INDEX IF NOT EXISTS idx_engine_retry_workflow_run
@@ -317,8 +455,14 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("worker_id"),
                 int(entry.get("attempt") or 0),
                 entry.get("worker_status") or "running",
-                float(entry.get("started_at_epoch") or now_epoch),
-                float(entry.get("heartbeat_at_epoch") or entry.get("started_at_epoch") or now_epoch),
+                float(_value_or_default(entry.get("started_at_epoch"), now_epoch)),
+                float(
+                    _first_value_or_default(
+                        now_epoch,
+                        entry.get("heartbeat_at_epoch"),
+                        entry.get("started_at_epoch"),
+                    )
+                ),
                 1 if entry.get("cancel_requested") else 0,
                 entry.get("cancel_reason"),
                 entry.get("thread_id"),
@@ -344,7 +488,7 @@ def save_engine_scheduler_state_to_connection(
                 workflow,
                 work_id,
                 int(entry.get("attempt") or 0),
-                float(entry.get("due_at_epoch") or now_epoch),
+                float(_value_or_default(entry.get("due_at_epoch"), now_epoch)),
                 entry.get("error"),
                 entry.get("current_attempt"),
                 entry.get("delay_type") or "failure",
@@ -508,8 +652,8 @@ def _scheduler_state_from_connection(
             "worker_id": worker_id,
             "attempt": int(attempt or 0),
             "worker_status": worker_status or "running",
-            "started_at_epoch": float(started_at_epoch or now_epoch),
-            "heartbeat_at_epoch": float(heartbeat_at_epoch or started_at_epoch or now_epoch),
+            "started_at_epoch": float(_value_or_default(started_at_epoch, now_epoch)),
+            "heartbeat_at_epoch": float(_first_value_or_default(now_epoch, heartbeat_at_epoch, started_at_epoch)),
             "cancel_requested": bool(cancel_requested),
             "cancel_reason": cancel_reason,
             "thread_id": thread_id,
@@ -533,7 +677,7 @@ def _scheduler_state_from_connection(
             "issue_id": str(work_id),
             "identifier": identifier,
             "attempt": int(attempt or 0),
-            "due_at_epoch": float(due_at_epoch or now_epoch),
+            "due_at_epoch": float(_value_or_default(due_at_epoch, now_epoch)),
             "error": error,
             "current_attempt": current_attempt,
             "delay_type": delay_type or "failure",
@@ -998,9 +1142,9 @@ def append_engine_event_to_connection(
             SELECT workflow, event_id, run_id, work_id, event_type, severity,
                    created_at, created_at_epoch, payload_json
             FROM engine_events
-            WHERE event_id=?
+            WHERE workflow=? AND event_id=?
             """,
-            (safe_event_id,),
+            (workflow, safe_event_id),
         ).fetchone()
         if row is not None:
             return {**_event_row_to_dict(row), "inserted": False}

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -497,7 +497,7 @@ class EngineStore:
                     "run_id": row[0],
                     "mode": row[1],
                     "started_at": row[2],
-                    "age_seconds": max(int(now_epoch - float(row[3] or now_epoch)), 0),
+                    "age_seconds": max(int(now_epoch - float(now_epoch if row[3] in (None, "") else row[3])), 0),
                     "suggested_recovery": f"inspect with `hermes daedalus runs show {row[0]}`",
                 }
                 for row in stale_runs

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -76,6 +76,17 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
     assert payload["running"][0]["running_for_ms"] == 100000
     assert payload["codex_threads"]["42"]["thread_id"] == "thread-1"
 
+    restored_zero = restore_scheduler_state(
+        {
+            "retryQueue": [{"issueId": "zero-retry", "dueAtEpoch": 0.0}],
+            "running": [{"issueId": "zero-running", "startedAtEpoch": 0.0, "heartbeatAtEpoch": 0.0}],
+        },
+        now_epoch=200.0,
+    )
+    assert restored_zero.retry_entries["zero-retry"]["due_at_epoch"] == 0.0
+    assert restored_zero.recovered_running[0]["started_at_epoch"] == 0.0
+    assert restored_zero.recovered_running[0]["heartbeat_at_epoch"] == 0.0
+
 
 def test_engine_work_items_and_lifecycle_helpers():
     from engine.lifecycle import clear_work_entries, mark_running_work, recover_running_as_retry, schedule_retry_entry
@@ -254,6 +265,49 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
     assert readonly == loaded
 
 
+def test_engine_state_preserves_zero_epoch_scheduler_values(tmp_path):
+    from engine.state import load_engine_scheduler_state, save_engine_scheduler_state
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    save_engine_scheduler_state(
+        db_path,
+        workflow="issue-runner",
+        running_entries={
+            "ISSUE-0": {
+                "issue_id": "ISSUE-0",
+                "identifier": "DAE-0",
+                "started_at_epoch": 0.0,
+                "heartbeat_at_epoch": 0.0,
+            }
+        },
+        retry_entries={
+            "ISSUE-RETRY-0": {
+                "issue_id": "ISSUE-RETRY-0",
+                "identifier": "DAE-R0",
+                "due_at_epoch": 0.0,
+                "error": "immediate retry",
+            }
+        },
+        codex_threads={},
+        codex_totals={},
+        now_iso="2026-04-30T00:00:00Z",
+        now_epoch=120.0,
+    )
+
+    loaded = load_engine_scheduler_state(
+        db_path,
+        workflow="issue-runner",
+        now_iso="2026-04-30T00:00:10Z",
+        now_epoch=125.0,
+    )
+
+    assert loaded["running"][0]["started_at_epoch"] == 0.0
+    assert loaded["running"][0]["heartbeat_at_epoch"] == 0.0
+    assert loaded["running"][0]["running_for_ms"] == 125000
+    assert loaded["retry_queue"][0]["due_at_epoch"] == 0.0
+    assert loaded["retry_queue"][0]["due_in_ms"] == 0
+
+
 def test_engine_store_wraps_scheduler_state_and_doctor(tmp_path):
     from engine.store import EngineStore
 
@@ -379,6 +433,93 @@ def test_engine_store_tracks_event_ledger_and_doctor_orphans(tmp_path):
 
     assert checks["engine-events"]["status"] == "warn"
     assert orphaned["event_id"] in checks["engine-events"]["items"]
+
+
+def test_engine_run_and_event_ids_are_workflow_scoped_after_schema_migration(tmp_path):
+    from engine.store import EngineStore
+
+    db_path = tmp_path / "runtime" / "state" / "daedalus.db"
+    db_path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE engine_runs (
+              workflow TEXT NOT NULL,
+              run_id TEXT PRIMARY KEY,
+              mode TEXT NOT NULL,
+              status TEXT NOT NULL,
+              started_at TEXT NOT NULL,
+              started_at_epoch REAL NOT NULL,
+              completed_at TEXT,
+              completed_at_epoch REAL,
+              selected_count INTEGER NOT NULL DEFAULT 0,
+              completed_count INTEGER NOT NULL DEFAULT 0,
+              error TEXT,
+              metadata_json TEXT
+            );
+
+            CREATE TABLE engine_events (
+              workflow TEXT NOT NULL,
+              event_id TEXT PRIMARY KEY,
+              run_id TEXT,
+              work_id TEXT,
+              event_type TEXT NOT NULL,
+              severity TEXT NOT NULL DEFAULT 'info',
+              created_at TEXT NOT NULL,
+              created_at_epoch REAL NOT NULL,
+              payload_json TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    clock = {"iso": "2026-04-30T00:00:00Z", "epoch": 100.0}
+    issue_runner = EngineStore(
+        db_path=db_path,
+        workflow="issue-runner",
+        now_iso=lambda: clock["iso"],
+        now_epoch=lambda: clock["epoch"],
+    )
+    change_delivery = EngineStore(
+        db_path=db_path,
+        workflow="change-delivery",
+        now_iso=lambda: clock["iso"],
+        now_epoch=lambda: clock["epoch"],
+    )
+
+    issue_run = issue_runner.start_run(mode="tick", run_id="shared-run")
+    change_run = change_delivery.start_run(mode="tick", run_id="shared-run")
+    issue_event = issue_runner.append_event(
+        event_id="shared-event",
+        event_type="issue.event",
+        payload={"run_id": issue_run["run_id"]},
+    )
+    change_event = change_delivery.append_event(
+        event_id="shared-event",
+        event_type="change.event",
+        payload={"run_id": change_run["run_id"]},
+    )
+
+    assert issue_run["workflow"] == "issue-runner"
+    assert change_run["workflow"] == "change-delivery"
+    assert issue_event["inserted"] is True
+    assert change_event["inserted"] is True
+    assert issue_runner.get_run("shared-run")["workflow"] == "issue-runner"
+    assert change_delivery.get_run("shared-run")["workflow"] == "change-delivery"
+    assert issue_runner.events_for_run("shared-run")[0]["event_type"] == "issue.event"
+    assert change_delivery.events_for_run("shared-run")[0]["event_type"] == "change.event"
+
+    conn = sqlite3.connect(db_path)
+    try:
+        run_pk = [row[1] for row in conn.execute("PRAGMA table_info(engine_runs)") if row[5]]
+        event_pk = [row[1] for row in conn.execute("PRAGMA table_info(engine_events)") if row[5]]
+    finally:
+        conn.close()
+    assert run_pk == ["workflow", "run_id"]
+    assert event_pk == ["workflow", "event_id"]
 
 
 def test_engine_store_filters_and_prunes_events(tmp_path):


### PR DESCRIPTION
## Summary

Continues the Daedalus engine audit with SQLite scheduler/run/event semantics fixes.

- Preserves valid `0.0` scheduler epoch values instead of treating them as missing.
- Migrates `engine_runs` and `engine_events` to workflow-scoped primary keys.
- Keeps duplicate engine event detection workflow-local.
- Adds regressions for zero-epoch scheduler values and cross-workflow run/event ID isolation after migration.

## Root Cause

Some scheduler projections used `value or now_epoch`, which rewrote legitimate zero timestamps. The run/event ledger also tagged rows by workflow but keyed them globally, so explicit run/event IDs could collide across workflows.

## Validation

- `pytest tests/test_engine_primitives.py`
- `pytest tests/test_daedalus_watch_sources.py tests/test_status_server.py tests/test_tools_run_cli_command_dispatch.py tests/test_runtime_tools_alerts.py tests/test_workflows_issue_runner_workspace.py`
- `pytest tests/test_daedalus_db_schema_migration.py tests/test_runtime_tools_alerts.py tests/test_engine_primitives.py`
- `pytest`