### PR TITLE
[codex] neutralize engine runtime contracts

### DIFF
--- a/daedalus/daedalus_cli.py
+++ b/daedalus/daedalus_cli.py
@@ -541,11 +541,26 @@ def _workflow_name_for_root(workflow_root: Path) -> str:
     return workflow_name
 
 
+def _load_workflow_module_for_root(workflow_root: Path):
+    workflow_name = _workflow_name_for_root(workflow_root)
+    try:
+        from workflows import load_workflow
+    except ImportError as exc:
+        raise DaedalusCommandError("unable to load workflow dispatcher") from exc
+    try:
+        return load_workflow(workflow_name)
+    except Exception as exc:
+        raise DaedalusCommandError(f"unable to load workflow {workflow_name!r}: {exc}") from exc
+
+
 def _assert_service_mode_supported(*, workflow_root: Path, service_mode: str) -> str:
     workflow_name = _workflow_name_for_root(workflow_root)
-    if workflow_name == "issue-runner" and service_mode != "active":
+    module = _load_workflow_module_for_root(workflow_root)
+    supported_modes = getattr(module, "SERVICE_MODES", None)
+    if supported_modes is not None and service_mode not in set(supported_modes):
         raise DaedalusCommandError(
-            "issue-runner supports only active supervised mode; use --service-mode active"
+            f"{workflow_name} does not support service mode {service_mode!r}; "
+            f"supported: {sorted(supported_modes)}"
         )
     return workflow_name
 
@@ -815,44 +830,18 @@ def service_loop(
     service_mode: str,
 ) -> dict[str, Any]:
     workflow_name = _assert_service_mode_supported(workflow_root=workflow_root, service_mode=service_mode)
-    if workflow_name == "change-delivery":
-        daedalus = _load_daedalus_module(workflow_root)
-        resolved_project_key = project_key or daedalus._project_key_for(workflow_root)
-        resolved_instance_id = instance_id or _instance_id_for(service_mode=service_mode, workspace=workflow_root.name)
-        lane_selection = (
-            _ensure_change_delivery_active_lane_for_start(workflow_root)
-            if service_mode == "active"
-            else None
-        )
-        if service_mode == "shadow":
-            return daedalus.run_shadow_loop(
-                workflow_root=workflow_root,
-                project_key=resolved_project_key,
-                instance_id=resolved_instance_id,
-                interval_seconds=interval_seconds,
-                max_iterations=max_iterations,
-            )
-        result = daedalus.run_active_loop(
-            workflow_root=workflow_root,
-            project_key=resolved_project_key,
-            instance_id=resolved_instance_id,
-            interval_seconds=interval_seconds,
-            max_iterations=max_iterations,
-        )
-        result["lane_selection"] = lane_selection
-        return result
-    if workflow_name == "issue-runner":
-        workspace = _load_issue_runner_workspace(workflow_root)
-        payload = workspace.run_loop(
-            interval_seconds=interval_seconds,
-            max_iterations=max_iterations,
-        )
-        return {
-            "workflow": workflow_name,
-            "service_mode": service_mode,
-            **payload,
-        }
-    raise DaedalusCommandError(f"unsupported workflow for service-loop: {workflow_name}")
+    module = _load_workflow_module_for_root(workflow_root)
+    loop_fn = getattr(module, "service_loop", None)
+    if not callable(loop_fn):
+        raise DaedalusCommandError(f"workflow {workflow_name!r} does not expose service_loop")
+    return loop_fn(
+        workflow_root=workflow_root,
+        project_key=project_key,
+        instance_id=instance_id,
+        interval_seconds=interval_seconds,
+        max_iterations=max_iterations,
+        service_mode=service_mode,
+    )
 
 
 def service_up(
@@ -869,17 +858,6 @@ def service_up(
         service_mode=service_mode,
     )
     workflow_name = preflight_result.get("workflow")
-    if workflow_name == "change-delivery":
-        daedalus = _load_daedalus_module(workflow_root)
-        init_result = daedalus.init_daedalus_db(workflow_root=workflow_root, project_key=project_key)
-    else:
-        init_result = {
-            "ok": True,
-            "workflow": workflow_name,
-            "skipped": True,
-            "reason": "workflow-managed runtime does not require daedalus.db bootstrap",
-        }
-    lane_selection_result = None
 
     install_result = install_supervised_service(
         workflow_root=workflow_root,
@@ -909,8 +887,24 @@ def service_up(
             f"{enable_result.get('stderr') or enable_result.get('stdout') or enable_result.get('returncode')}"
         )
 
-    if workflow_name == "change-delivery" and service_mode == "active":
-        lane_selection_result = _ensure_change_delivery_active_lane_for_start(workflow_root)
+    module = _load_workflow_module_for_root(workflow_root)
+    prepare_fn = getattr(module, "service_prepare", None)
+    if callable(prepare_fn):
+        prepare_result = prepare_fn(
+            workflow_root=workflow_root,
+            project_key=project_key,
+            service_mode=service_mode,
+        )
+        init_result = prepare_result.get("init") or prepare_result
+        lane_selection_result = prepare_result.get("lane_selection")
+    else:
+        init_result = {
+            "ok": True,
+            "workflow": workflow_name,
+            "skipped": True,
+            "reason": "workflow does not expose service_prepare",
+        }
+        lane_selection_result = None
 
     start_result = service_control(
         "start",
@@ -1324,8 +1318,8 @@ def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
         )
         if scheduler is None:
             continue
-        raw_threads = scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}
-        totals = scheduler.get("codex_totals") or scheduler.get("codexTotals") or {}
+        raw_threads = scheduler.get("runtime_sessions") or {}
+        totals = scheduler.get("runtime_totals") or {}
         if raw_threads or totals or workflow_name == workflow_names[-1]:
             break
 
@@ -1339,7 +1333,7 @@ def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
             "invalid_thread_count": 0,
             "error": None,
         }
-    raw_threads = scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}
+    raw_threads = scheduler.get("runtime_sessions") or {}
     threads: list[dict[str, Any]] = []
     invalid_thread_count = 0
     if isinstance(raw_threads, dict):
@@ -1347,27 +1341,27 @@ def _load_codex_scheduler_snapshot(workflow_root: Path) -> dict[str, Any]:
             if not isinstance(raw_entry, dict):
                 invalid_thread_count += 1
                 continue
-            thread_id = raw_entry.get("thread_id") or raw_entry.get("threadId")
+            thread_id = raw_entry.get("thread_id")
             if not str(thread_id or "").strip():
                 invalid_thread_count += 1
-            issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+            issue_number = raw_entry.get("issue_number")
             threads.append(
                 {
                     "issue_id": raw_entry.get("issue_id") or issue_id,
                     "issue_number": issue_number,
                     "identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
-                    "session_name": raw_entry.get("session_name") or raw_entry.get("sessionName"),
-                    "runtime_name": raw_entry.get("runtime_name") or raw_entry.get("runtimeName"),
-                    "runtime_kind": raw_entry.get("runtime_kind") or raw_entry.get("runtimeKind"),
+                    "session_name": raw_entry.get("session_name"),
+                    "runtime_name": raw_entry.get("runtime_name"),
+                    "runtime_kind": raw_entry.get("runtime_kind"),
                     "thread_id": thread_id,
-                    "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                    "turn_id": raw_entry.get("turn_id"),
                     "status": raw_entry.get("status"),
-                    "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
-                    "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
-                    "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+                    "cancel_requested": bool(raw_entry.get("cancel_requested") or False),
+                    "cancel_reason": raw_entry.get("cancel_reason"),
+                    "updated_at": raw_entry.get("updated_at"),
                 }
             )
-    totals = scheduler.get("codex_totals") or scheduler.get("codexTotals") or {}
+    totals = scheduler.get("runtime_totals") or {}
     return {
         "ok": invalid_thread_count == 0,
         "path": str(db_path),

--- a/daedalus/engine/__init__.py
+++ b/daedalus/engine/__init__.py
@@ -23,7 +23,7 @@ from .retention import normalize_event_retention
 from .scheduler import (
     RestoredSchedulerState,
     build_scheduler_payload,
-    codex_threads_snapshot,
+    runtime_sessions_snapshot,
     restore_scheduler_state,
     retry_due_at,
     retry_queue_snapshot,
@@ -59,7 +59,6 @@ from .work_items import (
     RunningWork,
     WorkItemRef,
     WorkResult,
-    work_item_from_change_delivery_lane,
     work_item_from_issue,
 )
 
@@ -76,7 +75,7 @@ __all__ = [
     "append_jsonl",
     "build_scheduler_payload",
     "clear_work_entries",
-    "codex_threads_snapshot",
+    "runtime_sessions_snapshot",
     "connect_daedalus_db",
     "engine_event_stats_from_connection",
     "engine_events_from_connection",
@@ -111,7 +110,6 @@ __all__ = [
     "save_engine_scheduler_state_to_connection",
     "release_engine_lease",
     "start_engine_run_to_connection",
-    "work_item_from_change_delivery_lane",
     "work_item_from_issue",
     "write_json_atomic",
     "write_text_atomic",

--- a/daedalus/engine/lifecycle.py
+++ b/daedalus/engine/lifecycle.py
@@ -95,6 +95,6 @@ def recover_running_as_retry(
             "error": error,
             "due_at_epoch": now_epoch,
             "current_attempt": running.get("attempt"),
-            "run_id": running.get("run_id") or running.get("runId"),
+            "run_id": running.get("run_id"),
         }
     return entries

--- a/daedalus/engine/scheduler.py
+++ b/daedalus/engine/scheduler.py
@@ -9,8 +9,8 @@ from typing import Any
 class RestoredSchedulerState:
     retry_entries: dict[str, dict[str, Any]]
     recovered_running: list[dict[str, Any]]
-    codex_totals: dict[str, Any]
-    codex_threads: dict[str, dict[str, Any]]
+    runtime_totals: dict[str, Any]
+    runtime_sessions: dict[str, dict[str, Any]]
 
 
 def _value_or_default(value: Any, default: Any) -> Any:
@@ -35,8 +35,6 @@ def retry_due_at(
         return float(payload.get("due_at_monotonic") or 0.0)
     if payload.get("due_at_epoch") is not None:
         return float(payload.get("due_at_epoch") or 0.0)
-    if payload.get("dueAtEpoch") is not None:
-        return float(payload.get("dueAtEpoch") or 0.0)
     if default is not None:
         return float(default)
     return float(now_epoch if now_epoch is not None else time.time())
@@ -44,10 +42,10 @@ def retry_due_at(
 
 def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> RestoredSchedulerState:
     retry_entries: dict[str, dict[str, Any]] = {}
-    for item in payload.get("retry_queue") or payload.get("retryQueue") or []:
+    for item in payload.get("retry_queue") or []:
         if not isinstance(item, dict):
             continue
-        issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
+        issue_id = str(item.get("issue_id") or "").strip()
         if not issue_id:
             continue
         retry_entries[issue_id] = {
@@ -55,48 +53,47 @@ def restore_scheduler_state(payload: dict[str, Any], *, now_epoch: float) -> Res
             "identifier": item.get("identifier"),
             "attempt": int(item.get("attempt") or 0),
             "error": item.get("error"),
-            "due_at_epoch": float(_first_value_or_default(now_epoch, item.get("due_at_epoch"), item.get("dueAtEpoch"))),
-            "current_attempt": item.get("current_attempt") or item.get("currentAttempt"),
-            "run_id": item.get("run_id") or item.get("runId"),
+            "due_at_epoch": float(_first_value_or_default(now_epoch, item.get("due_at_epoch"))),
+            "current_attempt": item.get("current_attempt"),
+            "run_id": item.get("run_id"),
         }
 
     recovered_running: list[dict[str, Any]] = []
     for item in payload.get("running") or []:
         if not isinstance(item, dict):
             continue
-        issue_id = str(item.get("issue_id") or item.get("issueId") or "").strip()
+        issue_id = str(item.get("issue_id") or "").strip()
         if not issue_id:
             continue
         started_at_epoch = float(
-            _first_value_or_default(now_epoch, item.get("started_at_epoch"), item.get("startedAtEpoch"))
+            _first_value_or_default(now_epoch, item.get("started_at_epoch"))
         )
         recovered_running.append(
             {
                 "issue_id": issue_id,
-                "worker_id": item.get("worker_id") or item.get("workerId") or f"worker:{issue_id}:recovered",
+                "worker_id": item.get("worker_id") or f"worker:{issue_id}:recovered",
                 "identifier": item.get("identifier"),
                 "attempt": int(item.get("attempt") or 0),
                 "state": item.get("state"),
-                "worker_status": item.get("worker_status") or item.get("workerStatus") or "recovered",
+                "worker_status": item.get("worker_status") or "recovered",
                 "started_at_epoch": started_at_epoch,
                 "heartbeat_at_epoch": float(
                     _first_value_or_default(
                         started_at_epoch,
                         item.get("heartbeat_at_epoch"),
-                        item.get("heartbeatAtEpoch"),
                     )
                 ),
-                "cancel_requested": bool(item.get("cancel_requested") or item.get("cancelRequested") or False),
-                "cancel_reason": item.get("cancel_reason") or item.get("cancelReason"),
-                "run_id": item.get("run_id") or item.get("runId"),
+                "cancel_requested": bool(item.get("cancel_requested") or False),
+                "cancel_reason": item.get("cancel_reason"),
+                "run_id": item.get("run_id"),
             }
         )
 
     return RestoredSchedulerState(
         retry_entries=retry_entries,
         recovered_running=recovered_running,
-        codex_totals=dict(payload.get("codex_totals") or payload.get("codexTotals") or {}),
-        codex_threads=restore_codex_threads(payload.get("codex_threads") or payload.get("codexThreads") or {}),
+        runtime_totals=dict(payload.get("runtime_totals") or {}),
+        runtime_sessions=restore_runtime_sessions(payload.get("runtime_sessions") or {}),
     )
 
 
@@ -125,7 +122,7 @@ def running_snapshot(
                 "cancel_reason": entry.get("cancel_reason"),
                 "thread_id": entry.get("thread_id"),
                 "turn_id": entry.get("turn_id"),
-                "run_id": entry.get("run_id") or entry.get("runId"),
+                "run_id": entry.get("run_id"),
             }
         )
     running.sort(key=lambda item: (item["state"] or "", item["identifier"] or item["issue_id"]))
@@ -148,14 +145,14 @@ def retry_queue_snapshot(
                 "error": entry.get("error"),
                 "due_at_epoch": due_at,
                 "due_in_ms": max(int((due_at - now_epoch) * 1000), 0),
-                "run_id": entry.get("run_id") or entry.get("runId"),
+                "run_id": entry.get("run_id"),
             }
         )
     entries.sort(key=lambda item: (item["due_in_ms"], item["attempt"], item["identifier"] or item["issue_id"]))
     return entries
 
 
-def restore_codex_threads(raw: Any) -> dict[str, dict[str, Any]]:
+def restore_runtime_sessions(raw: Any) -> dict[str, dict[str, Any]]:
     if not isinstance(raw, dict):
         return {}
     restored: dict[str, dict[str, Any]] = {}
@@ -172,16 +169,16 @@ def restore_codex_threads(raw: Any) -> dict[str, dict[str, Any]]:
             "session_name": item.get("session_name"),
             "thread_id": thread_id,
             "turn_id": item.get("turn_id"),
-            "run_id": item.get("run_id") or item.get("runId"),
+            "run_id": item.get("run_id"),
             "updated_at": item.get("updated_at"),
         }
     return restored
 
 
-def codex_threads_snapshot(codex_threads: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+def runtime_sessions_snapshot(runtime_sessions: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return {
         issue_id: dict(entry)
-        for issue_id, entry in sorted(codex_threads.items(), key=lambda item: item[0])
+        for issue_id, entry in sorted(runtime_sessions.items(), key=lambda item: item[0])
     }
 
 
@@ -190,16 +187,16 @@ def build_scheduler_payload(
     workflow: str,
     retry_entries: dict[str, dict[str, Any]],
     running_entries: dict[str, dict[str, Any]],
-    codex_totals: dict[str, Any] | None,
-    codex_threads: dict[str, dict[str, Any]],
+    runtime_totals: dict[str, Any] | None,
+    runtime_sessions: dict[str, dict[str, Any]],
     now_iso: str,
     now_epoch: float,
 ) -> dict[str, Any]:
     return {
         "workflow": workflow,
-        "updatedAt": now_iso,
+        "updated_at": now_iso,
         "retry_queue": retry_queue_snapshot(retry_entries, now_epoch=now_epoch),
         "running": running_snapshot(running_entries, now_epoch=now_epoch),
-        "codex_totals": dict(codex_totals or {}),
-        "codex_threads": codex_threads_snapshot(codex_threads),
+        "runtime_totals": dict(runtime_totals or {}),
+        "runtime_sessions": runtime_sessions_snapshot(runtime_sessions),
     }

--- a/daedalus/engine/state.py
+++ b/daedalus/engine/state.py
@@ -427,8 +427,8 @@ def save_engine_scheduler_state_to_connection(
     workflow: str,
     retry_entries: dict[str, dict[str, Any]],
     running_entries: dict[str, dict[str, Any]],
-    codex_totals: dict[str, Any] | None,
-    codex_threads: dict[str, dict[str, Any]],
+    runtime_totals: dict[str, Any] | None,
+    runtime_sessions: dict[str, dict[str, Any]],
     now_iso: str,
     now_epoch: float,
 ) -> None:
@@ -467,7 +467,7 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("cancel_reason"),
                 entry.get("thread_id"),
                 entry.get("turn_id"),
-                entry.get("run_id") or entry.get("runId"),
+                entry.get("run_id"),
                 now_iso,
                 now_epoch,
             ),
@@ -492,13 +492,13 @@ def save_engine_scheduler_state_to_connection(
                 entry.get("error"),
                 entry.get("current_attempt"),
                 entry.get("delay_type") or "failure",
-                entry.get("run_id") or entry.get("runId"),
+                entry.get("run_id"),
                 now_iso,
                 now_epoch,
             ),
         )
 
-    for work_id, entry in sorted(codex_threads.items(), key=lambda item: str(item[0])):
+    for work_id, entry in sorted(runtime_sessions.items(), key=lambda item: str(item[0])):
         if not isinstance(entry, dict):
             continue
         work_id = str(entry.get("issue_id") or work_id or "").strip()
@@ -523,9 +523,7 @@ def save_engine_scheduler_state_to_connection(
                 "cancel_requested",
                 "cancel_reason",
                 "run_id",
-                "runId",
                 "updated_at",
-                "updatedAt",
             }
         }
         conn.execute(
@@ -538,23 +536,23 @@ def save_engine_scheduler_state_to_connection(
             (
                 workflow,
                 work_id,
-                entry.get("session_name") or entry.get("sessionName"),
-                entry.get("runtime_name") or entry.get("runtimeName"),
-                entry.get("runtime_kind") or entry.get("runtimeKind"),
-                entry.get("session_id") or entry.get("sessionId"),
+                entry.get("session_name"),
+                entry.get("runtime_name"),
+                entry.get("runtime_kind"),
+                entry.get("session_id"),
                 thread_id,
-                entry.get("turn_id") or entry.get("turnId"),
+                entry.get("turn_id"),
                 entry.get("status"),
-                1 if (entry.get("cancel_requested") or entry.get("cancelRequested")) else 0,
-                entry.get("cancel_reason") or entry.get("cancelReason"),
-                entry.get("run_id") or entry.get("runId"),
+                1 if entry.get("cancel_requested") else 0,
+                entry.get("cancel_reason"),
+                entry.get("run_id"),
                 _json_dumps(metadata),
-                entry.get("updated_at") or entry.get("updatedAt") or now_iso,
+                entry.get("updated_at") or now_iso,
                 now_epoch,
             ),
         )
 
-    totals = dict(codex_totals or {})
+    totals = dict(runtime_totals or {})
     conn.execute(
         """
         INSERT INTO engine_runtime_totals (
@@ -588,8 +586,8 @@ def save_engine_scheduler_state(
     workflow: str,
     retry_entries: dict[str, dict[str, Any]],
     running_entries: dict[str, dict[str, Any]],
-    codex_totals: dict[str, Any] | None,
-    codex_threads: dict[str, dict[str, Any]],
+    runtime_totals: dict[str, Any] | None,
+    runtime_sessions: dict[str, dict[str, Any]],
     now_iso: str,
     now_epoch: float,
 ) -> None:
@@ -600,8 +598,8 @@ def save_engine_scheduler_state(
             workflow=workflow,
             retry_entries=retry_entries,
             running_entries=running_entries,
-            codex_totals=codex_totals,
-            codex_threads=codex_threads,
+            runtime_totals=runtime_totals,
+            runtime_sessions=runtime_sessions,
             now_iso=now_iso,
             now_epoch=now_epoch,
         )
@@ -684,7 +682,7 @@ def _scheduler_state_from_connection(
             "run_id": run_id,
         }
 
-    codex_threads: dict[str, dict[str, Any]] = {}
+    runtime_sessions: dict[str, dict[str, Any]] = {}
     session_run_id_expr = "s.run_id" if _column_exists(conn, "engine_runtime_sessions", "run_id") else "NULL"
     for row in conn.execute(
         f"""
@@ -729,7 +727,7 @@ def _scheduler_state_from_connection(
             "run_id": run_id,
             "updated_at": updated_at,
         }
-        codex_threads[str(work_id)] = {key: value for key, value in entry.items() if value is not None}
+        runtime_sessions[str(work_id)] = {key: value for key, value in entry.items() if value is not None}
 
     totals_row = conn.execute(
         """
@@ -739,10 +737,10 @@ def _scheduler_state_from_connection(
         """,
         (workflow,),
     ).fetchone()
-    codex_totals: dict[str, Any] = {}
+    runtime_totals: dict[str, Any] = {}
     if totals_row is not None:
         input_tokens, output_tokens, total_tokens, turn_count, rate_limits_json = totals_row
-        codex_totals = {
+        runtime_totals = {
             "input_tokens": int(input_tokens or 0),
             "output_tokens": int(output_tokens or 0),
             "total_tokens": int(total_tokens or 0),
@@ -750,14 +748,14 @@ def _scheduler_state_from_connection(
         }
         rate_limits = _json_loads(rate_limits_json)
         if rate_limits is not None:
-            codex_totals["rate_limits"] = rate_limits
+            runtime_totals["rate_limits"] = rate_limits
 
     return build_scheduler_payload(
         workflow=workflow,
         retry_entries=retry_entries,
         running_entries=running_entries,
-        codex_totals=codex_totals,
-        codex_threads=codex_threads,
+        runtime_totals=runtime_totals,
+        runtime_sessions=runtime_sessions,
         now_iso=now_iso,
         now_epoch=now_epoch,
     )

--- a/daedalus/engine/store.py
+++ b/daedalus/engine/store.py
@@ -109,8 +109,8 @@ class EngineStore:
         *,
         retry_entries: dict[str, dict[str, Any]],
         running_entries: dict[str, dict[str, Any]],
-        codex_totals: dict[str, Any] | None,
-        codex_threads: dict[str, dict[str, Any]],
+        runtime_totals: dict[str, Any] | None,
+        runtime_sessions: dict[str, dict[str, Any]],
         now_iso: str | None = None,
         now_epoch: float | None = None,
     ) -> None:
@@ -120,8 +120,8 @@ class EngineStore:
                 workflow=self.workflow,
                 retry_entries=retry_entries,
                 running_entries=running_entries,
-                codex_totals=codex_totals,
-                codex_threads=codex_threads,
+                runtime_totals=runtime_totals,
+                runtime_sessions=runtime_sessions,
                 now_iso=now_iso or self._now_iso(),
                 now_epoch=self._now_epoch() if now_epoch is None else now_epoch,
             )
@@ -311,15 +311,13 @@ class EngineStore:
     ) -> dict[str, Any]:
         event_payload = dict(payload or {})
         nested_payload = event_payload.get("payload") if isinstance(event_payload.get("payload"), dict) else {}
-        resolved_run_id = run_id or _payload_value(event_payload, "run_id", "runId") or _payload_value(
-            nested_payload, "run_id", "runId"
-        )
+        resolved_run_id = run_id or _payload_value(event_payload, "run_id") or _payload_value(nested_payload, "run_id")
         resolved_work_id = (
             work_id
-            or _payload_value(event_payload, "work_id", "workId", "issue_id", "issueId", "lane_id", "laneId")
-            or _payload_value(nested_payload, "work_id", "workId", "issue_id", "issueId", "lane_id", "laneId")
+            or _payload_value(event_payload, "work_id", "issue_id", "lane_id")
+            or _payload_value(nested_payload, "work_id", "issue_id", "lane_id")
         )
-        resolved_event_id = event_id or _payload_value(event_payload, "event_id", "eventId")
+        resolved_event_id = event_id or _payload_value(event_payload, "event_id")
         resolved_event_type = event_type or _payload_value(
             event_payload, "event_type", "event", "action", "type"
         ) or _payload_value(nested_payload, "event_type", "event", "action", "type") or "event"

--- a/daedalus/engine/work_items.py
+++ b/daedalus/engine/work_items.py
@@ -101,27 +101,3 @@ def work_item_from_issue(issue: dict[str, Any], *, source: str | None = None) ->
         source=source,
         metadata={"raw": issue},
     )
-
-
-def work_item_from_change_delivery_lane(lane: dict[str, Any]) -> WorkItemRef:
-    lane_id = str(lane.get("lane_id") or lane.get("laneId") or "").strip()
-    issue_number = lane.get("issue_number") or lane.get("issueNumber") or lane.get("github_issue_number")
-    if not lane_id:
-        if issue_number in (None, ""):
-            raise ValueError("change-delivery lane is missing lane_id and issue_number")
-        lane_id = f"lane:{issue_number}"
-    identifier = f"#{issue_number}" if issue_number not in (None, "") else lane_id
-    return WorkItemRef(
-        id=lane_id,
-        identifier=identifier,
-        state=str(lane.get("workflow_state") or lane.get("workflowState") or "").strip() or None,
-        title=str(lane.get("issue_title") or lane.get("issueTitle") or "").strip() or None,
-        url=str(lane.get("issue_url") or lane.get("issueUrl") or "").strip() or None,
-        source="change-delivery",
-        metadata={
-            "issue_number": issue_number,
-            "lane_status": lane.get("lane_status") or lane.get("laneStatus"),
-            "active_actor_id": lane.get("active_actor_id") or lane.get("activeActorId"),
-            "current_action_id": lane.get("current_action_id") or lane.get("currentActionId"),
-        },
-    )

--- a/daedalus/formatters.py
+++ b/daedalus/formatters.py
@@ -238,7 +238,7 @@ def format_status(
         last_run = result.get("lastRun") or {}
         metrics = result.get("metrics") or {}
         tokens = metrics.get("tokens") or {}
-        totals = scheduler.get("codex_totals") or {}
+        totals = scheduler.get("runtime_totals") or {}
         tracker_rows = [
             Row(label="workflow", value=str(result.get("workflow") or EMPTY_VALUE)),
             Row(label="health", value=str(result.get("health") or EMPTY_VALUE)),

--- a/daedalus/runtime.py
+++ b/daedalus/runtime.py
@@ -627,6 +627,15 @@ def _workflow_root_from_event_log_path(event_log_path: Path) -> Path:
     return base_dir.parent if base_dir.name == "runtime" else base_dir
 
 
+def _workflow_name_from_root(workflow_root: Path) -> str | None:
+    try:
+        contract = load_workflow_contract(workflow_root)
+    except (FileNotFoundError, WorkflowContractError, OSError, UnicodeDecodeError):
+        return None
+    workflow = str(contract.config.get("workflow") or "").strip()
+    return workflow or None
+
+
 def _event_payload_value(event: dict[str, Any], *keys: str) -> Any:
     for key in keys:
         value = event.get(key)
@@ -647,7 +656,7 @@ def append_daedalus_event(*, event_log_path: Path, event: dict[str, Any]) -> dic
         handle.write(json.dumps(event, sort_keys=True) + "\n")
     try:
         workflow_root = _workflow_root_from_event_log_path(event_log_path)
-        workflow = str(_event_payload_value(event, "workflow") or "change-delivery")
+        workflow = str(_event_payload_value(event, "workflow") or _workflow_name_from_root(workflow_root) or "unknown")
         EngineStore(
             db_path=runtime_paths(workflow_root)["db_path"],
             workflow=workflow,
@@ -4041,7 +4050,7 @@ def _active_loop_cancel_reason(
     return "no-active-lane" if current_lane_id is None else "active-lane-changed"
 
 
-def _interrupt_active_loop_codex_turn(
+def _interrupt_active_loop_runtime_turn(
     *,
     workflow_root: Path,
     supervised_iteration: dict[str, Any],
@@ -4073,7 +4082,7 @@ def _request_active_loop_cancel(
     future = supervised_iteration.get("future")
     if isinstance(future, concurrent.futures.Future):
         future.cancel()
-    interrupt_result = _interrupt_active_loop_codex_turn(
+    interrupt_result = _interrupt_active_loop_runtime_turn(
         workflow_root=workflow_root,
         supervised_iteration=supervised_iteration,
         reason=reason,

--- a/daedalus/runtimes/capabilities.py
+++ b/daedalus/runtimes/capabilities.py
@@ -112,6 +112,8 @@ def runtime_profile_capabilities(runtime_cfg: Mapping[str, Any] | None) -> Runti
         mode = str(cfg.get("mode") or ("external" if cfg.get("endpoint") else "managed")).strip()
         if mode == "external":
             capabilities.add(CAP_SERVICE_REQUIRED)
+    if cfg.get("stage-command") is False or cfg.get("stage_command") is False:
+        capabilities.discard(CAP_COMMAND_STAGE)
     return RuntimeCapabilityProfile(
         kind=profile.kind,
         capabilities=frozenset(capabilities),

--- a/daedalus/runtimes/stages.py
+++ b/daedalus/runtimes/stages.py
@@ -96,13 +96,15 @@ def resolve_stage_command(*, agent_cfg: dict[str, Any], runtime_cfg: dict[str, A
     if command:
         return _ensure_argv(command)
 
-    command = runtime_cfg.get("command")
-    if not command:
+    if runtime_cfg.get("stage-command") is False or runtime_cfg.get("stage_command") is False:
         return None
 
-    # For codex-app-server, runtime.command starts/connects the app-server
-    # transport. It is not a per-stage agent command.
-    if str(runtime_cfg.get("kind") or "") == "codex-app-server":
+    command_role = str(runtime_cfg.get("command-role") or runtime_cfg.get("command_role") or "stage").strip()
+    if command_role != "stage":
+        return None
+
+    command = runtime_cfg.get("command")
+    if not command:
         return None
     return _ensure_argv(command)
 

--- a/daedalus/watch.py
+++ b/daedalus/watch.py
@@ -31,7 +31,7 @@ def _lanes_table(lanes: list[dict[str, Any]]) -> Table:
         t.add_row(
             str(lane.get("lane_id") or ""),
             str(lane.get("state") or ""),
-            str(lane.get("issue_identifier") or lane.get("github_issue_number") or ""),
+            str(lane.get("issue_identifier") or lane.get("issue_number") or ""),
         )
     return t
 
@@ -87,14 +87,14 @@ def _workflow_status_panel(workflow_status: Mapping[str, Any]) -> Panel | None:
             f"selected={run.get('selected_count') or 0} "
             f"completed={run.get('completed_count') or 0}"
         )
-    for turn in workflow_status.get("codex_turns") or []:
-        if turn.get("status") == "canceling" or turn.get("cancel_requested"):
+    for session in workflow_status.get("runtime_sessions") or []:
+        if session.get("status") == "canceling" or session.get("cancel_requested"):
             lines.append(
-                "codex_canceling="
-                f"{turn.get('issue_identifier') or turn.get('issue_id')} "
-                f"thread={turn.get('thread_id')} "
-                f"turn={turn.get('turn_id')} "
-                f"reason={turn.get('cancel_reason') or '?'}"
+                "runtime_canceling="
+                f"{session.get('issue_identifier') or session.get('issue_id')} "
+                f"thread={session.get('thread_id')} "
+                f"turn={session.get('turn_id')} "
+                f"reason={session.get('cancel_reason') or '?'}"
             )
     if workflow_status.get("updated_at"):
         lines.append(f"updated_at={workflow_status.get('updated_at')}")

--- a/daedalus/watch_sources.py
+++ b/daedalus/watch_sources.py
@@ -20,7 +20,8 @@ from pathlib import Path
 from typing import Any
 
 from engine.state import read_engine_events, read_engine_runs, read_engine_scheduler_state
-from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
+from engine.work_items import work_item_from_issue
+from workflows.change_delivery.work_items import lane_to_work_item_ref
 from workflows.contract import WorkflowContractError, load_workflow_contract
 
 # Sibling-import boilerplate.
@@ -131,7 +132,7 @@ def recent_workflow_audit(workflow_root: Path, limit: int = 50) -> list[dict[str
 def recent_engine_events(workflow_root: Path, limit: int = 50) -> list[dict[str, Any]]:
     workflow_root = Path(workflow_root)
     workflow = _workflow_name(workflow_root)
-    if workflow not in {"issue-runner", "change-delivery"}:
+    if not workflow:
         return []
     return [
         {**event, "source": "engine-events"}
@@ -146,8 +147,11 @@ def recent_engine_events(workflow_root: Path, limit: int = 50) -> list[dict[str,
 
 def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
     workflow_root = Path(workflow_root)
-    if _workflow_name(workflow_root) == "issue-runner":
-        scheduler = _engine_scheduler(workflow_root, "issue-runner")
+    workflow_name = _workflow_name(workflow_root)
+    if not workflow_name:
+        return []
+    if workflow_name == "issue-runner":
+        scheduler = _engine_scheduler(workflow_root, workflow_name)
         out: list[dict[str, Any]] = []
         for row in scheduler.get("running") or []:
             if not isinstance(row, dict):
@@ -166,8 +170,6 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                     "lane_id": row.get("issue_id"),
                     "state": row.get("state") or "running",
                     "workflow_state": row.get("state") or "running",
-                    "github_issue_number": identifier,
-                    "issue_number": identifier,
                     "issue_identifier": identifier,
                     "lane_status": "active",
                     "kind": "running",
@@ -191,8 +193,6 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                     "lane_id": row.get("issue_id"),
                     "state": "retrying",
                     "workflow_state": "retrying",
-                    "github_issue_number": identifier,
-                    "issue_number": identifier,
                     "issue_identifier": identifier,
                     "lane_status": "retrying",
                     "kind": "retrying",
@@ -200,6 +200,21 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                 }
             )
         return out
+
+    if workflow_name != "change-delivery":
+        scheduler = _engine_scheduler(workflow_root, workflow_name)
+        return [
+            {
+                "lane_id": row.get("issue_id"),
+                "state": row.get("state") or row.get("worker_status") or "running",
+                "workflow_state": row.get("state") or row.get("worker_status") or "running",
+                "issue_identifier": row.get("identifier") or row.get("issue_id"),
+                "lane_status": row.get("worker_status") or "running",
+                "kind": "running",
+            }
+            for row in (scheduler.get("running") or [])
+            if isinstance(row, dict)
+        ]
 
     paths = runtime_paths(Path(workflow_root))
     db_path = paths["db_path"]
@@ -212,7 +227,8 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
     try:
         # Real columns per runtime.py lanes schema:
         #   lane_id (PK), issue_number, workflow_state, lane_status, ...
-        # An earlier draft queried `state` and `github_issue_number` which
+        # An earlier draft queried generic display aliases instead of the
+        # real lanes schema, which
         # raised sqlite3.OperationalError against any real db, silently
         # returning [] and making /daedalus watch falsely report
         # "no active lanes" even when lanes existed.
@@ -230,11 +246,11 @@ def active_lanes(workflow_root: Path) -> list[dict[str, Any]]:
                 # consumers that care.
                 "state": row[1],
                 "workflow_state": row[1],
-                "github_issue_number": row[2],
                 "issue_number": row[2],
+                "issue_identifier": f"#{row[2]}",
                 "lane_status": row[3],
             }
-            lane["work_item"] = work_item_from_change_delivery_lane(lane).to_dict()
+            lane["work_item"] = lane_to_work_item_ref(lane).to_dict()
             out.append(lane)
     except sqlite3.OperationalError:
         out = []
@@ -254,23 +270,23 @@ def alert_state(workflow_root: Path) -> dict[str, Any]:
         return {}
 
 
-def _codex_turn_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
+def _runtime_session_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
     entries = []
-    for issue_id, raw_entry in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).items():
+    for issue_id, raw_entry in (scheduler.get("runtime_sessions") or {}).items():
         if not isinstance(raw_entry, dict):
             continue
-        issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+        issue_number = raw_entry.get("issue_number")
         entries.append(
             {
                 "issue_id": raw_entry.get("issue_id") or issue_id,
                 "issue_number": issue_number,
                 "issue_identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
-                "thread_id": raw_entry.get("thread_id") or raw_entry.get("threadId"),
-                "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                "thread_id": raw_entry.get("thread_id"),
+                "turn_id": raw_entry.get("turn_id"),
                 "status": raw_entry.get("status"),
-                "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
-                "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
-                "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+                "cancel_requested": bool(raw_entry.get("cancel_requested") or False),
+                "cancel_reason": raw_entry.get("cancel_reason"),
+                "updated_at": raw_entry.get("updated_at"),
             }
         )
     return sorted(entries, key=lambda item: str(item.get("issue_id") or ""))
@@ -279,44 +295,61 @@ def _codex_turn_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
 def workflow_status(workflow_root: Path) -> dict[str, Any]:
     workflow_root = Path(workflow_root)
     workflow_name = _workflow_name(workflow_root)
-    if workflow_name not in {"issue-runner", "change-delivery"}:
+    if not workflow_name:
         return {}
     if workflow_name == "change-delivery":
         scheduler_payload = _engine_scheduler(workflow_root, "change-delivery")
-        totals = scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {}
-        codex_turns = _codex_turn_entries(scheduler_payload)
+        totals = scheduler_payload.get("runtime_totals") or {}
+        runtime_sessions = _runtime_session_entries(scheduler_payload)
         latest_runs = _engine_runs(workflow_root, "change-delivery")
         return {
             "workflow": "change-delivery",
             "health": None,
-            "updated_at": scheduler_payload.get("updatedAt"),
-            "running_count": len([entry for entry in codex_turns if entry.get("status") == "running"]),
+            "updated_at": scheduler_payload.get("updated_at"),
+            "running_count": len([entry for entry in runtime_sessions if entry.get("status") == "running"]),
             "retry_count": 0,
-            "canceling_count": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
+            "canceling_count": len([entry for entry in runtime_sessions if entry.get("status") == "canceling"]),
             "selected_issue": None,
-            "codex_turns": codex_turns,
+            "runtime_sessions": runtime_sessions,
             "latest_runs": latest_runs,
             "total_tokens": int(totals.get("total_tokens") or 0),
             "rate_limits": totals.get("rate_limits"),
         }
+    if workflow_name != "issue-runner":
+        scheduler_payload = _engine_scheduler(workflow_root, workflow_name)
+        totals = scheduler_payload.get("runtime_totals") or {}
+        running = scheduler_payload.get("running") or []
+        retry_queue = scheduler_payload.get("retry_queue") or []
+        return {
+            "workflow": workflow_name,
+            "health": None,
+            "updated_at": scheduler_payload.get("updated_at"),
+            "running_count": len(running),
+            "retry_count": len(retry_queue),
+            "selected_issue": None,
+            "latest_runs": _engine_runs(workflow_root, workflow_name),
+            "total_tokens": int(totals.get("total_tokens") or 0),
+            "rate_limits": totals.get("rate_limits"),
+        }
+
     status_path = _resolve_issue_runner_storage_path(workflow_root, "status", "memory/workflow-status.json")
     status_payload = _load_optional_json(status_path) or {}
     scheduler_payload = _engine_scheduler(workflow_root, "issue-runner")
     scheduler = {
         "running": scheduler_payload.get("running") or [],
-        "retry_queue": scheduler_payload.get("retry_queue") or scheduler_payload.get("retryQueue") or [],
-        "codex_totals": scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {},
+        "retry_queue": scheduler_payload.get("retry_queue") or [],
+        "runtime_totals": scheduler_payload.get("runtime_totals") or {},
     }
     last_run = status_payload.get("lastRun") or {}
     latest_runs = _engine_runs(workflow_root, "issue-runner")
     return {
         "workflow": "issue-runner",
         "health": status_payload.get("health"),
-        "updated_at": scheduler_payload.get("updatedAt") or last_run.get("updatedAt"),
+        "updated_at": scheduler_payload.get("updated_at") or last_run.get("updatedAt"),
         "running_count": len(scheduler["running"]),
         "retry_count": len(scheduler["retry_queue"]),
         "selected_issue": ((last_run.get("issue") or {}).get("identifier") or (last_run.get("issue") or {}).get("id")),
         "latest_runs": latest_runs,
-        "total_tokens": int((scheduler["codex_totals"].get("total_tokens") or 0)),
-        "rate_limits": scheduler["codex_totals"].get("rate_limits"),
+        "total_tokens": int((scheduler["runtime_totals"].get("total_tokens") or 0)),
+        "rate_limits": scheduler["runtime_totals"].get("rate_limits"),
     }

--- a/daedalus/workflows/change_delivery/__init__.py
+++ b/daedalus/workflows/change_delivery/__init__.py
@@ -13,10 +13,12 @@ This package satisfies the daedalus workflow-plugin contract:
 - cli_main(workspace, argv): argparse-backed CLI dispatcher
 """
 from pathlib import Path
+from typing import Any
 
 NAME = "change-delivery"
 SUPPORTED_SCHEMA_VERSIONS = (1,)
 CONFIG_SCHEMA_PATH = Path(__file__).parent / "schema.yaml"
+SERVICE_MODES = frozenset({"shadow", "active"})
 
 # Codex P1 on PR #21: preflight must ONLY gate commands that actually
 # attempt dispatch. Diagnostic / repair / read-only commands like status,
@@ -42,6 +44,7 @@ PREFLIGHT_GATED_COMMANDS = frozenset({
 })
 
 from workflows.change_delivery.workspace import make_workspace as _make_workspace_inner
+from workflows.change_delivery.workspace import load_workspace_from_config
 from workflows.change_delivery.cli import main as cli_main
 from workflows.change_delivery.preflight import run_preflight
 
@@ -57,12 +60,97 @@ def make_workspace(*, workflow_root: Path, config: dict):
     return _make_workspace_inner(workspace_root=workflow_root, config=config)
 
 
+def _instance_id_for(*, service_mode: str, workflow_root: Path) -> str:
+    return f"daedalus-{service_mode}-{workflow_root.name}"
+
+
+def _ensure_active_lane_for_service(workflow_root: Path) -> dict[str, Any]:
+    try:
+        workspace = load_workspace_from_config(workspace_root=workflow_root)
+        return workspace.ensure_active_lane()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "promoted": False,
+            "reason": "active-lane-selection-failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def service_prepare(
+    *,
+    workflow_root: Path,
+    project_key: str | None,
+    service_mode: str,
+) -> dict[str, Any]:
+    import runtime as daedalus_runtime
+
+    resolved_project_key = project_key or daedalus_runtime._project_key_for(workflow_root)
+    init_result = daedalus_runtime.init_daedalus_db(
+        workflow_root=workflow_root,
+        project_key=resolved_project_key,
+    )
+    lane_selection = _ensure_active_lane_for_service(workflow_root) if service_mode == "active" else None
+    return {
+        "ok": bool(init_result.get("ok", True)) and not (
+            lane_selection is not None and lane_selection.get("ok") is False
+        ),
+        "workflow": NAME,
+        "project_key": resolved_project_key,
+        "service_mode": service_mode,
+        "init": init_result,
+        "lane_selection": lane_selection,
+    }
+
+
+def service_loop(
+    *,
+    workflow_root: Path,
+    project_key: str | None,
+    instance_id: str | None,
+    interval_seconds: int,
+    max_iterations: int | None,
+    service_mode: str,
+) -> dict[str, Any]:
+    import runtime as daedalus_runtime
+
+    resolved_project_key = project_key or daedalus_runtime._project_key_for(workflow_root)
+    resolved_instance_id = instance_id or _instance_id_for(
+        service_mode=service_mode,
+        workflow_root=workflow_root,
+    )
+    if service_mode == "shadow":
+        result = daedalus_runtime.run_shadow_loop(
+            workflow_root=workflow_root,
+            project_key=resolved_project_key,
+            instance_id=resolved_instance_id,
+            interval_seconds=interval_seconds,
+            max_iterations=max_iterations,
+        )
+        return {"workflow": NAME, "service_mode": service_mode, **result}
+    if service_mode != "active":
+        raise ValueError(f"change-delivery does not support service_mode={service_mode!r}")
+    lane_selection = _ensure_active_lane_for_service(workflow_root)
+    result = daedalus_runtime.run_active_loop(
+        workflow_root=workflow_root,
+        project_key=resolved_project_key,
+        instance_id=resolved_instance_id,
+        interval_seconds=interval_seconds,
+        max_iterations=max_iterations,
+    )
+    result["lane_selection"] = lane_selection
+    return {"workflow": NAME, "service_mode": service_mode, **result}
+
+
 __all__ = [
     "NAME",
     "SUPPORTED_SCHEMA_VERSIONS",
     "CONFIG_SCHEMA_PATH",
     "PREFLIGHT_GATED_COMMANDS",
+    "SERVICE_MODES",
     "make_workspace",
     "cli_main",
     "run_preflight",
+    "service_prepare",
+    "service_loop",
 ]

--- a/daedalus/workflows/change_delivery/orchestrator.py
+++ b/daedalus/workflows/change_delivery/orchestrator.py
@@ -475,23 +475,23 @@ def reconcile(workspace: Any, *, write_health: bool = True, fix_watchers: bool =
                 headSha=pre_publish_review_preflight.get("currentHeadSha"),
             )
 
-    resolved_codex_threads = ws._resolve_codex_superseded_threads(
+    resolved_runtime_sessions = ws._resolve_codex_superseded_threads(
         get_review(reviews, "externalReview"),
         current_head_sha=(open_pr or {}).get("headRefOid"),
     )
-    if resolved_codex_threads:
+    if resolved_runtime_sessions:
         resolution_event = {
             "at": now_iso,
             "headSha": (open_pr or {}).get("headRefOid"),
             "prNumber": (open_pr or {}).get("number"),
             "signal": (get_review(reviews, "externalReview").get("prBodySignal") or {}).get("content"),
-            "threadIds": resolved_codex_threads,
+            "threadIds": resolved_runtime_sessions,
         }
         ledger["externalReviewAutoResolved"] = resolution_event
         ws.audit(
             "reconcile",
             "Resolved superseded external review threads after clean PR-body signal",
-            threadIds=resolved_codex_threads,
+            threadIds=resolved_runtime_sessions,
             activeLane=(active_lane or {}).get("number"),
             prNumber=(open_pr or {}).get("number"),
             headSha=(open_pr or {}).get("headRefOid"),

--- a/daedalus/workflows/change_delivery/schema.yaml
+++ b/daedalus/workflows/change_delivery/schema.yaml
@@ -457,6 +457,8 @@ definitions:
     required: [kind]
     properties:
       kind: {const: codex-app-server}
+      stage-command: {type: boolean}
+      stage_command: {type: boolean}
       command:
         oneOf:
           - type: string

--- a/daedalus/workflows/change_delivery/server/html.py
+++ b/daedalus/workflows/change_delivery/server/html.py
@@ -124,7 +124,7 @@ def render_dashboard(state: dict[str, Any]) -> str:
     running = state.get("running") or []
     retrying = state.get("retrying") or []
     events = state.get("recent_events") or []
-    totals = state.get("codex_totals") or {}
+    totals = state.get("runtime_totals") or {}
     rate_limits = state.get("rate_limits")
 
     parts: list[str] = [_PAGE_HEAD]

--- a/daedalus/workflows/change_delivery/server/views.py
+++ b/daedalus/workflows/change_delivery/server/views.py
@@ -8,7 +8,7 @@ JSONL events log on disk per request.
 Shape conforms to Symphony §13.7 (spec §6.4):
 
 - ``state_view`` returns a snapshot of running + retrying work plus a
-  ``codex_totals`` block. `change-delivery` keeps the lane-backed domain
+  ``runtime_totals`` block. `change-delivery` keeps the lane-backed domain
   model; engine execution state is projected from shared SQLite tables.
 - ``issue_view`` returns the per-lane shape, or ``None`` if the
   identifier is unknown.
@@ -352,12 +352,12 @@ def run_view(workflow_root: Path, events_log_path: Path, run_id: str) -> dict[st
     ]
     retrying = [
         row
-        for row in (scheduler.get("retry_queue") or scheduler.get("retryQueue") or [])
+        for row in (scheduler.get("retry_queue") or [])
         if isinstance(row, dict) and _event_run_id(row) == run_id
     ]
-    codex_threads = [
+    runtime_sessions = [
         row
-        for row in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).values()
+        for row in (scheduler.get("runtime_sessions") or {}).values()
         if isinstance(row, dict) and _event_run_id(row) == run_id
     ]
     return {
@@ -367,7 +367,7 @@ def run_view(workflow_root: Path, events_log_path: Path, run_id: str) -> dict[st
         "related": {
             "running": running,
             "retrying": retrying,
-            "codex_threads": codex_threads,
+            "runtime_sessions": runtime_sessions,
         },
         "timeline": _run_timeline(workflow_root, events_log_path, run_id),
     }
@@ -480,30 +480,30 @@ def _issue_runner_state_view(workflow_root: Path, events_log_path: Path) -> dict
     ]
     retry_rows = [
         _issue_runner_retry_entry(row)
-        for row in (scheduler_payload.get("retry_queue") or scheduler_payload.get("retryQueue") or [])
+        for row in (scheduler_payload.get("retry_queue") or [])
         if isinstance(row, dict)
     ]
-    codex_totals = dict(scheduler_payload.get("codex_totals") or scheduler_payload.get("codexTotals") or {})
+    runtime_totals = dict(scheduler_payload.get("runtime_totals") or {})
     seconds_running = sum(int((row.get("running_for_ms") or 0)) for row in (scheduler_payload.get("running") or []) if isinstance(row, dict)) // 1000
     recent_events = _issue_runner_recent_events(
         workflow_root,
         events_log_path=events_log_path,
         audit_log_path=audit_log_path,
     )
-    rate_limits = codex_totals.pop("rate_limits", None)
+    rate_limits = runtime_totals.pop("rate_limits", None)
     totals = {
-        "input_tokens": int(codex_totals.get("input_tokens") or 0),
-        "output_tokens": int(codex_totals.get("output_tokens") or 0),
-        "total_tokens": int(codex_totals.get("total_tokens") or 0),
+        "input_tokens": int(runtime_totals.get("input_tokens") or 0),
+        "output_tokens": int(runtime_totals.get("output_tokens") or 0),
+        "total_tokens": int(runtime_totals.get("total_tokens") or 0),
         "seconds_running": seconds_running,
     }
     return {
-        "generated_at": scheduler_payload.get("updatedAt") or ((status_payload.get("lastRun") or {}).get("updatedAt")) or _now_iso(),
+        "generated_at": scheduler_payload.get("updated_at") or ((status_payload.get("lastRun") or {}).get("updatedAt")) or _now_iso(),
         "counts": {"running": len(running_rows), "retrying": len(retry_rows)},
         "running": running_rows,
         "retrying": retry_rows,
         "latest_runs": _engine_runs(workflow_root, "issue-runner"),
-        "codex_totals": totals,
+        "runtime_totals": totals,
         "rate_limits": rate_limits,
         "recent_events": recent_events,
     }
@@ -537,26 +537,26 @@ def _issue_runner_issue_view(
     return {**entry, "recent_events": issue_events}
 
 
-def _codex_turn_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
+def _runtime_session_entries(scheduler: dict[str, Any]) -> list[dict[str, Any]]:
     entries = []
-    for issue_id, raw_entry in (scheduler.get("codex_threads") or scheduler.get("codexThreads") or {}).items():
+    for issue_id, raw_entry in (scheduler.get("runtime_sessions") or {}).items():
         if not isinstance(raw_entry, dict):
             continue
-        issue_number = raw_entry.get("issue_number") or raw_entry.get("issueNumber")
+        issue_number = raw_entry.get("issue_number")
         entries.append(
             {
                 "issue_id": raw_entry.get("issue_id") or issue_id,
                 "issue_number": issue_number,
                 "issue_identifier": raw_entry.get("identifier") or (f"#{issue_number}" if issue_number else issue_id),
-                "session_name": raw_entry.get("session_name") or raw_entry.get("sessionName"),
-                "runtime_name": raw_entry.get("runtime_name") or raw_entry.get("runtimeName"),
-                "runtime_kind": raw_entry.get("runtime_kind") or raw_entry.get("runtimeKind"),
-                "thread_id": raw_entry.get("thread_id") or raw_entry.get("threadId"),
-                "turn_id": raw_entry.get("turn_id") or raw_entry.get("turnId"),
+                "session_name": raw_entry.get("session_name"),
+                "runtime_name": raw_entry.get("runtime_name"),
+                "runtime_kind": raw_entry.get("runtime_kind"),
+                "thread_id": raw_entry.get("thread_id"),
+                "turn_id": raw_entry.get("turn_id"),
                 "status": raw_entry.get("status"),
-                "cancel_requested": bool(raw_entry.get("cancel_requested") or raw_entry.get("cancelRequested") or False),
-                "cancel_reason": raw_entry.get("cancel_reason") or raw_entry.get("cancelReason"),
-                "updated_at": raw_entry.get("updated_at") or raw_entry.get("updatedAt"),
+                "cancel_requested": bool(raw_entry.get("cancel_requested") or False),
+                "cancel_reason": raw_entry.get("cancel_reason"),
+                "updated_at": raw_entry.get("updated_at"),
             }
         )
     return sorted(entries, key=lambda item: str(item.get("issue_id") or ""))
@@ -572,24 +572,24 @@ def state_view(db_path: Path, events_log_path: Path, workflow_root: Path | None 
         events = _read_events_tail(events_log_path, _RECENT_EVENTS_LIMIT)
     running = [_lane_to_running_entry(lane, events) for lane in lanes]
     scheduler = _engine_scheduler(workflow_root, "change-delivery")
-    codex_totals = dict(scheduler.get("codex_totals") or scheduler.get("codexTotals") or {})
-    rate_limits = codex_totals.pop("rate_limits", None)
-    codex_turns = _codex_turn_entries(scheduler)
+    runtime_totals = dict(scheduler.get("runtime_totals") or {})
+    rate_limits = runtime_totals.pop("rate_limits", None)
+    runtime_sessions = _runtime_session_entries(scheduler)
     return {
         "generated_at": _now_iso(),
         "counts": {"running": len(running), "retrying": 0},
         "running": running,
         "retrying": [],
-        "codex_turns": codex_turns,
-        "codex_turn_counts": {
-            "running": len([entry for entry in codex_turns if entry.get("status") == "running"]),
-            "canceling": len([entry for entry in codex_turns if entry.get("status") == "canceling"]),
+        "runtime_sessions": runtime_sessions,
+        "runtime_session_counts": {
+            "running": len([entry for entry in runtime_sessions if entry.get("status") == "running"]),
+            "canceling": len([entry for entry in runtime_sessions if entry.get("status") == "canceling"]),
         },
         "latest_runs": _engine_runs(workflow_root, "change-delivery"),
-        "codex_totals": {
-            "input_tokens": int(codex_totals.get("input_tokens") or 0),
-            "output_tokens": int(codex_totals.get("output_tokens") or 0),
-            "total_tokens": int(codex_totals.get("total_tokens") or 0),
+        "runtime_totals": {
+            "input_tokens": int(runtime_totals.get("input_tokens") or 0),
+            "output_tokens": int(runtime_totals.get("output_tokens") or 0),
+            "total_tokens": int(runtime_totals.get("total_tokens") or 0),
             "seconds_running": 0,
         },
         "rate_limits": rate_limits,

--- a/daedalus/workflows/change_delivery/storage.py
+++ b/daedalus/workflows/change_delivery/storage.py
@@ -76,8 +76,8 @@ def default_scheduler_payload(*, now_iso: str | None = None) -> dict[str, Any]:
         "updatedAt": now_iso,
         "running": [],
         "retry_queue": [],
-        "codex_threads": {},
-        "codex_totals": {},
+        "runtime_sessions": {},
+        "runtime_totals": {},
     }
 
 

--- a/daedalus/workflows/change_delivery/work_items.py
+++ b/daedalus/workflows/change_delivery/work_items.py
@@ -2,9 +2,29 @@ from __future__ import annotations
 
 from typing import Any
 
-from engine.work_items import WorkItemRef, work_item_from_change_delivery_lane
+from engine.work_items import WorkItemRef
 
 
 def lane_to_work_item_ref(lane: dict[str, Any]) -> WorkItemRef:
     """Expose a change-delivery lane through the shared engine work-item shape."""
-    return work_item_from_change_delivery_lane(lane)
+    lane_id = str(lane.get("lane_id") or "").strip()
+    issue_number = lane.get("issue_number")
+    if not lane_id:
+        if issue_number in (None, ""):
+            raise ValueError("change-delivery lane is missing lane_id and issue_number")
+        lane_id = f"lane:{issue_number}"
+    identifier = f"#{issue_number}" if issue_number not in (None, "") else lane_id
+    return WorkItemRef(
+        id=lane_id,
+        identifier=identifier,
+        state=str(lane.get("workflow_state") or "").strip() or None,
+        title=str(lane.get("issue_title") or "").strip() or None,
+        url=str(lane.get("issue_url") or "").strip() or None,
+        source="change-delivery",
+        metadata={
+            "issue_number": issue_number,
+            "lane_status": lane.get("lane_status"),
+            "active_actor_id": lane.get("active_actor_id"),
+            "current_action_id": lane.get("current_action_id"),
+        },
+    )

--- a/daedalus/workflows/change_delivery/workflow.template.md
+++ b/daedalus/workflows/change_delivery/workflow.template.md
@@ -26,6 +26,7 @@ code-host:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -529,8 +529,8 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
         engine_store.save_scheduler(
             retry_entries={},
             running_entries={},
-            codex_totals=payload.get("codex_totals") or payload.get("codexTotals") or {},
-            codex_threads=payload.get("codex_threads") or payload.get("codexThreads") or {},
+            runtime_totals=payload.get("runtime_totals") or {},
+            runtime_sessions=payload.get("runtime_sessions") or {},
             now_iso=payload.get("updatedAt") or _now_iso(),
             now_epoch=time.time(),
         )
@@ -750,6 +750,7 @@ def make_workspace(*, workspace_root: Path, config: dict[str, Any]) -> SimpleNam
     _default_runtimes_cfg = {
         "codex-app-server": {
             "kind": "codex-app-server",
+            "stage-command": False,
             "mode": "external",
             "endpoint": "ws://127.0.0.1:4500",
             "healthcheck_path": "/readyz",
@@ -963,7 +964,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
         thread_id = ns._codex_thread_for_issue_number(issue_number)
         if thread_id:
-            entry = ((ns.load_scheduler().get("codex_threads") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
+            entry = ((ns.load_scheduler().get("runtime_sessions") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
             return {
                 "name": session_name,
                 "closed": False,
@@ -1273,7 +1274,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         key = ns._scheduler_issue_key(issue_number)
         if not key:
             return None
-        entry = ((ns.load_scheduler().get("codex_threads") or {}).get(key) or {})
+        entry = ((ns.load_scheduler().get("runtime_sessions") or {}).get(key) or {})
         thread_id = str(entry.get("thread_id") or "").strip()
         return thread_id or None
 
@@ -1282,14 +1283,14 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         if not key:
             return False
         scheduler = ns.load_scheduler()
-        threads = dict(scheduler.get("codex_threads") or {})
+        threads = dict(scheduler.get("runtime_sessions") or {})
         if key not in threads:
             return False
         threads.pop(key, None)
         scheduler["workflow"] = "change-delivery"
         scheduler["updatedAt"] = ns._now_iso()
-        scheduler["codex_threads"] = threads
-        scheduler.setdefault("codex_totals", {})
+        scheduler["runtime_sessions"] = threads
+        scheduler.setdefault("runtime_totals", {})
         ns.save_scheduler(scheduler)
         return True
 
@@ -1301,7 +1302,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         if not key:
             return metrics
         scheduler = ns.load_scheduler()
-        threads = dict(scheduler.get("codex_threads") or {})
+        threads = dict(scheduler.get("runtime_sessions") or {})
         thread_id = str(metrics.get("thread_id") or metrics.get("session_id") or "").strip()
         if thread_id:
             threads[key] = {
@@ -1319,7 +1320,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
                 "run_id": getattr(ns, "CURRENT_ENGINE_RUN_ID", None),
                 "updated_at": at,
             }
-        totals = dict(scheduler.get("codex_totals") or {})
+        totals = dict(scheduler.get("runtime_totals") or {})
         tokens = metrics.get("tokens") or {}
         totals["input_tokens"] = int(totals.get("input_tokens") or 0) + int(tokens.get("input_tokens") or 0)
         totals["output_tokens"] = int(totals.get("output_tokens") or 0) + int(tokens.get("output_tokens") or 0)
@@ -1331,8 +1332,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             {
                 "workflow": "change-delivery",
                 "updatedAt": ns._now_iso(),
-                "codex_threads": threads,
-                "codex_totals": totals,
+                "runtime_sessions": threads,
+                "runtime_totals": totals,
             }
         )
         ns.save_scheduler(scheduler)
@@ -1349,7 +1350,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
         if not key:
             return None
         scheduler = ns.load_scheduler()
-        threads = dict(scheduler.get("codex_threads") or {})
+        threads = dict(scheduler.get("runtime_sessions") or {})
         prior = dict(threads.get(key) or {})
         threads[key] = {
             **prior,
@@ -1372,8 +1373,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             {
                 "workflow": "change-delivery",
                 "updatedAt": ns._now_iso(),
-                "codex_threads": threads,
-                "codex_totals": scheduler.get("codex_totals") or {},
+                "runtime_sessions": threads,
+                "runtime_totals": scheduler.get("runtime_totals") or {},
             }
         )
         ns.save_scheduler(scheduler)
@@ -1381,7 +1382,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
 
     def _interrupt_active_implementation_turn(*, issue_number=None, reason="cancel-requested"):
         scheduler = ns.load_scheduler()
-        threads = dict(scheduler.get("codex_threads") or {})
+        threads = dict(scheduler.get("runtime_sessions") or {})
         key = ns._scheduler_issue_key(issue_number) if issue_number is not None else None
         if key is None:
             running_entries = [
@@ -1420,8 +1421,8 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             {
                 "workflow": "change-delivery",
                 "updatedAt": ns._now_iso(),
-                "codex_threads": threads,
-                "codex_totals": scheduler.get("codex_totals") or {},
+                "runtime_sessions": threads,
+                "runtime_totals": scheduler.get("runtime_totals") or {},
             }
         )
         ns.save_scheduler(scheduler)
@@ -1600,7 +1601,7 @@ def _install_wrapper_adapter_shims(ns: SimpleNamespace) -> None:
             issue_number = ns._scheduler_issue_number_from_session(worktree=worktree, session_name=session_name)
             thread_id = ns._codex_thread_for_issue_number(issue_number)
             if thread_id:
-                entry = ((ns.load_scheduler().get("codex_threads") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
+                entry = ((ns.load_scheduler().get("runtime_sessions") or {}).get(ns._scheduler_issue_key(issue_number)) or {})
                 return {
                     "name": session_name,
                     "closed": False,

--- a/daedalus/workflows/issue_runner/__init__.py
+++ b/daedalus/workflows/issue_runner/__init__.py
@@ -2,22 +2,67 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 NAME = "issue-runner"
 SUPPORTED_SCHEMA_VERSIONS = (1,)
 CONFIG_SCHEMA_PATH = Path(__file__).parent / "schema.yaml"
 PREFLIGHT_GATED_COMMANDS = frozenset({"tick", "run"})
+SERVICE_MODES = frozenset({"active"})
 
 from workflows.issue_runner.cli import main as cli_main
 from workflows.issue_runner.preflight import run_preflight
 from workflows.issue_runner.workspace import make_workspace
+from workflows.issue_runner.workspace import load_workspace_from_config
+
+
+def service_prepare(
+    *,
+    workflow_root: Path,
+    project_key: str | None,
+    service_mode: str,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "workflow": NAME,
+        "project_key": project_key,
+        "service_mode": service_mode,
+        "skipped": True,
+        "reason": "issue-runner initializes engine state through EngineStore on first service tick",
+    }
+
+
+def service_loop(
+    *,
+    workflow_root: Path,
+    project_key: str | None,
+    instance_id: str | None,
+    interval_seconds: int,
+    max_iterations: int | None,
+    service_mode: str,
+) -> dict[str, Any]:
+    workspace = load_workspace_from_config(workspace_root=workflow_root)
+    payload = workspace.run_loop(
+        interval_seconds=interval_seconds,
+        max_iterations=max_iterations,
+    )
+    return {
+        "workflow": NAME,
+        "project_key": project_key,
+        "instance_id": instance_id,
+        "service_mode": service_mode,
+        **payload,
+    }
 
 __all__ = [
     "NAME",
     "SUPPORTED_SCHEMA_VERSIONS",
     "CONFIG_SCHEMA_PATH",
     "PREFLIGHT_GATED_COMMANDS",
+    "SERVICE_MODES",
     "make_workspace",
     "cli_main",
     "run_preflight",
+    "service_prepare",
+    "service_loop",
 ]

--- a/daedalus/workflows/issue_runner/orchestrator.py
+++ b/daedalus/workflows/issue_runner/orchestrator.py
@@ -1,0 +1,921 @@
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from engine.lifecycle import clear_work_entries, mark_running_work, schedule_retry_entry
+from engine.scheduler import retry_due_at
+from engine.storage import load_optional_json as _load_optional_json
+from engine.work_items import work_item_from_issue
+from runtimes import PromptRunResult
+from workflows.issue_runner.tracker import eligible_issues, issue_session_name
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _now_epoch() -> float:
+    return time.time()
+
+
+def _cfg_value(config: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in config:
+            return config[key]
+    return default
+
+
+def scheduler_state_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    polling_cfg = config.get("polling") or {}
+    agent_cfg = config.get("agent") or {}
+    interval_ms = _cfg_value(polling_cfg, "interval_ms")
+    if interval_ms in (None, ""):
+        interval_ms = int(_cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30) or 30) * 1000
+    return {
+        "poll_interval_ms": max(int(interval_ms or 30000), 1),
+        "max_concurrent_agents": max(int(agent_cfg.get("max_concurrent_agents") or 10), 1),
+        "max_concurrent_agents_by_state": {
+            str(state).strip().lower(): int(limit)
+            for state, limit in ((agent_cfg.get("max_concurrent_agents_by_state") or {}).items())
+            if str(state).strip() and int(limit) > 0
+        },
+    }
+
+
+@dataclass
+class IssueRunnerOrchestrator:
+    """Decision authority for issue-runner scheduling state transitions.
+
+    The workspace remains the composition root for persistence, runtime,
+    tracker, and filesystem helpers. This object owns the orchestration flow:
+    select work, mark it running, reconcile workers, apply outcomes, and queue
+    retries.
+    """
+
+    workspace: Any
+
+    def _poll_interval_seconds(self, override: int | None) -> int:
+        if override is not None:
+            return max(int(override), 1)
+        polling_cfg = self.workspace.config.get("polling") or {}
+        interval_ms = _cfg_value(polling_cfg, "interval_ms")
+        if interval_ms not in (None, ""):
+            return max(int(interval_ms) // 1000, 1)
+        interval_seconds = _cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30)
+        return max(int(interval_seconds or 30), 1)
+
+    def _dispatch_slots(self) -> int:
+        w = self.workspace
+        scheduler = scheduler_state_from_config(w.config)
+        running_count = len(w.running_entries)
+        return max(int(scheduler["max_concurrent_agents"]) - running_count, 0)
+
+    def select_issue_batch(
+        self,
+        *,
+        issues: list[dict[str, Any]],
+        issues_by_id: dict[str, dict[str, Any]],
+    ) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+        w = self.workspace
+        slots = self._dispatch_slots()
+        if slots <= 0:
+            return []
+
+        tracker_cfg = w.config.get("tracker") or {}
+        scheduler = scheduler_state_from_config(w.config)
+        state_limits = dict(scheduler["max_concurrent_agents_by_state"])
+        pending_retry_ids = {
+            issue_id
+            for issue_id, entry in w.retry_entries.items()
+            if retry_due_at(entry, default=0.0) > _now_epoch()
+        }
+        running_ids = set(w.running_entries)
+        selected: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+        selected_ids: set[str] = set()
+        state_counts: dict[str, int] = {}
+
+        def can_take(issue: dict[str, Any]) -> bool:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id or issue_id in selected_ids or issue_id in running_ids:
+                return False
+            if issue_id in pending_retry_ids:
+                return False
+            state = str(issue.get("state") or "").strip().lower()
+            limit = state_limits.get(state)
+            if limit is not None and state_counts.get(state, 0) >= limit:
+                return False
+            return True
+
+        due_retry_entries = sorted(
+            [
+                (issue_id, entry)
+                for issue_id, entry in w.retry_entries.items()
+                if retry_due_at(entry, default=0.0) <= _now_epoch()
+            ],
+            key=lambda item: (
+                retry_due_at(item[1], default=0.0),
+                int((item[1] or {}).get("attempt") or 0),
+                str((item[1] or {}).get("identifier") or item[0]),
+            ),
+        )
+        for issue_id, retry_entry in due_retry_entries:
+            if len(selected) >= slots:
+                break
+            issue = issues_by_id.get(issue_id)
+            if issue is None:
+                w.retry_entries.pop(issue_id, None)
+                continue
+            if not can_take(issue):
+                continue
+            selected.append((issue, retry_entry))
+            selected_ids.add(issue_id)
+            state = str(issue.get("state") or "").strip().lower()
+            state_counts[state] = state_counts.get(state, 0) + 1
+
+        if len(selected) >= slots:
+            return selected
+
+        for issue in eligible_issues(tracker_cfg=tracker_cfg, issues=issues):
+            if len(selected) >= slots:
+                break
+            if not can_take(issue):
+                continue
+            issue_id = str(issue.get("id") or "").strip()
+            selected.append((issue, w.retry_entries.get(issue_id)))
+            selected_ids.add(issue_id)
+            state = str(issue.get("state") or "").strip().lower()
+            state_counts[state] = state_counts.get(state, 0) + 1
+        return selected
+
+    def issue_attempt(self, *, issue: dict[str, Any], retry_entry: dict[str, Any] | None) -> int:
+        if retry_entry is not None:
+            return int(retry_entry.get("attempt") or 0) + 1
+        last_run = (_load_optional_json(self.workspace.status_path) or {}).get("lastRun") or {}
+        if (last_run.get("issue") or {}).get("id") == issue.get("id"):
+            return int(last_run.get("attempt") or 0) + 1
+        return 1
+
+    def mark_running(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None = None,
+    ) -> None:
+        w = self.workspace
+        now_epoch = _now_epoch()
+        tracker_kind = str((w.config.get("tracker") or {}).get("kind") or "tracker")
+        w.running_entries = mark_running_work(
+            w.running_entries,
+            work_items=[
+                (
+                    work_item_from_issue(issue, source=tracker_kind),
+                    self.issue_attempt(issue=issue, retry_entry=retry_entry),
+                )
+                for issue, retry_entry in selections
+                if str(issue.get("id") or "").strip()
+            ],
+            now_epoch=now_epoch,
+        )
+        if run_id:
+            for issue, _retry_entry in selections:
+                issue_id = str(issue.get("id") or "").strip()
+                if issue_id in w.running_entries:
+                    w.running_entries[issue_id]["run_id"] = run_id
+        w.running_issue_id = next(iter(w.running_entries), None)
+        w._persist_scheduler_state()
+
+    def clear_running(self, issue_ids: list[str]) -> None:
+        w = self.workspace
+        w.running_entries = clear_work_entries(w.running_entries, issue_ids)
+        w.running_issue_id = next(iter(w.running_entries), None)
+
+    def schedule_retry(
+        self,
+        *,
+        issue: dict[str, Any],
+        error: str,
+        current_attempt: int | None,
+        delay_type: str = "failure",
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        w = self.workspace
+        max_backoff_ms = int((w.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
+        work_item = work_item_from_issue(issue, source=str((w.config.get("tracker") or {}).get("kind") or "tracker"))
+        entry, retry = schedule_retry_entry(
+            work_item=work_item,
+            existing_entry=w.retry_entries.get(work_item.id),
+            error=error,
+            current_attempt=current_attempt,
+            delay_type=delay_type,
+            max_backoff_ms=max_backoff_ms,
+            now_epoch=_now_epoch(),
+        )
+        if run_id:
+            entry["run_id"] = run_id
+            retry["run_id"] = run_id
+        w.retry_entries[work_item.id] = entry
+        w._emit_event(
+            "issue_runner.retry.scheduled",
+            {
+                **retry,
+                "error": error,
+                "run_id": run_id,
+            },
+        )
+        return retry
+
+    def clear_retry(self, issue_id: str | None) -> None:
+        self.workspace.retry_entries = clear_work_entries(self.workspace.retry_entries, [issue_id])
+
+    def publish_selected_feedback(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None,
+    ) -> None:
+        w = self.workspace
+        for issue, retry_entry in selections:
+            attempt = self.issue_attempt(issue=issue, retry_entry=retry_entry)
+            retrying = retry_entry is not None
+            verb = "Selected this issue for another execution attempt." if retrying else "Selected this issue for execution."
+            w._publish_tracker_feedback(
+                issue=issue,
+                event="issue.selected",
+                summary=verb,
+                run_id=run_id,
+                metadata={
+                    "attempt": attempt,
+                    "retrying": retrying,
+                    "state": issue.get("state"),
+                },
+            )
+
+    def apply_issue_results(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        w = self.workspace
+        applied: list[dict[str, Any]] = []
+        for result in results:
+            issue = result.get("issue") or {}
+            issue_id = str(issue.get("id") or "")
+            run_id = result.get("run_id") or result.get("runId")
+            metrics = result.get("metrics") or {}
+            if metrics:
+                recorded_metrics = w._record_metrics(
+                    PromptRunResult(
+                        output="",
+                        session_id=metrics.get("session_id"),
+                        thread_id=metrics.get("thread_id"),
+                        turn_id=metrics.get("turn_id"),
+                        last_event=metrics.get("last_event"),
+                        last_message=metrics.get("last_message"),
+                        turn_count=int(metrics.get("turn_count") or 0),
+                        tokens=metrics.get("tokens"),
+                        rate_limits=metrics.get("rate_limits"),
+                    )
+                )
+                w._record_runtime_session(
+                    issue=issue,
+                    session_name=issue_session_name(issue),
+                    metrics=recorded_metrics,
+                    runtime_name=result.get("runtime"),
+                    runtime_kind=result.get("runtimeKind"),
+                    run_id=run_id,
+                )
+                result["metrics"] = recorded_metrics
+
+            if result.get("ok"):
+                feedback_result = w._publish_tracker_feedback(
+                    issue=issue,
+                    event="issue.completed",
+                    summary="The configured runtime completed this issue run successfully.",
+                    run_id=run_id,
+                    metadata={
+                        "attempt": result.get("attempt"),
+                        "workspace": result.get("workspace"),
+                        "output_path": result.get("outputPath"),
+                        "runtime": result.get("runtime"),
+                    },
+                )
+                if w._feedback_reached_terminal_state(feedback_result):
+                    result["suppressRetry"] = True
+                self.clear_retry(issue_id)
+                if result.get("suppressRetry"):
+                    result["retry"] = None
+                else:
+                    retry = self.schedule_retry(
+                        issue=issue,
+                        error="continuation",
+                        current_attempt=result.get("attempt"),
+                        delay_type="continuation",
+                        run_id=run_id,
+                    )
+                    result["retry"] = retry
+                    w._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.retry_scheduled",
+                        summary="Scheduled a continuation retry for this issue.",
+                        run_id=run_id,
+                        metadata={
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "delay_ms": retry.get("delay_ms"),
+                            "delay_type": retry.get("delay_type"),
+                        },
+                    )
+                w._emit_event(
+                    "issue_runner.tick.completed",
+                    {
+                        "issue_id": issue.get("id"),
+                        "attempt": result.get("attempt"),
+                        "workspace": result.get("workspace"),
+                        "output_path": result.get("outputPath"),
+                        "run_id": run_id,
+                        "continuation_retry_attempt": (result.get("retry") or {}).get("retry_attempt"),
+                        "continuation_retry_delay_ms": (result.get("retry") or {}).get("delay_ms"),
+                    },
+                )
+            else:
+                if result.get("suppressRetry"):
+                    result["retry"] = None
+                    w._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.canceled",
+                        summary=str(result.get("error") or "The issue run was canceled and will not be retried."),
+                        run_id=run_id,
+                        metadata={
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "retry_suppressed": True,
+                        },
+                    )
+                    w._emit_event(
+                        "issue_runner.tick.canceled",
+                        {
+                            "issue_id": issue.get("id"),
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "error": result.get("error"),
+                            "run_id": run_id,
+                            "retry_suppressed": True,
+                        },
+                    )
+                else:
+                    w._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.failed",
+                        summary=str(result.get("error") or "The configured runtime failed this issue run."),
+                        run_id=run_id,
+                        metadata={
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "runtime": result.get("runtime"),
+                        },
+                    )
+                    retry = self.schedule_retry(
+                        issue=issue,
+                        error=str(result.get("error") or "issue execution failed"),
+                        current_attempt=result.get("attempt"),
+                        run_id=run_id,
+                    )
+                    result["retry"] = retry
+                    w._publish_tracker_feedback(
+                        issue=issue,
+                        event="issue.retry_scheduled",
+                        summary=(
+                            "Scheduled a retry after the issue run failed."
+                            if retry.get("delay_type") != "continuation"
+                            else "Scheduled a continuation retry for this issue."
+                        ),
+                        run_id=run_id,
+                        metadata={
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "delay_ms": retry.get("delay_ms"),
+                            "delay_type": retry.get("delay_type"),
+                            "error": retry.get("error"),
+                        },
+                    )
+                    w._emit_event(
+                        "issue_runner.tick.failed",
+                        {
+                            "issue_id": issue.get("id"),
+                            "attempt": result.get("attempt"),
+                            "workspace": result.get("workspace"),
+                            "error": result.get("error"),
+                            "run_id": run_id,
+                            "retry_attempt": retry.get("retry_attempt"),
+                            "retry_delay_ms": retry.get("delay_ms"),
+                        },
+                    )
+            applied.append(result)
+        return applied
+
+    def status_from_results(
+        self,
+        *,
+        base_status: dict[str, Any],
+        results: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        results.sort(
+            key=lambda item: str(
+                ((item.get("issue") or {}).get("identifier"))
+                or ((item.get("issue") or {}).get("id"))
+                or ""
+            )
+        )
+        applied = self.apply_issue_results(results)
+        tick_metrics = [result.get("metrics") or {} for result in applied if result.get("metrics")]
+        first = applied[0] if applied else {}
+        base_status.update(
+            {
+                "ok": all(result.get("ok") or result.get("suppressRetry") for result in applied),
+                "attempt": first.get("attempt"),
+                "outputPath": first.get("outputPath"),
+                "workspace": first.get("workspace"),
+                "createdWorkspace": first.get("createdWorkspace"),
+                "hookResults": first.get("hookResults"),
+                "results": applied,
+                "metrics": self.workspace._aggregate_metrics(tick_metrics),
+            }
+        )
+        failed = next((result for result in applied if not result.get("ok") and not result.get("suppressRetry")), None)
+        if failed:
+            base_status["error"] = failed.get("error")
+            base_status["retry"] = failed.get("retry")
+        return base_status
+
+    def request_supervised_cancel(self, issue_id: str, *, reason: str) -> bool:
+        w = self.workspace
+        if not issue_id or issue_id not in w.running_entries:
+            return False
+        entry = w.running_entries[issue_id]
+        if entry.get("cancel_requested"):
+            return False
+        entry["cancel_requested"] = True
+        entry["cancel_reason"] = reason
+        entry["worker_status"] = "canceling"
+        entry["heartbeat_at_epoch"] = _now_epoch()
+        event = w._supervisor_cancel_events.get(issue_id)
+        if event is not None:
+            event.set()
+        future = w._supervisor_futures.get(issue_id)
+        if future is not None:
+            future.cancel()
+        w._emit_event(
+            "issue_runner.worker.cancel_requested",
+            {
+                "issue_id": issue_id,
+                "identifier": entry.get("identifier"),
+                "reason": reason,
+                "worker_id": entry.get("worker_id"),
+                "run_id": entry.get("run_id") or entry.get("runId"),
+            },
+        )
+        w._persist_scheduler_state()
+        return True
+
+    def request_terminal_cancellations(self, terminal_issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        w = self.workspace
+        requested = []
+        for issue in terminal_issues:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id or issue_id not in w.running_entries:
+                continue
+            if self.request_supervised_cancel(issue_id, reason="terminal-state"):
+                requested.append(
+                    {
+                        "issue_id": issue_id,
+                        "identifier": issue.get("identifier"),
+                        "reason": "terminal-state",
+                    }
+                )
+        return requested
+
+    def reconcile_supervised_workers(self) -> list[dict[str, Any]]:
+        w = self.workspace
+        completed: list[dict[str, Any]] = []
+        for issue_id, future in list(w._supervisor_futures.items()):
+            if not future.done():
+                entry = w.running_entries.get(issue_id)
+                if entry is not None:
+                    entry["heartbeat_at_epoch"] = _now_epoch()
+                continue
+            w._supervisor_futures.pop(issue_id, None)
+            w._supervisor_cancel_events.pop(issue_id, None)
+            entry = w.running_entries.get(issue_id) or {}
+            if future.cancelled():
+                result = w._cancel_result(
+                    issue={
+                        "id": issue_id,
+                        "identifier": entry.get("identifier"),
+                        "state": entry.get("state"),
+                    },
+                    attempt=int(entry.get("attempt") or 0),
+                    reason=str(entry.get("cancel_reason") or "canceled"),
+                    run_id=entry.get("run_id") or entry.get("runId"),
+                )
+            else:
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    result = {
+                        "ok": False,
+                        "issue": {
+                            "id": issue_id,
+                            "identifier": entry.get("identifier"),
+                            "state": entry.get("state"),
+                        },
+                        "attempt": int(entry.get("attempt") or 0),
+                        "workspace": None,
+                        "createdWorkspace": False,
+                        "hookResults": [],
+                        "outputPath": None,
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "metrics": {},
+                        "runtime": None,
+                        "runtimeKind": None,
+                        "runId": entry.get("run_id") or entry.get("runId"),
+                    }
+            if entry.get("cancel_requested"):
+                result["cancelRequested"] = True
+                result["cancelReason"] = entry.get("cancel_reason")
+                if entry.get("cancel_reason") == "terminal-state":
+                    result["suppressRetry"] = True
+            metrics = result.get("metrics") or {}
+            if metrics.get("thread_id"):
+                entry["thread_id"] = metrics.get("thread_id")
+            if metrics.get("turn_id"):
+                entry["turn_id"] = metrics.get("turn_id")
+            entry["worker_status"] = "completed" if result.get("ok") else ("canceled" if result.get("canceled") else "failed")
+            entry["heartbeat_at_epoch"] = _now_epoch()
+            self.clear_running([issue_id])
+            completed.append(result)
+            w._emit_event(
+                "issue_runner.worker.completed",
+                {
+                    "issue_id": issue_id,
+                    "identifier": (result.get("issue") or {}).get("identifier") or entry.get("identifier"),
+                    "worker_id": entry.get("worker_id"),
+                    "run_id": entry.get("run_id") or entry.get("runId") or result.get("runId"),
+                    "ok": result.get("ok"),
+                    "canceled": result.get("canceled"),
+                    "error": result.get("error"),
+                },
+            )
+        if completed:
+            w._persist_scheduler_state()
+        return completed
+
+    def dispatch_supervised_workers(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+        *,
+        run_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        w = self.workspace
+        if not selections:
+            return []
+        executor = w._ensure_supervisor_executor()
+        self.mark_running(selections, run_id=run_id)
+        dispatched: list[dict[str, Any]] = []
+        for issue, retry_entry in selections:
+            issue_id = str(issue.get("id") or "").strip()
+            if not issue_id:
+                continue
+            cancel_event = threading.Event()
+            w._supervisor_cancel_events[issue_id] = cancel_event
+            future = executor.submit(
+                w._execute_issue,
+                issue=issue,
+                retry_entry=retry_entry,
+                cancel_event=cancel_event,
+                run_id=run_id,
+            )
+            w._supervisor_futures[issue_id] = future
+            entry = w.running_entries.get(issue_id) or {}
+            resume_session_id = w._runtime_session_id_for_issue(issue)
+            if resume_session_id:
+                entry["session_id"] = resume_session_id
+                persisted_session = w.runtime_sessions.get(issue_id) or {}
+                if persisted_session.get("thread_id"):
+                    entry["thread_id"] = persisted_session.get("thread_id")
+            dispatched.append(dict(entry))
+            w._emit_event(
+                "issue_runner.worker.dispatched",
+                {
+                    "issue_id": issue_id,
+                    "identifier": issue.get("identifier"),
+                    "worker_id": entry.get("worker_id"),
+                    "attempt": entry.get("attempt"),
+                    "state": issue.get("state"),
+                    "run_id": run_id,
+                },
+            )
+            w._publish_tracker_feedback(
+                issue=issue,
+                event="issue.dispatched",
+                summary="Dispatched a supervised worker for this issue.",
+                run_id=run_id,
+                metadata={
+                    "attempt": entry.get("attempt"),
+                    "worker_id": entry.get("worker_id"),
+                    "state": issue.get("state"),
+                },
+            )
+        w._persist_scheduler_state()
+        return dispatched
+
+    def supervise_once(self) -> dict[str, Any]:
+        w = self.workspace
+        engine_run = w.engine_store.start_run(mode="supervised")
+        status = {
+            "ok": True,
+            "workflow": "issue-runner",
+            "mode": "supervised",
+            "updatedAt": _now_iso(),
+            "selectedIssue": None,
+            "selectedIssues": [],
+            "attempt": None,
+            "outputPath": None,
+            "metrics": {},
+            "results": [],
+            "completedResults": [],
+            "dispatchedWorkers": [],
+            "cancellationRequests": [],
+        }
+        try:
+            try:
+                issues = w.tracker_client.list_all()
+                terminal_issues = w.tracker_client.list_terminal()
+            except Exception as exc:
+                status["ok"] = False
+                status["error"] = f"{type(exc).__name__}: {exc}"
+                status["engineRun"] = w._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "tracker-load-failed"},
+                )
+                w._write_status(status, health="error")
+                w._emit_event(
+                    "issue_runner.tick.failed",
+                    {
+                        "error": status["error"],
+                        "reason": "tracker-load-failed",
+                        "run_id": engine_run["run_id"],
+                    },
+                )
+                return status
+
+            status["cancellationRequests"] = self.request_terminal_cancellations(terminal_issues)
+            completed = self.reconcile_supervised_workers()
+            if completed:
+                status = self.status_from_results(base_status=status, results=completed)
+                status["completedResults"] = status.get("results") or []
+            suppressed_completed_ids = {
+                str((result.get("issue") or {}).get("id") or "").strip()
+                for result in completed
+                if result.get("suppressRetry")
+            }
+            cleanup = w._cleanup_terminal_workspaces(terminal_issues)
+            status["cleanup"] = cleanup
+
+            dispatch_issues = [
+                issue
+                for issue in issues
+                if str(issue.get("id") or "").strip() not in suppressed_completed_ids
+            ]
+            issues_by_id = {
+                str(issue.get("id")): issue
+                for issue in dispatch_issues
+                if str(issue.get("id") or "").strip()
+            }
+            selections = self.select_issue_batch(issues=dispatch_issues, issues_by_id=issues_by_id)
+            selections = self._refresh_selections(selections)
+            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
+            status["selectedIssue"] = selections[0][0] if selections else None
+            self.publish_selected_feedback(selections, run_id=engine_run["run_id"])
+            dispatched = self.dispatch_supervised_workers(selections, run_id=engine_run["run_id"])
+            status["dispatchedWorkers"] = dispatched
+            if not completed and not dispatched:
+                status["message"] = "no dispatchable issues"
+                w._emit_event(
+                    "issue_runner.tick.noop",
+                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
+                )
+
+            if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
+                status["ok"] = False
+            status["engineRun"] = w._finish_engine_run_for_status(
+                engine_run,
+                status,
+                metadata={
+                    "dispatched_count": len(dispatched),
+                    "cancellation_count": len(status.get("cancellationRequests") or []),
+                },
+            )
+            w._write_status(status, health="healthy" if status["ok"] else "error")
+            w._persist_scheduler_state()
+            return status
+        except Exception as exc:
+            w._fail_engine_run_after_exception(engine_run, exc)
+            raise
+
+    def reconcile_before_loop_exit(self, last_result: dict[str, Any] | None) -> dict[str, Any] | None:
+        w = self.workspace
+        engine_run = w.engine_store.start_run(mode="supervised-exit-reconcile")
+        try:
+            completed = self.reconcile_supervised_workers()
+            if not completed:
+                w._persist_scheduler_state()
+                w.engine_store.complete_run(
+                    engine_run["run_id"],
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"changed": False},
+                )
+                return last_result
+            status = {
+                "ok": True,
+                "workflow": "issue-runner",
+                "mode": "supervised-exit-reconcile",
+                "updatedAt": _now_iso(),
+                "selectedIssue": None,
+                "selectedIssues": [],
+                "attempt": None,
+                "outputPath": None,
+                "metrics": {},
+                "results": [],
+                "completedResults": [],
+                "dispatchedWorkers": [],
+                "cancellationRequests": [],
+            }
+            status = self.status_from_results(base_status=status, results=completed)
+            status["completedResults"] = status.get("results") or []
+            status["engineRun"] = w._finish_engine_run_for_status(
+                engine_run,
+                status,
+                selected_count=0,
+                completed_count=len(completed),
+                metadata={"changed": True},
+            )
+            w._write_status(status, health="healthy" if status["ok"] else "error")
+            w._persist_scheduler_state()
+            return status
+        except Exception as exc:
+            w._fail_engine_run_after_exception(engine_run, exc)
+            raise
+
+    def tick(self) -> dict[str, Any]:
+        w = self.workspace
+        engine_run = w.engine_store.start_run(mode="tick")
+        status = {
+            "ok": False,
+            "workflow": "issue-runner",
+            "updatedAt": _now_iso(),
+            "selectedIssue": None,
+            "selectedIssues": [],
+            "attempt": None,
+            "outputPath": None,
+            "metrics": {},
+        }
+        try:
+            try:
+                issues = w.tracker_client.list_all()
+                cleanup = w._cleanup_terminal_workspaces(w.tracker_client.list_terminal())
+            except Exception as exc:
+                status["error"] = f"{type(exc).__name__}: {exc}"
+                status["engineRun"] = w._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "tracker-load-failed"},
+                )
+                w._write_status(status, health="error")
+                w._emit_event(
+                    "issue_runner.tick.failed",
+                    {
+                        "error": status["error"],
+                        "reason": "tracker-load-failed",
+                        "run_id": engine_run["run_id"],
+                    },
+                )
+                return status
+            issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
+            selections = self.select_issue_batch(issues=issues, issues_by_id=issues_by_id)
+            selections = self._refresh_selections(selections)
+            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
+            status["selectedIssue"] = selections[0][0] if selections else None
+            status["cleanup"] = cleanup
+            if not selections:
+                status["ok"] = True
+                status["message"] = "no dispatchable issues"
+                status["engineRun"] = w._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=0,
+                    completed_count=0,
+                    metadata={"reason": "no-dispatchable-issues"},
+                )
+                w._write_status(status, health="healthy")
+                w._persist_scheduler_state()
+                w._emit_event(
+                    "issue_runner.tick.noop",
+                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
+                )
+                return status
+
+            self.publish_selected_feedback(selections, run_id=engine_run["run_id"])
+            self.mark_running(selections, run_id=engine_run["run_id"])
+            results: list[dict[str, Any]] = []
+            try:
+                if len(selections) == 1:
+                    issue, retry_entry = selections[0]
+                    results = [
+                        w._execute_issue(
+                            issue=issue,
+                            retry_entry=retry_entry,
+                            run_id=engine_run["run_id"],
+                        )
+                    ]
+                else:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=len(selections)) as executor:
+                        future_map = {
+                            executor.submit(
+                                w._execute_issue,
+                                issue=issue,
+                                retry_entry=retry_entry,
+                                run_id=engine_run["run_id"],
+                            ): (issue, retry_entry)
+                            for issue, retry_entry in selections
+                        }
+                        for future in concurrent.futures.as_completed(future_map):
+                            results.append(future.result())
+
+                status = self.status_from_results(base_status=status, results=results)
+                status["engineRun"] = w._finish_engine_run_for_status(
+                    engine_run,
+                    status,
+                    selected_count=len(selections),
+                    completed_count=len(results),
+                )
+                w._write_status(status, health="healthy" if status["ok"] else "error")
+                return status
+            finally:
+                self.clear_running([str(issue.get("id") or "") for issue, _retry_entry in selections])
+                w._persist_scheduler_state()
+        except Exception as exc:
+            w._fail_engine_run_after_exception(engine_run, exc)
+            raise
+        finally:
+            w._apply_event_retention()
+
+    def run_loop(
+        self,
+        *,
+        interval_seconds: int | None,
+        max_iterations: int | None = None,
+        sleep_fn=time.sleep,
+    ) -> dict[str, Any]:
+        w = self.workspace
+        iterations = 0
+        last_result = None
+        last_retention = w._apply_event_retention()
+        loop_status = "completed"
+        try:
+            while True:
+                w.reload_contract()
+                # Call through the workspace facade so tests and operators can
+                # wrap supervise_once without bypassing orchestration.
+                last_result = w.supervise_once()
+                last_retention = w._apply_event_retention()
+                iterations += 1
+                if max_iterations is not None and iterations >= max_iterations:
+                    break
+                sleep_fn(self._poll_interval_seconds(interval_seconds))
+        except KeyboardInterrupt:
+            loop_status = "interrupted"
+        last_result = self.reconcile_before_loop_exit(last_result)
+        if not w._supervisor_futures:
+            w.close()
+        return {
+            "loop_status": loop_status,
+            "iterations": iterations,
+            "last_result": last_result,
+            "event_retention": last_retention,
+        }
+
+    def _refresh_selections(
+        self,
+        selections: list[tuple[dict[str, Any], dict[str, Any] | None]],
+    ) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+        refreshed: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+        for selected, retry_entry in selections:
+            issue_id = str(selected.get("id") or "").strip()
+            if issue_id:
+                selected = self.workspace.tracker_client.refresh([issue_id]).get(issue_id, selected)
+            refreshed.append((selected, retry_entry))
+        return refreshed

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -35,7 +35,6 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
     daedalus_cfg = config.get("daedalus") or {}
     runtimes = config.get("runtimes") or (daedalus_cfg.get("runtimes") if isinstance(daedalus_cfg, dict) else {}) or {}
     agent = config.get("agent") or {}
-    codex_cfg = config.get("codex") or {}
     runtime_name = str(agent.get("runtime") or "").strip()
     if runtime_name:
         if runtime_name not in runtimes:
@@ -50,16 +49,15 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
         if runtime_kind == "codex-app-server":
             runtime_mode = str(
                 runtime_cfg.get("mode")
-                or codex_cfg.get("mode")
-                or ("external" if runtime_cfg.get("endpoint") or codex_cfg.get("endpoint") else "managed")
+                or ("external" if runtime_cfg.get("endpoint") else "managed")
             ).strip()
-            if runtime_mode == "external" and not (runtime_cfg.get("endpoint") or codex_cfg.get("endpoint")):
+            if runtime_mode == "external" and not runtime_cfg.get("endpoint"):
                 raise RuntimeError(
-                    "external codex-app-server runtime requires endpoint on the runtime profile or codex block"
+                    "external codex-app-server runtime requires endpoint on the runtime profile"
                 )
-            if runtime_mode != "external" and not (runtime_cfg.get("command") or codex_cfg.get("command")):
+            if runtime_mode != "external" and not runtime_cfg.get("command"):
                 raise RuntimeError(
-                    "codex-app-server runtime requires command on the runtime profile or codex block"
+                    "managed codex-app-server runtime requires command on the runtime profile"
                 )
     else:
         raise RuntimeError("issue-runner requires agent.runtime")

--- a/daedalus/workflows/issue_runner/schema.yaml
+++ b/daedalus/workflows/issue_runner/schema.yaml
@@ -138,43 +138,6 @@ properties:
         type: integer
         minimum: 1
 
-  codex:
-    type: object
-    properties:
-      command: {type: string}
-      mode:
-        type: string
-        enum: [managed, external]
-      endpoint: {type: string}
-      healthcheck_path: {type: string}
-      ws_token_env: {type: string}
-      ws_token_file: {type: string}
-      ephemeral: {type: boolean}
-      keep_alive: {type: boolean}
-      keep-alive: {type: boolean}
-      approval_policy:
-        oneOf:
-          - type: string
-            enum: [untrusted, on-failure, on-request, never]
-          - type: object
-      thread_sandbox:
-        type: string
-        enum: [read-only, workspace-write, danger-full-access]
-      turn_sandbox_policy:
-        oneOf:
-          - type: string
-            enum: [read-only, workspace-write, danger-full-access]
-          - type: object
-      turn_timeout_ms:
-        type: integer
-        minimum: 1
-      read_timeout_ms:
-        type: integer
-        minimum: 1
-      stall_timeout_ms:
-        type: integer
-        minimum: 0
-
   daedalus:
     type: object
     properties:
@@ -336,6 +299,8 @@ definitions:
     properties:
       kind:
         const: codex-app-server
+      stage-command: {type: boolean}
+      stage_command: {type: boolean}
       command:
         oneOf:
           - type: string

--- a/daedalus/workflows/issue_runner/workflow.template.md
+++ b/daedalus/workflows/issue_runner/workflow.template.md
@@ -60,6 +60,7 @@ agent:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -17,7 +17,7 @@ from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 
 from engine.scheduler import (
     build_scheduler_payload,
-    codex_threads_snapshot,
+    runtime_sessions_snapshot,
     restore_scheduler_state,
     retry_due_at,
     retry_queue_snapshot,
@@ -40,6 +40,7 @@ from runtimes.stages import prompt_result_from_stage, run_runtime_stage
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
 from workflows.shared.paths import runtime_paths
+from workflows.issue_runner.orchestrator import IssueRunnerOrchestrator
 from workflows.issue_runner.tracker import (
     TrackerClient,
     TrackerConfigError,
@@ -213,52 +214,10 @@ def _runtime_profiles_from_config(config: dict[str, Any]) -> dict[str, dict[str,
     raw_profiles = config.get("runtimes") or (
         daedalus_cfg.get("runtimes") if isinstance(daedalus_cfg, dict) else {}
     ) or {}
-    profiles = {
+    return {
         str(name): dict(profile_cfg or {})
         for name, profile_cfg in raw_profiles.items()
     }
-    codex_cfg = dict(config.get("codex") or {})
-    agent_cfg = config.get("agent") or {}
-    runtime_name = str(agent_cfg.get("runtime") or "").strip()
-
-    for profile in profiles.values():
-        if str(profile.get("kind") or "").strip() != "codex-app-server":
-            continue
-        for key in (
-            "command",
-            "mode",
-            "endpoint",
-            "healthcheck_path",
-            "ws_token_env",
-            "ws_token_file",
-            "ephemeral",
-            "approval_policy",
-            "thread_sandbox",
-            "turn_sandbox_policy",
-            "turn_timeout_ms",
-            "read_timeout_ms",
-            "stall_timeout_ms",
-            "keep_alive",
-            "keep-alive",
-        ):
-            if profile.get(key) in (None, "", []):
-                value = codex_cfg.get(key)
-                if value not in (None, "", []):
-                    profile[key] = value
-
-    if not runtime_name and codex_cfg.get("command"):
-        profiles.setdefault(
-            "codex",
-            {
-                "kind": "codex-app-server",
-                **{
-                    key: value
-                    for key, value in codex_cfg.items()
-                    if value not in (None, "", [])
-                },
-            },
-        )
-    return profiles
 
 
 def _build_runtimes_from_config(
@@ -308,12 +267,15 @@ class IssueRunnerWorkspace(WorkflowDriver):
     _run_json: Callable[..., dict[str, Any]]
     retry_entries: dict[str, dict[str, Any]]
     running_entries: dict[str, dict[str, Any]]
-    codex_threads: dict[str, dict[str, Any]]
+    runtime_sessions: dict[str, dict[str, Any]]
     running_issue_id: str | None = None
-    codex_totals: dict[str, Any] | None = None
+    runtime_totals: dict[str, Any] | None = None
     _supervisor_executor: concurrent.futures.ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
     _supervisor_futures: dict[str, concurrent.futures.Future] = field(default_factory=dict, init=False, repr=False)
     _supervisor_cancel_events: dict[str, threading.Event] = field(default_factory=dict, init=False, repr=False)
+
+    def orchestrator(self) -> IssueRunnerOrchestrator:
+        return IssueRunnerOrchestrator(self)
 
     def runtime(self, name: str) -> Runtime:
         return self.runtimes[name]
@@ -391,8 +353,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 **_scheduler_state_from_config(self.config),
                 "running": self._running_snapshot(),
                 "retry_queue": self._retry_queue_snapshot(),
-                "codex_totals": dict(self.codex_totals or {}),
-                "codex_threads": self._codex_threads_snapshot(),
+                "runtime_totals": dict(self.runtime_totals or {}),
+                "runtime_sessions": self._runtime_sessions_snapshot(),
             },
             "runtimeDiagnostics": self._runtime_diagnostics(),
             "selectedIssue": selected,
@@ -530,8 +492,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
         self.engine_store.save_scheduler(
             retry_entries=self.retry_entries,
             running_entries=self.running_entries,
-            codex_totals=self.codex_totals,
-            codex_threads=self.codex_threads,
+            runtime_totals=self.runtime_totals,
+            runtime_sessions=self.runtime_sessions,
             now_iso=now_iso,
             now_epoch=now_epoch,
         )
@@ -541,8 +503,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 workflow="issue-runner",
                 retry_entries=self.retry_entries,
                 running_entries=self.running_entries,
-                codex_totals=self.codex_totals,
-                codex_threads=self.codex_threads,
+                runtime_totals=self.runtime_totals,
+                runtime_sessions=self.runtime_sessions,
                 now_iso=now_iso,
                 now_epoch=now_epoch,
             ),
@@ -596,8 +558,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
         restored = restore_scheduler_state(payload, now_epoch=_now_epoch())
         self.retry_entries = restored.retry_entries
         self.running_entries = {}
-        self.codex_totals = dict(restored.codex_totals)
-        self.codex_threads = restored.codex_threads
+        self.runtime_totals = dict(restored.runtime_totals)
+        self.runtime_sessions = restored.runtime_sessions
         self.running_issue_id = None
 
         if restored.recovered_running:
@@ -615,42 +577,48 @@ class IssueRunnerWorkspace(WorkflowDriver):
     def _retry_queue_snapshot(self) -> list[dict[str, Any]]:
         return retry_queue_snapshot(self.retry_entries, now_epoch=_now_epoch())
 
-    def _codex_threads_snapshot(self) -> dict[str, dict[str, Any]]:
-        return codex_threads_snapshot(self.codex_threads)
+    def _runtime_sessions_snapshot(self) -> dict[str, dict[str, Any]]:
+        return runtime_sessions_snapshot(self.runtime_sessions)
 
-    def _codex_thread_for_issue(self, issue: dict[str, Any]) -> str | None:
+    def _runtime_session_id_for_issue(self, issue: dict[str, Any]) -> str | None:
         issue_id = str(issue.get("id") or "").strip()
         if not issue_id:
             return None
-        entry = self.codex_threads.get(issue_id) or {}
-        thread_id = str(entry.get("thread_id") or "").strip()
-        return thread_id or None
+        entry = self.runtime_sessions.get(issue_id) or {}
+        session_id = str(entry.get("session_id") or entry.get("thread_id") or "").strip()
+        return session_id or None
 
-    def _record_codex_thread(
+    def _record_runtime_session(
         self,
         *,
         issue: dict[str, Any],
         session_name: str,
         metrics: dict[str, Any],
+        runtime_name: str | None = None,
+        runtime_kind: str | None = None,
         run_id: str | None = None,
     ) -> None:
         issue_id = str(issue.get("id") or "").strip()
+        session_id = str(metrics.get("session_id") or metrics.get("thread_id") or "").strip()
         thread_id = str(metrics.get("thread_id") or "").strip()
-        if not issue_id or not thread_id:
+        if not issue_id or not session_id:
             return
-        self.codex_threads[issue_id] = {
+        self.runtime_sessions[issue_id] = {
             "issue_id": issue_id,
             "identifier": issue.get("identifier"),
             "session_name": session_name,
-            "thread_id": thread_id,
+            "session_id": session_id,
+            "thread_id": thread_id or None,
             "turn_id": metrics.get("turn_id"),
+            "runtime_name": runtime_name,
+            "runtime_kind": runtime_kind,
             "run_id": run_id,
             "updated_at": _now_iso(),
         }
 
-    def _clear_codex_thread(self, issue_id: str | None) -> None:
+    def _clear_runtime_session(self, issue_id: str | None) -> None:
         if issue_id:
-            self.codex_threads.pop(issue_id, None)
+            self.runtime_sessions.pop(issue_id, None)
 
     def _due_retry_issue(self, *, issues_by_id: dict[str, dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         now_epoch = _now_epoch()
@@ -801,7 +769,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
 
     def _record_metrics(self, result: PromptRunResult) -> dict[str, Any]:
         metrics = self._metrics_payload(result)
-        totals = dict(self.codex_totals or {})
+        totals = dict(self.runtime_totals or {})
         tokens = metrics.get("tokens") or {}
         totals["input_tokens"] = int(totals.get("input_tokens") or 0) + int(tokens.get("input_tokens") or 0)
         totals["output_tokens"] = int(totals.get("output_tokens") or 0) + int(tokens.get("output_tokens") or 0)
@@ -809,7 +777,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         totals["turn_count"] = int(totals.get("turn_count") or 0) + int(metrics.get("turn_count") or 0)
         if metrics.get("rate_limits") is not None:
             totals["rate_limits"] = metrics.get("rate_limits")
-        self.codex_totals = totals
+        self.runtime_totals = totals
         return metrics
 
     def _dispatch_slots(self) -> int:
@@ -1036,9 +1004,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
             else:
                 runtime = _build_runtimes_from_config(self.config, run=self._run, run_json=self._run_json)[runtime_name]
             session_name = issue_session_name(issue)
-            resume_thread_id = None
-            if str(runtime_cfg.get("kind") or "").strip() == "codex-app-server":
-                resume_thread_id = self._codex_thread_for_issue(issue)
+            resume_session_id = self._runtime_session_id_for_issue(issue)
             stage_result = run_runtime_stage(
                 runtime=runtime,
                 runtime_cfg=runtime_cfg,
@@ -1049,7 +1015,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 prompt=prompt,
                 prompt_path=prompt_path,
                 env=env,
-                resume_session_id=resume_thread_id,
+                resume_session_id=resume_session_id,
                 cancel_event=cancel_event,
                 placeholders={
                     "issue_id": str(issue.get("id") or ""),
@@ -1125,13 +1091,14 @@ class IssueRunnerWorkspace(WorkflowDriver):
                         rate_limits=metrics.get("rate_limits"),
                     )
                 )
-                if result.get("runtimeKind") == "codex-app-server":
-                    self._record_codex_thread(
-                        issue=issue,
-                        session_name=issue_session_name(issue),
-                        metrics=recorded_metrics,
-                        run_id=run_id,
-                    )
+                self._record_runtime_session(
+                    issue=issue,
+                    session_name=issue_session_name(issue),
+                    metrics=recorded_metrics,
+                    runtime_name=result.get("runtime"),
+                    runtime_kind=result.get("runtimeKind"),
+                    run_id=run_id,
+                )
                 result["metrics"] = recorded_metrics
 
             if result.get("ok"):
@@ -1444,9 +1411,12 @@ class IssueRunnerWorkspace(WorkflowDriver):
             )
             self._supervisor_futures[issue_id] = future
             entry = self.running_entries.get(issue_id) or {}
-            resume_thread_id = self._codex_thread_for_issue(issue)
-            if resume_thread_id:
-                entry["thread_id"] = resume_thread_id
+            resume_session_id = self._runtime_session_id_for_issue(issue)
+            if resume_session_id:
+                entry["session_id"] = resume_session_id
+                persisted_session = self.runtime_sessions.get(issue_id) or {}
+                if persisted_session.get("thread_id"):
+                    entry["thread_id"] = persisted_session.get("thread_id")
             dispatched.append(dict(entry))
             self._emit_event(
                 "issue_runner.worker.dispatched",
@@ -1474,260 +1444,13 @@ class IssueRunnerWorkspace(WorkflowDriver):
         return dispatched
 
     def supervise_once(self) -> dict[str, Any]:
-        engine_run = self.engine_store.start_run(mode="supervised")
-        status = {
-            "ok": True,
-            "workflow": "issue-runner",
-            "mode": "supervised",
-            "updatedAt": _now_iso(),
-            "selectedIssue": None,
-            "selectedIssues": [],
-            "attempt": None,
-            "outputPath": None,
-            "metrics": {},
-            "results": [],
-            "completedResults": [],
-            "dispatchedWorkers": [],
-            "cancellationRequests": [],
-        }
-        try:
-            try:
-                issues = self.tracker_client.list_all()
-                terminal_issues = self.tracker_client.list_terminal()
-            except Exception as exc:
-                status["ok"] = False
-                status["error"] = f"{type(exc).__name__}: {exc}"
-                status["engineRun"] = self._finish_engine_run_for_status(
-                    engine_run,
-                    status,
-                    selected_count=0,
-                    completed_count=0,
-                    metadata={"reason": "tracker-load-failed"},
-                )
-                self._write_status(status, health="error")
-                self._emit_event(
-                    "issue_runner.tick.failed",
-                    {
-                        "error": status["error"],
-                        "reason": "tracker-load-failed",
-                        "run_id": engine_run["run_id"],
-                    },
-                )
-                return status
-
-            status["cancellationRequests"] = self._request_terminal_cancellations(terminal_issues)
-            completed = self._reconcile_supervised_workers()
-            if completed:
-                status = self._status_from_results(base_status=status, results=completed)
-                status["completedResults"] = status.get("results") or []
-            suppressed_completed_ids = {
-                str((result.get("issue") or {}).get("id") or "").strip()
-                for result in completed
-                if result.get("suppressRetry")
-            }
-            cleanup = self._cleanup_terminal_workspaces(terminal_issues)
-            status["cleanup"] = cleanup
-
-            dispatch_issues = [
-                issue
-                for issue in issues
-                if str(issue.get("id") or "").strip() not in suppressed_completed_ids
-            ]
-            issues_by_id = {
-                str(issue.get("id")): issue
-                for issue in dispatch_issues
-                if str(issue.get("id") or "").strip()
-            }
-            selections = self._select_issue_batch(issues=dispatch_issues, issues_by_id=issues_by_id)
-            refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
-            for selected, retry_entry in selections:
-                issue_id = str(selected.get("id") or "").strip()
-                if issue_id:
-                    selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
-                refreshed_selections.append((selected, retry_entry))
-            selections = refreshed_selections
-            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
-            status["selectedIssue"] = selections[0][0] if selections else None
-            self._publish_selected_feedback(selections, run_id=engine_run["run_id"])
-            dispatched = self._dispatch_supervised_workers(selections, run_id=engine_run["run_id"])
-            status["dispatchedWorkers"] = dispatched
-            if not completed and not dispatched:
-                status["message"] = "no dispatchable issues"
-                self._emit_event(
-                    "issue_runner.tick.noop",
-                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
-                )
-
-            if completed and not all(result.get("ok") or result.get("suppressRetry") for result in completed):
-                status["ok"] = False
-            status["engineRun"] = self._finish_engine_run_for_status(
-                engine_run,
-                status,
-                metadata={
-                    "dispatched_count": len(dispatched),
-                    "cancellation_count": len(status.get("cancellationRequests") or []),
-                },
-            )
-            self._write_status(status, health="healthy" if status["ok"] else "error")
-            self._persist_scheduler_state()
-            return status
-        except Exception as exc:
-            self._fail_engine_run_after_exception(engine_run, exc)
-            raise
+        return self.orchestrator().supervise_once()
 
     def _reconcile_before_loop_exit(self, last_result: dict[str, Any] | None) -> dict[str, Any] | None:
-        engine_run = self.engine_store.start_run(mode="supervised-exit-reconcile")
-        try:
-            completed = self._reconcile_supervised_workers()
-            if not completed:
-                self._persist_scheduler_state()
-                self.engine_store.complete_run(
-                    engine_run["run_id"],
-                    selected_count=0,
-                    completed_count=0,
-                    metadata={"changed": False},
-                )
-                return last_result
-            status = {
-                "ok": True,
-                "workflow": "issue-runner",
-                "mode": "supervised-exit-reconcile",
-                "updatedAt": _now_iso(),
-                "selectedIssue": None,
-                "selectedIssues": [],
-                "attempt": None,
-                "outputPath": None,
-                "metrics": {},
-                "results": [],
-                "completedResults": [],
-                "dispatchedWorkers": [],
-                "cancellationRequests": [],
-            }
-            status = self._status_from_results(base_status=status, results=completed)
-            status["completedResults"] = status.get("results") or []
-            status["engineRun"] = self._finish_engine_run_for_status(
-                engine_run,
-                status,
-                selected_count=0,
-                completed_count=len(completed),
-                metadata={"changed": True},
-            )
-            self._write_status(status, health="healthy" if status["ok"] else "error")
-            self._persist_scheduler_state()
-            return status
-        except Exception as exc:
-            self._fail_engine_run_after_exception(engine_run, exc)
-            raise
+        return self.orchestrator().reconcile_before_loop_exit(last_result)
 
     def tick(self) -> dict[str, Any]:
-        engine_run = self.engine_store.start_run(mode="tick")
-        status = {
-            "ok": False,
-            "workflow": "issue-runner",
-            "updatedAt": _now_iso(),
-            "selectedIssue": None,
-            "selectedIssues": [],
-            "attempt": None,
-            "outputPath": None,
-            "metrics": {},
-        }
-        try:
-            try:
-                issues = self.tracker_client.list_all()
-                cleanup = self._cleanup_terminal_workspaces(self.tracker_client.list_terminal())
-            except Exception as exc:
-                status["error"] = f"{type(exc).__name__}: {exc}"
-                status["engineRun"] = self._finish_engine_run_for_status(
-                    engine_run,
-                    status,
-                    selected_count=0,
-                    completed_count=0,
-                    metadata={"reason": "tracker-load-failed"},
-                )
-                self._write_status(status, health="error")
-                self._emit_event(
-                    "issue_runner.tick.failed",
-                    {
-                        "error": status["error"],
-                        "reason": "tracker-load-failed",
-                        "run_id": engine_run["run_id"],
-                    },
-                )
-                return status
-            issues_by_id = {str(issue.get("id")): issue for issue in issues if str(issue.get("id") or "").strip()}
-            selections = self._select_issue_batch(issues=issues, issues_by_id=issues_by_id)
-            refreshed_selections: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
-            for selected, retry_entry in selections:
-                issue_id = str(selected.get("id") or "").strip()
-                if issue_id:
-                    selected = self.tracker_client.refresh([issue_id]).get(issue_id, selected)
-                refreshed_selections.append((selected, retry_entry))
-            selections = refreshed_selections
-            status["selectedIssues"] = [issue for issue, _retry_entry in selections]
-            status["selectedIssue"] = selections[0][0] if selections else None
-            status["cleanup"] = cleanup
-            if not selections:
-                status["ok"] = True
-                status["message"] = "no dispatchable issues"
-                status["engineRun"] = self._finish_engine_run_for_status(
-                    engine_run,
-                    status,
-                    selected_count=0,
-                    completed_count=0,
-                    metadata={"reason": "no-dispatchable-issues"},
-                )
-                self._write_status(status, health="healthy")
-                self._persist_scheduler_state()
-                self._emit_event(
-                    "issue_runner.tick.noop",
-                    {"reason": "no-dispatchable-issues", "run_id": engine_run["run_id"]},
-                )
-                return status
-
-            self._publish_selected_feedback(selections, run_id=engine_run["run_id"])
-            self._mark_running(selections, run_id=engine_run["run_id"])
-            results: list[dict[str, Any]] = []
-            try:
-                if len(selections) == 1:
-                    issue, retry_entry = selections[0]
-                    results = [
-                        self._execute_issue(
-                            issue=issue,
-                            retry_entry=retry_entry,
-                            run_id=engine_run["run_id"],
-                        )
-                    ]
-                else:
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=len(selections)) as executor:
-                        future_map = {
-                            executor.submit(
-                                self._execute_issue,
-                                issue=issue,
-                                retry_entry=retry_entry,
-                                run_id=engine_run["run_id"],
-                            ): (issue, retry_entry)
-                            for issue, retry_entry in selections
-                        }
-                        for future in concurrent.futures.as_completed(future_map):
-                            results.append(future.result())
-
-                status = self._status_from_results(base_status=status, results=results)
-                status["engineRun"] = self._finish_engine_run_for_status(
-                    engine_run,
-                    status,
-                    selected_count=len(selections),
-                    completed_count=len(results),
-                )
-                self._write_status(status, health="healthy" if status["ok"] else "error")
-                return status
-            finally:
-                self._clear_running([str(issue.get("id") or "") for issue, _retry_entry in selections])
-                self._persist_scheduler_state()
-        except Exception as exc:
-            self._fail_engine_run_after_exception(engine_run, exc)
-            raise
-        finally:
-            self._apply_event_retention()
+        return self.orchestrator().tick()
 
     def _cleanup_terminal_workspaces(self, issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
         terminal_states = self._terminal_states()
@@ -1738,7 +1461,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
                 continue
             issue_id = str(issue.get("id") or "")
             if issue_id in self.running_entries:
-                self._request_supervised_cancel(issue_id, reason="terminal-state")
+                self.orchestrator().request_supervised_cancel(issue_id, reason="terminal-state")
                 cleaned.append(
                     {
                         "issue_id": issue.get("id"),
@@ -1749,8 +1472,8 @@ class IssueRunnerWorkspace(WorkflowDriver):
                     }
                 )
                 continue
-            self._clear_retry(issue_id)
-            self._clear_codex_thread(issue_id)
+            self.orchestrator().clear_retry(issue_id)
+            self._clear_runtime_session(issue_id)
             issue_workspace = _safe_issue_workspace_path(self.issue_workspace_root, issue)
             if not issue_workspace.exists():
                 continue
@@ -1922,30 +1645,11 @@ class IssueRunnerWorkspace(WorkflowDriver):
         max_iterations: int | None = None,
         sleep_fn=time.sleep,
     ) -> dict[str, Any]:
-        iterations = 0
-        last_result = None
-        last_retention = self._apply_event_retention()
-        loop_status = "completed"
-        try:
-            while True:
-                self.reload_contract()
-                last_result = self.supervise_once()
-                last_retention = self._apply_event_retention()
-                iterations += 1
-                if max_iterations is not None and iterations >= max_iterations:
-                    break
-                sleep_fn(self._poll_interval_seconds(interval_seconds))
-        except KeyboardInterrupt:
-            loop_status = "interrupted"
-        last_result = self._reconcile_before_loop_exit(last_result)
-        if not self._supervisor_futures:
-            self.close()
-        return {
-            "loop_status": loop_status,
-            "iterations": iterations,
-            "last_result": last_result,
-            "event_retention": last_retention,
-        }
+        return self.orchestrator().run_loop(
+            interval_seconds=interval_seconds,
+            max_iterations=max_iterations,
+            sleep_fn=sleep_fn,
+        )
 
     def reload_contract(self) -> None:
         try:
@@ -2110,8 +1814,8 @@ def load_workspace_from_config(
         _run_json=runner_json,
         retry_entries={},
         running_entries={},
-        codex_threads={},
-        codex_totals={},
+        runtime_sessions={},
+        runtime_totals={},
     )
     workspace._restore_scheduler_state()
     return workspace

--- a/daedalus/workflows/runtime_presets.py
+++ b/daedalus/workflows/runtime_presets.py
@@ -31,6 +31,7 @@ from runtimes.capabilities import (
 RUNTIME_PRESETS: dict[str, dict[str, Any]] = {
     "codex-app-server": {
         "kind": "codex-app-server",
+        "stage-command": False,
         "mode": "external",
         "endpoint": "ws://127.0.0.1:4500",
         "ephemeral": False,

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -112,6 +112,7 @@ The bundled templates default executable roles to `codex-app-server`:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     ephemeral: false
@@ -234,6 +235,7 @@ consumes notifications until `turn/completed`.
 runtimes:
   codex:
     kind: codex-app-server
+    stage-command: false
     command: codex app-server
     ephemeral: false
     approval_policy: never
@@ -286,6 +288,7 @@ Then configure Daedalus for external mode:
 runtimes:
   codex:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz

--- a/docs/examples/change-delivery.workflow.md
+++ b/docs/examples/change-delivery.workflow.md
@@ -26,6 +26,7 @@ code-host:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz

--- a/docs/examples/issue-runner.workflow.md
+++ b/docs/examples/issue-runner.workflow.md
@@ -60,6 +60,7 @@ agent:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     healthcheck_path: /readyz

--- a/docs/operator/http-status.md
+++ b/docs/operator/http-status.md
@@ -55,18 +55,18 @@ Conforms to Symphony §13.7 / Daedalus spec §6.4:
   "counts":   { "running": 3, "retrying": 0 },
   "running":  [ { "issue_id": "01HF…", "issue_identifier": "#42", "state": "coding_dispatched", "session_id": "claude-coder-1", "turn_count": 0, "last_event": "turn_started", "started_at": "…", "last_event_at": "…", "tokens": { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680 } } ],
   "retrying": [],
-  "codex_totals": { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680, "seconds_running": 43 },
+  "runtime_totals": { "input_tokens": 1200, "output_tokens": 480, "total_tokens": 1680, "seconds_running": 43 },
   "rate_limits": { "requests_remaining": 47 },
   "recent_events": [ /* up to 20, newest first */ ]
 }
 ```
 
-Both bundled workflows report aggregate Codex token totals and latest
-rate-limit data from shared engine state when their active runtime is
-`codex-app-server`. `change-delivery` still derives running lane rows from its
-SQLite lane model; `issue-runner` derives running and retrying rows from the
-shared engine tables. `change-delivery` also includes `codex_turns` so
-operators can inspect active or canceling Codex `thread_id` / `turn_id` pairs.
+Both bundled workflows report aggregate runtime token totals and latest
+rate-limit data from shared engine state when the active runtime provides them.
+`change-delivery` derives running lane rows from its SQLite lane model;
+`issue-runner` derives running and retrying rows from the shared engine tables.
+`change-delivery` also includes `runtime_sessions` so operators can inspect
+active or canceling runtime session identifiers such as `thread_id` / `turn_id`.
 
 ### `GET /api/v1/events`
 

--- a/docs/symphony-daedalus-component-audit.md
+++ b/docs/symphony-daedalus-component-audit.md
@@ -1,0 +1,508 @@
+# Symphony vs Daedalus Component Audit
+
+This audit compares the pasted OpenAI/Symphony system overview against the
+current Daedalus implementation in this repository.
+
+Summary: Daedalus is architecturally aligned with Symphony, but it is not a
+strict Symphony realization yet. The closest compatibility target is the
+generic `issue-runner` workflow. The `change-delivery` workflow is intentionally
+richer and GitHub-first.
+
+## Executive Summary
+
+- `issue-runner` maps closely to the Symphony component model:
+  workflow loader, tracker client, workspace manager, agent runner, polling
+  orchestrator, status surface, and structured event/audit output.
+- `change-delivery` extends beyond Symphony:
+  lanes, actors, stages, gates, PR publish, internal/external review, merge
+  promotion, code-host operations, shadow/active execution, and operator
+  attention.
+- Daedalus persists orchestration state in SQLite plus JSON/JSONL projections.
+  Symphony's overview describes mainly in-memory runtime state plus logs.
+- Daedalus is tracker-neutral in code, but GitHub is the supported production
+  path today. Linear exists as an experimental adapter.
+
+## Main Component Comparison
+
+### Workflow Loader
+
+Symphony reference:
+
+- Reads `WORKFLOW.md`.
+- Parses YAML front matter and prompt body.
+- Returns `{config, prompt_template}`.
+
+Daedalus realization:
+
+- Supports `WORKFLOW.md`.
+- Supports `WORKFLOW-<workflow>.md` for multiple workflows in one repo.
+- Supports a workflow-root pointer at `config/workflow-contract-path`.
+- Parses YAML front matter and Markdown body.
+- Returns `WorkflowContract` with:
+  - `source_path`
+  - `config`
+  - `prompt_template`
+  - `front_matter`
+- Also projects the Markdown body into `config["workflow-policy"]`.
+
+Relevant code:
+
+- `daedalus/workflows/contract.py`
+
+Difference:
+
+Daedalus is more flexible than the reference loader, but the projected
+`workflow-policy` field means the body is not only returned as a prompt
+template; it is also merged into the config model.
+
+## Config Layer
+
+Symphony reference:
+
+- Exposes typed getters for workflow config values.
+- Applies defaults.
+- Resolves environment variable indirection.
+- Performs validation before dispatch.
+
+Daedalus realization:
+
+- Uses workflow-specific JSON Schema validation.
+- Uses workflow-specific preflight checks.
+- Uses local helper getters such as `_cfg_value`.
+- Resolves some environment indirection, for example:
+  - Linear API key via `$LINEAR_API_KEY`
+  - Codex WebSocket token env/file settings
+- Does not yet have one central typed config facade for all config values.
+
+Relevant code:
+
+- `daedalus/workflows/validation.py`
+- `daedalus/workflows/issue_runner/preflight.py`
+- `daedalus/workflows/issue_runner/workspace.py`
+- `daedalus/trackers/__init__.py`
+
+Difference:
+
+Daedalus validates strongly, but its config access is still distributed across
+workflow modules instead of being one explicit typed getter layer.
+
+## Issue Tracker Client
+
+Symphony reference:
+
+- Linear-first tracker in this specification version.
+- Fetches active candidate issues.
+- Refreshes specific issue IDs for reconciliation.
+- Fetches terminal-state issues during startup cleanup.
+- Normalizes tracker payloads into stable issue models.
+
+Daedalus realization:
+
+- Shared tracker protocol supports:
+  - `github`
+  - `local-json`
+  - `linear`
+- `issue-runner` uses this shared tracker boundary.
+- GitHub is the first-class public production path.
+- Linear exists, but is experimental/deferred.
+- Normalized issue shape includes:
+  - `id`
+  - `identifier`
+  - `title`
+  - `description`
+  - `priority`
+  - `state`
+  - `branch_name`
+  - `url`
+  - `labels`
+  - `blocked_by`
+  - timestamps
+
+Relevant code:
+
+- `daedalus/trackers/__init__.py`
+- `daedalus/trackers/github.py`
+- `daedalus/trackers/linear.py`
+- `daedalus/trackers/local_json.py`
+- `daedalus/workflows/issue_runner/tracker.py`
+
+Difference:
+
+Symphony is Linear-first. Daedalus is tracker-neutral in shape but GitHub-first
+in supported production use.
+
+## Orchestrator
+
+Symphony reference:
+
+- Owns the poll tick.
+- Owns in-memory runtime state.
+- Decides dispatch, retry, stop, and release behavior.
+- Tracks session metrics and retry queue state.
+
+Daedalus realization:
+
+- `issue-runner` now has an explicit `IssueRunnerOrchestrator`.
+- The orchestrator owns:
+  - issue selection
+  - retry priority
+  - worker dispatch
+  - worker reconciliation
+  - terminal cancellation requests
+  - run-loop behavior
+- Runtime state is not only in memory.
+- Scheduler state is persisted through `EngineStore` into SQLite.
+- JSON scheduler files are generated operator projections.
+
+Relevant code:
+
+- `daedalus/workflows/issue_runner/orchestrator.py`
+- `daedalus/workflows/issue_runner/workspace.py`
+- `daedalus/engine/store.py`
+- `daedalus/engine/scheduler.py`
+- `daedalus/engine/lifecycle.py`
+
+Difference:
+
+Daedalus is more durable than the reference overview. It treats SQLite as the
+source of truth for engine execution state instead of relying on in-memory
+runtime state alone.
+
+## Workspace Manager
+
+Symphony reference:
+
+- Maps issue identifiers to workspace paths.
+- Ensures per-issue workspace directories exist.
+- Runs workspace lifecycle hooks.
+- Cleans workspaces for terminal issues.
+
+Daedalus realization:
+
+- `issue-runner` maps issue identifiers to sanitized workspace slugs.
+- It enforces root containment checks before using workspace paths.
+- It creates per-issue directories.
+- It writes prompt/output under `.daedalus/`.
+- It supports hooks:
+  - `after_create`
+  - `before_run`
+  - `after_run`
+  - `before_remove`
+- It cleans terminal issue workspaces and suppresses retry state.
+
+Relevant code:
+
+- `daedalus/workflows/issue_runner/workspace.py`
+- `daedalus/workflows/issue_runner/tracker.py`
+
+Difference:
+
+`issue-runner` matches the Symphony workspace manager closely. `change-delivery`
+uses lane worktrees, lane state files, and lane memos instead of simple
+per-issue workspaces.
+
+## Agent Runner
+
+Symphony reference:
+
+- Creates workspace.
+- Builds prompt from issue plus workflow template.
+- Launches coding-agent app-server client.
+- Streams agent updates back to the orchestrator.
+
+Daedalus realization:
+
+- `issue-runner` creates/reuses the workspace.
+- It renders the Markdown body as the prompt template.
+- It dispatches through a shared runtime stage boundary.
+- Runtime backends include:
+  - `codex-app-server`
+  - `acpx-codex`
+  - `claude-cli`
+  - `hermes-agent`
+  - command stages
+- `codex-app-server` supports:
+  - managed stdio mode
+  - external WebSocket mode
+  - thread resume
+  - cooperative cancellation
+  - token metrics
+  - rate-limit metrics
+  - structured turn events
+
+Relevant code:
+
+- `daedalus/runtimes/__init__.py`
+- `daedalus/runtimes/stages.py`
+- `daedalus/runtimes/codex_app_server.py`
+- `daedalus/runtimes/capabilities.py`
+- `daedalus/workflows/issue_runner/workspace.py`
+
+Difference:
+
+Symphony's overview centers on one coding-agent app-server executable. Daedalus
+has a broader runtime abstraction. This is more flexible, but only
+`codex-app-server` fully matches the structured app-server behavior.
+
+## Status Surface
+
+Symphony reference:
+
+- Optional human-readable status surface.
+- Could be terminal output, dashboard, or another operator-facing view.
+
+Daedalus realization:
+
+- CLI/slash status commands.
+- `doctor` checks.
+- Watch/TUI surfaces.
+- Optional localhost HTTP server.
+- Engine run history.
+- Filterable event ledger.
+- Per-work-item debug views.
+- Status reads from SQLite plus JSON/JSONL projections.
+
+Relevant docs/code:
+
+- `docs/operator/http-status.md`
+- `daedalus/workflows/change_delivery/server/`
+- `daedalus/formatters.py`
+- `daedalus/watch.py`
+- `daedalus/watch_sources.py`
+
+Difference:
+
+Daedalus is stronger than the reference here. It has a larger operator control
+surface and more durable observability.
+
+## Logging
+
+Symphony reference:
+
+- Emits structured runtime logs to configured sinks.
+
+Daedalus realization:
+
+- Writes workflow audit JSONL.
+- Writes Daedalus runtime event JSONL.
+- Indexes events into SQLite best-effort.
+- Exposes event retention controls.
+- Supports webhook subscribers in `change-delivery`.
+- Tracks runtime metrics such as tokens and rate limits where the runtime
+  supports them.
+
+Relevant code:
+
+- `daedalus/engine/store.py`
+- `daedalus/engine/audit.py`
+- `daedalus/workflows/change_delivery/webhooks/`
+- `daedalus/workflows/issue_runner/workspace.py`
+
+Difference:
+
+Daedalus logging is not only sink-based; it is also part of the durable engine
+event model.
+
+## Abstraction Layer Comparison
+
+### Policy Layer
+
+Symphony:
+
+- `WORKFLOW.md` prompt body.
+- Team rules for ticket handling, validation, and handoff.
+
+Daedalus:
+
+- `WORKFLOW.md` body is policy text.
+- `issue-runner` uses it as the issue prompt template.
+- `change-delivery` composes it into actor prompts and gate-specific behavior.
+
+Difference:
+
+Daedalus supports the same idea, but `change-delivery` has much more policy in
+workflow code and schema, not only in the prompt body.
+
+### Configuration Layer
+
+Symphony:
+
+- Typed getters.
+- Defaults.
+- Environment indirection.
+- Path normalization.
+
+Daedalus:
+
+- Schema validation.
+- Preflight checks.
+- Local helper getters.
+- Some environment indirection.
+- Path normalization inside workspace/runtime loading.
+
+Difference:
+
+This is one of the clearest conformance gaps. Daedalus should centralize this
+if strict Symphony compatibility is the goal.
+
+### Coordination Layer
+
+Symphony:
+
+- Polling loop.
+- Eligibility.
+- Concurrency.
+- Retries.
+- Reconciliation.
+
+Daedalus:
+
+- `issue-runner` has this layer directly.
+- Durable scheduler state is shared through engine primitives.
+- `change-delivery` has a more complex lane/action orchestration model.
+
+Difference:
+
+Daedalus implements the layer, but it is split between generic engine primitives
+and workflow-specific orchestration.
+
+### Execution Layer
+
+Symphony:
+
+- Filesystem lifecycle.
+- Workspace preparation.
+- Coding-agent protocol.
+
+Daedalus:
+
+- Workspace lifecycle exists in `issue-runner`.
+- Lane worktree lifecycle exists in `change-delivery`.
+- Runtime dispatch is shared.
+- Codex app-server is supported, but not the only runtime.
+
+Difference:
+
+Daedalus is broader and more plugin-like.
+
+### Integration Layer
+
+Symphony:
+
+- Linear adapter.
+
+Daedalus:
+
+- GitHub adapter.
+- Local JSON adapter.
+- Experimental Linear adapter.
+- Separate `code-host` abstraction for PR/review/merge in `change-delivery`.
+
+Difference:
+
+Daedalus splits tracker and code-host concerns. That is more suitable for
+SDLC automation, but it diverges from the simpler Symphony overview.
+
+### Observability Layer
+
+Symphony:
+
+- Logs and optional status surface.
+
+Daedalus:
+
+- Logs.
+- Status.
+- Doctor.
+- Watch.
+- HTTP API.
+- SQLite runs/events.
+- Runtime metrics.
+- Tracker feedback.
+- Webhooks.
+
+Difference:
+
+Daedalus is significantly more developed here.
+
+## Workflow-Specific Notes
+
+### `issue-runner`
+
+Best match for Symphony.
+
+It provides:
+
+- Generic tracker-driven execution.
+- Per-issue workspaces.
+- Hooks.
+- Prompt rendering from `WORKFLOW.md` body.
+- One configured agent runtime.
+- Retry/backoff.
+- Running-worker recovery.
+- Terminal-state cleanup.
+- Optional tracker feedback.
+- Optional HTTP status surface.
+
+Remaining strict-conformance gaps:
+
+- Public contract is still Daedalus-shaped, not purely Symphony-shaped.
+- Runtime config uses `runtimes:` and `agent.runtime`, not a minimal Symphony
+  `codex` app-server-only model.
+- Config access is not centralized into a typed facade.
+- GitHub is the hardened public tracker path; Linear is not the primary
+  supported path.
+
+### `change-delivery`
+
+Opinionated SDLC workflow, not a strict Symphony port.
+
+It adds:
+
+- Active lane selection.
+- Implementation actors.
+- Internal review.
+- External review.
+- Repair handoff.
+- PR publish/update.
+- Maintainer approval gates.
+- CI gates.
+- Merge and promotion.
+- Shadow/active execution controls.
+- Operator attention state.
+- Code-host integration.
+
+This should be documented as a Daedalus extension rather than forced into the
+generic Symphony component model.
+
+## Material Differences to Track
+
+1. Make `issue-runner` the strict Symphony compatibility target.
+2. Move Daedalus-specific config under `daedalus:` where possible.
+3. Add or formalize a typed config layer with consistent defaults, environment
+   indirection, and path normalization.
+4. Decide whether strict compatibility means Linear-first, or whether Daedalus
+   will remain tracker-neutral with GitHub as the supported public path.
+5. Keep `change-delivery` as an opinionated extension with clear docs instead
+   of treating it as the reference Symphony realization.
+6. Strengthen command-runtime cancellation if non-Codex runtimes are expected
+   to behave like app-server runtimes.
+
+## Bottom Line
+
+Daedalus is a durable, production-oriented workflow engine inspired by the
+Symphony component model. It already implements most of the important system
+components, especially in `issue-runner`.
+
+The main mismatch is shape and scope:
+
+- Symphony describes a smaller Linear/app-server-centered reference workflow.
+- Daedalus implements a broader durable orchestration system with multiple
+  workflows, multiple runtime backends, durable SQLite state, GitHub-first
+  production integration, and a richer SDLC workflow.
+
+For release language, use:
+
+> Daedalus is Symphony-inspired and partially compatible. `issue-runner` is the
+> intended compatibility surface; `change-delivery` is an opinionated GitHub-first
+> SDLC extension.

--- a/docs/workflows/change-delivery.md
+++ b/docs/workflows/change-delivery.md
@@ -65,6 +65,7 @@ change only `runtimes` and the matching `actors.*.runtime` binding in
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     ephemeral: false
@@ -96,7 +97,7 @@ During supervised active service runs, Daedalus also records the active `turn_id
 If the active lane disappears, changes, the lease is lost, or the service is
 interrupted, the runtime requests `turn/interrupt` and marks the scheduler
 thread entry as `canceling`. Operators can see those entries in `/daedalus
-watch` and the HTTP state payload under `codex_turns`.
+watch` and the HTTP state payload under `runtime_sessions`.
 
 ## Operator path
 

--- a/docs/workflows/issue-runner.md
+++ b/docs/workflows/issue-runner.md
@@ -57,6 +57,7 @@ agent:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
     ephemeral: false

--- a/docs/workflows/workflow-contract.md
+++ b/docs/workflows/workflow-contract.md
@@ -51,6 +51,7 @@ agent:
 runtimes:
   codex-app-server:
     kind: codex-app-server
+    stage-command: false
     mode: external
     endpoint: ws://127.0.0.1:4500
 ---

--- a/tests/test_change_delivery_codex_app_server_smoke.py
+++ b/tests/test_change_delivery_codex_app_server_smoke.py
@@ -260,7 +260,7 @@ def test_live_change_delivery_codex_app_server_creates_issue_and_dispatches_lane
         assert result["threadId"] or result["resumeSessionId"]
 
         scheduler = workspace.load_scheduler()
-        entry = (scheduler.get("codex_threads") or {}).get(f"lane:{issue_number}") or {}
+        entry = (scheduler.get("runtime_sessions") or {}).get(f"lane:{issue_number}") or {}
         assert entry.get("thread_id") == (result["threadId"] or result["resumeSessionId"])
         assert entry.get("status") == "completed"
 

--- a/tests/test_daedalus_watch_render.py
+++ b/tests/test_daedalus_watch_render.py
@@ -37,7 +37,7 @@ def test_render_frame_with_one_lane():
     watch = _module()
     out = watch.render_frame_to_string({
         "active_lanes": [
-            {"lane_id": "329", "state": "under_review", "github_issue_number": 329}
+            {"lane_id": "329", "state": "under_review", "issue_identifier": "#329"}
         ],
         "alert_state": {},
         "recent_events": [
@@ -98,7 +98,7 @@ def test_render_frame_includes_issue_runner_workflow_status():
     assert "run=tick:completed selected=1 completed=1" in out
 
 
-def test_render_frame_includes_canceling_codex_turns():
+def test_render_frame_includes_canceling_runtime_sessions():
     watch = _module()
     out = watch.render_frame_to_string({
         "active_lanes": [],
@@ -108,7 +108,7 @@ def test_render_frame_includes_canceling_codex_turns():
             "retry_count": 0,
             "canceling_count": 1,
             "total_tokens": 18,
-            "codex_turns": [
+            "runtime_sessions": [
                 {
                     "issue_id": "lane:42",
                     "issue_identifier": "#42",
@@ -123,7 +123,7 @@ def test_render_frame_includes_canceling_codex_turns():
         "recent_events": [],
     })
     assert "canceling=1" in out
-    assert "codex_canceling=#42" in out
+    assert "runtime_canceling=#42" in out
     assert "thread=thread-42" in out
     assert "reason=operator-interrupt" in out
 
@@ -141,9 +141,34 @@ def _make_workflow_root(tmp_path):
     return root
 
 
+def _write_change_delivery_contract(root: Path):
+    from workflows.contract import render_workflow_markdown
+
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "change-delivery",
+                "schema-version": 1,
+                "instance": {"name": "attmous-daedalus-change-delivery", "engine-owner": "hermes"},
+                "repository": {"local-path": "/tmp/repo", "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+                "tracker": {"kind": "github", "github_slug": "attmous/daedalus"},
+                "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
+                "runtimes": {"coder-runtime": {"kind": "codex-app-server", "stage-command": False, "command": "codex app-server"}},
+                "actors": {"implementer": {"name": "coder", "model": "gpt-5.5", "runtime": "coder-runtime"}},
+                "stages": {"implement": {"actor": "implementer"}},
+                "gates": {"ci-green": {"type": "code-host-checks"}},
+                "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+            },
+            prompt_template="Deliver the active change.",
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_build_snapshot_combines_all_sources(tmp_path):
     watch = _module()
     root = _make_workflow_root(tmp_path)
+    _write_change_delivery_contract(root)
 
     # Seed daedalus-events
     (root / "runtime" / "memory" / "daedalus-events.jsonl").write_text(
@@ -261,8 +286,8 @@ def test_build_snapshot_includes_issue_runner_workflow_status(tmp_path):
         workflow="issue-runner",
         running_entries={"123": {"issue_id": "123", "identifier": "#123", "state": "open"}},
         retry_entries={},
-        codex_totals={"total_tokens": 18},
-        codex_threads={},
+        runtime_totals={"total_tokens": 18},
+        runtime_sessions={},
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478420.0,
     )

--- a/tests/test_daedalus_watch_sources.py
+++ b/tests/test_daedalus_watch_sources.py
@@ -31,6 +31,30 @@ def _make_workflow_root(tmp_path):
     return root
 
 
+def _write_change_delivery_contract(root: Path):
+    from workflows.contract import render_workflow_markdown
+
+    (root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(
+            config={
+                "workflow": "change-delivery",
+                "schema-version": 1,
+                "instance": {"name": "attmous-daedalus-change-delivery", "engine-owner": "hermes"},
+                "repository": {"local-path": "/tmp/repo", "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
+                "tracker": {"kind": "github", "github_slug": "attmous/daedalus"},
+                "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
+                "runtimes": {"coder-runtime": {"kind": "codex-app-server", "stage-command": False, "command": "codex app-server"}},
+                "actors": {"implementer": {"name": "coder", "model": "gpt-5.5", "runtime": "coder-runtime"}},
+                "stages": {"implement": {"actor": "implementer"}},
+                "gates": {"ci-green": {"type": "code-host-checks"}},
+                "triggers": {"lane-selector": {"type": "github-label", "label": "active-lane"}},
+            },
+            prompt_template="Deliver the active change.",
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_read_recent_daedalus_events_returns_last_n_lines_newest_first(tmp_path):
     sources = _module()
     root = _make_workflow_root(tmp_path)
@@ -94,11 +118,12 @@ def test_recent_engine_events_reads_sqlite_ledger(tmp_path):
 def test_read_active_lanes_from_db(tmp_path):
     """Schema must match the real ``lanes`` table in runtime.py:
        lane_id (PK), issue_number, workflow_state, lane_status.
-    Earlier drafts of active_lanes() queried `state` / `github_issue_number`
+    Earlier drafts of active_lanes() queried display aliases
     which silently raised sqlite3.OperationalError and was caught — making
     /daedalus watch always show no active lanes against a real db."""
     sources = _module()
     root = _make_workflow_root(tmp_path)
+    _write_change_delivery_contract(root)
     db_path = root / "runtime" / "state" / "daedalus" / "daedalus.db"
     conn = sqlite3.connect(db_path)
     conn.execute(
@@ -117,7 +142,7 @@ def test_read_active_lanes_from_db(tmp_path):
     assert lanes[0]["state"] == "under_review"             # consumer-facing alias
     assert lanes[0]["workflow_state"] == "under_review"    # canonical column name
     assert lanes[0]["issue_number"] == 329
-    assert lanes[0]["github_issue_number"] == 329          # consumer-facing alias
+    assert lanes[0]["issue_identifier"] == "#329"
     assert lanes[0]["lane_status"] == "active"
     assert lanes[0]["work_item"]["id"] == "lane-329"
     assert lanes[0]["work_item"]["identifier"] == "#329"
@@ -135,6 +160,7 @@ def test_active_lanes_returns_empty_when_query_fails():
         (root / "runtime" / "state" / "daedalus").mkdir(parents=True)
         (root / "config").mkdir()
         (root / "workspace").mkdir()
+        _write_change_delivery_contract(root)
         db_path = root / "runtime" / "state" / "daedalus" / "daedalus.db"
         conn = sqlite3.connect(db_path)
         # Wrong-shape lanes table — the prior bug.
@@ -198,8 +224,8 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
         workflow="issue-runner",
         running_entries={"123": {"issue_id": "123", "identifier": "#123", "state": "open"}},
         retry_entries={"124": {"issue_id": "124", "identifier": "#124", "error": "x", "due_at_epoch": 1714478410.0}},
-        codex_totals={"total_tokens": 18, "rate_limits": {"requests_remaining": 88}},
-        codex_threads={},
+        runtime_totals={"total_tokens": 18, "rate_limits": {"requests_remaining": 88}},
+        runtime_sessions={},
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478400.0,
     )
@@ -231,7 +257,7 @@ def test_issue_runner_watch_sources_use_repo_storage_paths(tmp_path):
     assert workflow_status["latest_runs"][0]["selected_count"] == 1
 
 
-def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
+def test_change_delivery_watch_sources_surface_canceling_runtime_sessions(tmp_path):
     from engine.state import save_engine_scheduler_state
     from engine.store import EngineStore
     from workflows.contract import render_workflow_markdown
@@ -248,7 +274,7 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
                 "repository": {"local-path": "/tmp/repo", "slug": "attmous/daedalus", "active-lane-label": "active-lane"},
                 "tracker": {"kind": "github", "github_slug": "attmous/daedalus", "active_states": ["open"], "terminal_states": ["closed"]},
                 "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
-                "runtimes": {"coder-runtime": {"kind": "codex-app-server", "command": "codex app-server"}},
+                "runtimes": {"coder-runtime": {"kind": "codex-app-server", "stage-command": False, "command": "codex app-server"}},
                 "actors": {"implementer": {"name": "coder", "model": "gpt-5.5", "runtime": "coder-runtime"}},
                 "stages": {"implement": {"actor": "implementer"}},
                 "gates": {"ci-green": {"type": "code-host-checks"}},
@@ -265,8 +291,8 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
         workflow="change-delivery",
         running_entries={},
         retry_entries={},
-        codex_totals={"total_tokens": 18},
-        codex_threads={
+        runtime_totals={"total_tokens": 18},
+        runtime_sessions={
             "lane:42": {
                 "issue_id": "lane:42",
                 "issue_number": 42,
@@ -296,7 +322,7 @@ def test_change_delivery_watch_sources_surface_canceling_codex_turns(tmp_path):
     assert workflow_status["running_count"] == 0
     assert workflow_status["canceling_count"] == 1
     assert workflow_status["total_tokens"] == 18
-    assert workflow_status["codex_turns"][0]["thread_id"] == "thread-42"
-    assert workflow_status["codex_turns"][0]["turn_id"] == "turn-42"
-    assert workflow_status["codex_turns"][0]["cancel_reason"] == "operator-interrupt"
+    assert workflow_status["runtime_sessions"][0]["thread_id"] == "thread-42"
+    assert workflow_status["runtime_sessions"][0]["turn_id"] == "turn-42"
+    assert workflow_status["runtime_sessions"][0]["cancel_reason"] == "operator-interrupt"
     assert workflow_status["latest_runs"][0]["mode"] == "active-iteration"

--- a/tests/test_engine_primitives.py
+++ b/tests/test_engine_primitives.py
@@ -25,31 +25,31 @@ def test_engine_storage_writes_json_and_jsonl(tmp_path):
     assert json.loads(log_path.read_text(encoding="utf-8")) == {"at": "now", "event": "b"}
 
 
-def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
+def test_engine_scheduler_restores_current_shapes_and_snapshots():
     from engine.scheduler import build_scheduler_payload, restore_scheduler_state, retry_due_at
 
     restored = restore_scheduler_state(
         {
-            "retryQueue": [
-                {
-                    "issueId": "42",
-                    "identifier": "#42",
-                    "attempt": 2,
-                    "dueAtEpoch": 125.0,
-                    "currentAttempt": 1,
-                }
-            ],
-            "running": [
-                {
-                    "issueId": "43",
-                    "workerId": "worker:43",
-                    "startedAtEpoch": 100.0,
-                    "heartbeatAtEpoch": 110.0,
-                    "cancelRequested": True,
-                }
-            ],
-            "codexTotals": {"total_tokens": 5},
-            "codexThreads": {"42": {"thread_id": "thread-1", "turn_id": "turn-1"}},
+                "retry_queue": [
+                    {
+                        "issue_id": "42",
+                        "identifier": "#42",
+                        "attempt": 2,
+                        "due_at_epoch": 125.0,
+                        "current_attempt": 1,
+                    }
+                ],
+                "running": [
+                    {
+                        "issue_id": "43",
+                        "worker_id": "worker:43",
+                        "started_at_epoch": 100.0,
+                        "heartbeat_at_epoch": 110.0,
+                        "cancel_requested": True,
+                    }
+                ],
+                "runtime_totals": {"total_tokens": 5},
+                "runtime_sessions": {"42": {"thread_id": "thread-1", "turn_id": "turn-1"}},
         },
         now_epoch=200.0,
     )
@@ -57,16 +57,16 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
     assert restored.retry_entries["42"]["due_at_epoch"] == 125.0
     assert restored.recovered_running[0]["issue_id"] == "43"
     assert restored.recovered_running[0]["cancel_requested"] is True
-    assert restored.codex_totals == {"total_tokens": 5}
-    assert restored.codex_threads["42"]["thread_id"] == "thread-1"
+    assert restored.runtime_totals == {"total_tokens": 5}
+    assert restored.runtime_sessions["42"]["thread_id"] == "thread-1"
     assert retry_due_at(restored.retry_entries["42"], default=999.0) == 125.0
 
     payload = build_scheduler_payload(
         workflow="issue-runner",
         retry_entries=restored.retry_entries,
         running_entries={"43": restored.recovered_running[0]},
-        codex_totals=restored.codex_totals,
-        codex_threads=restored.codex_threads,
+        runtime_totals=restored.runtime_totals,
+        runtime_sessions=restored.runtime_sessions,
         now_iso="2026-04-30T00:00:00Z",
         now_epoch=200.0,
     )
@@ -74,12 +74,12 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
     assert payload["workflow"] == "issue-runner"
     assert payload["retry_queue"][0]["due_in_ms"] == 0
     assert payload["running"][0]["running_for_ms"] == 100000
-    assert payload["codex_threads"]["42"]["thread_id"] == "thread-1"
+    assert payload["runtime_sessions"]["42"]["thread_id"] == "thread-1"
 
     restored_zero = restore_scheduler_state(
         {
-            "retryQueue": [{"issueId": "zero-retry", "dueAtEpoch": 0.0}],
-            "running": [{"issueId": "zero-running", "startedAtEpoch": 0.0, "heartbeatAtEpoch": 0.0}],
+            "retry_queue": [{"issue_id": "zero-retry", "due_at_epoch": 0.0}],
+            "running": [{"issue_id": "zero-running", "started_at_epoch": 0.0, "heartbeat_at_epoch": 0.0}],
         },
         now_epoch=200.0,
     )
@@ -90,7 +90,8 @@ def test_engine_scheduler_restores_legacy_shapes_and_snapshots():
 
 def test_engine_work_items_and_lifecycle_helpers():
     from engine.lifecycle import clear_work_entries, mark_running_work, recover_running_as_retry, schedule_retry_entry
-    from engine.work_items import work_item_from_change_delivery_lane, work_item_from_issue
+    from engine.work_items import work_item_from_issue
+    from workflows.change_delivery.work_items import lane_to_work_item_ref
 
     issue_work = work_item_from_issue(
         {
@@ -126,7 +127,7 @@ def test_engine_work_items_and_lifecycle_helpers():
     assert recovered["ISSUE-1"]["error"] == "scheduler restarted while issue was running"
     assert recovered["ISSUE-1"]["due_at_epoch"] == 200.0
 
-    lane_work = work_item_from_change_delivery_lane(
+    lane_work = lane_to_work_item_ref(
         {
             "lane_id": "lane-42",
             "issue_number": 42,
@@ -223,7 +224,7 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
                 "run_id": "run-1",
             }
         },
-        codex_threads={
+        runtime_sessions={
             "ISSUE-1": {
                 "issue_id": "ISSUE-1",
                 "identifier": "DAE-1",
@@ -235,7 +236,7 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
                 "updated_at": "2026-04-30T00:00:00Z",
             }
         },
-        codex_totals={"input_tokens": 3, "output_tokens": 4, "total_tokens": 7, "turn_count": 1},
+        runtime_totals={"input_tokens": 3, "output_tokens": 4, "total_tokens": 7, "turn_count": 1},
         now_iso="2026-04-30T00:00:00Z",
         now_epoch=120.0,
     )
@@ -259,9 +260,9 @@ def test_engine_state_persists_scheduler_snapshot_in_sqlite(tmp_path):
     assert loaded["retry_queue"][0]["issue_id"] == "ISSUE-2"
     assert loaded["retry_queue"][0]["run_id"] == "run-1"
     assert loaded["retry_queue"][0]["due_in_ms"] == 5000
-    assert loaded["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
-    assert loaded["codex_threads"]["ISSUE-1"]["run_id"] == "run-1"
-    assert loaded["codex_totals"]["total_tokens"] == 7
+    assert loaded["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert loaded["runtime_sessions"]["ISSUE-1"]["run_id"] == "run-1"
+    assert loaded["runtime_totals"]["total_tokens"] == 7
     assert readonly == loaded
 
 
@@ -288,8 +289,8 @@ def test_engine_state_preserves_zero_epoch_scheduler_values(tmp_path):
                 "error": "immediate retry",
             }
         },
-        codex_threads={},
-        codex_totals={},
+        runtime_sessions={},
+        runtime_totals={},
         now_iso="2026-04-30T00:00:00Z",
         now_epoch=120.0,
     )
@@ -331,21 +332,21 @@ def test_engine_store_wraps_scheduler_state_and_doctor(tmp_path):
             }
         },
         retry_entries={},
-        codex_threads={
+        runtime_sessions={
             "ISSUE-1": {
                 "issue_id": "ISSUE-1",
                 "identifier": "DAE-1",
                 "thread_id": "thread-1",
             }
         },
-        codex_totals={"total_tokens": 3},
+        runtime_totals={"total_tokens": 3},
     )
 
     snapshot = store.load_scheduler()
     checks = {check["name"]: check for check in store.doctor(stale_running_seconds=60)}
 
     assert snapshot["running"][0]["issue_id"] == "ISSUE-1"
-    assert snapshot["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert snapshot["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
     assert checks["engine-schema"]["status"] == "pass"
     assert checks["engine-running-work"]["status"] == "pass"
     assert checks["engine-retry-queue"]["detail"] == "0 queued retry item(s)"

--- a/tests/test_formatters_no_info_loss.py
+++ b/tests/test_formatters_no_info_loss.py
@@ -98,7 +98,7 @@ def test_issue_runner_status_no_info_loss():
             "max_concurrent_agents": 2,
             "running": [{"issue_id": "123"}],
             "retry_queue": [{"issue_id": "124"}],
-            "codex_totals": {
+            "runtime_totals": {
                 "input_tokens": 11,
                 "output_tokens": 7,
                 "total_tokens": 18,

--- a/tests/test_formatters_status.py
+++ b/tests/test_formatters_status.py
@@ -102,7 +102,7 @@ def test_format_status_issue_runner_renders_scheduler_and_tokens():
             "max_concurrent_agents": 2,
             "running": [{"issue_id": "123"}],
             "retry_queue": [{"issue_id": "124"}],
-            "codex_totals": {
+            "runtime_totals": {
                 "input_tokens": 11,
                 "output_tokens": 7,
                 "total_tokens": 18,

--- a/tests/test_runtime_presets.py
+++ b/tests/test_runtime_presets.py
@@ -141,6 +141,7 @@ def test_configure_runtime_uses_workflow_root_pointer_for_change_delivery(tmp_pa
     assert cfg["actors"]["implementer-high-effort"]["runtime"] == "coder-runtime"
     assert cfg["runtimes"]["codex"] == {
         "kind": "codex-app-server",
+        "stage-command": False,
         "mode": "external",
         "endpoint": "ws://127.0.0.1:4500",
         "ephemeral": False,

--- a/tests/test_runtime_stage_dispatcher.py
+++ b/tests/test_runtime_stage_dispatcher.py
@@ -122,7 +122,7 @@ def test_runtime_stage_reads_structured_command_result(tmp_path):
     assert metrics_source.rate_limits == {"requests_remaining": 42}
 
 
-def test_runtime_stage_runs_prompt_runtime_and_ignores_codex_transport_command(tmp_path):
+def test_runtime_stage_respects_transport_command_profile_flag(tmp_path):
     from runtimes.stages import prompt_result_from_stage, run_runtime_stage
 
     calls = {}
@@ -150,7 +150,7 @@ def test_runtime_stage_runs_prompt_runtime_and_ignores_codex_transport_command(t
 
     result = run_runtime_stage(
         runtime=FakeCodexRuntime(),
-        runtime_cfg={"kind": "codex-app-server", "command": ["codex", "app-server"]},
+        runtime_cfg={"kind": "codex-app-server", "stage-command": False, "command": ["codex", "app-server"]},
         agent_cfg={"model": "gpt-test", "runtime": "codex"},
         stage_name="coder",
         worktree=tmp_path,

--- a/tests/test_status_server.py
+++ b/tests/test_status_server.py
@@ -179,13 +179,13 @@ def _make_issue_runner_root(root: Path) -> None:
                 "due_at_epoch": 1714478410.0,
             }
         },
-        codex_totals={
+        runtime_totals={
             "input_tokens": 11,
             "output_tokens": 7,
             "total_tokens": 18,
             "rate_limits": {"requests_remaining": 88},
         },
-        codex_threads={},
+        runtime_sessions={},
         now_iso="2026-04-30T12:00:20Z",
         now_epoch=1714478415.0,
     )
@@ -224,7 +224,7 @@ def _make_change_delivery_root(root: Path) -> None:
                 "tracker": {"kind": "github", "github_slug": "attmous/daedalus", "active_states": ["open"], "terminal_states": ["closed"]},
                 "code-host": {"kind": "github", "github_slug": "attmous/daedalus"},
                 "runtimes": {
-                    "coder-runtime": {"kind": "codex-app-server", "command": "codex app-server"},
+                    "coder-runtime": {"kind": "codex-app-server", "stage-command": False, "command": "codex app-server"},
                     "reviewer-runtime": {"kind": "claude-cli", "max-turns-per-invocation": 24, "timeout-seconds": 1200},
                 },
                 "actors": {
@@ -254,7 +254,7 @@ def _make_change_delivery_root(root: Path) -> None:
         workflow="change-delivery",
         running_entries={},
         retry_entries={},
-        codex_threads={
+        runtime_sessions={
             "lane:42": {
                 "issue_id": "lane:42",
                 "issue_number": 42,
@@ -269,7 +269,7 @@ def _make_change_delivery_root(root: Path) -> None:
                 "updated_at": "2026-04-30T12:00:20Z",
             }
         },
-        codex_totals={
+        runtime_totals={
             "input_tokens": 11,
             "output_tokens": 7,
             "total_tokens": 18,
@@ -297,7 +297,7 @@ def test_state_view_empty_when_no_db(tmp_path: Path) -> None:
     assert view["counts"] == {"running": 0, "retrying": 0}
     assert view["running"] == []
     assert view["retrying"] == []
-    assert view["codex_totals"]["total_tokens"] == 0
+    assert view["runtime_totals"]["total_tokens"] == 0
     assert view["rate_limits"] is None
     assert "generated_at" in view
 
@@ -371,12 +371,12 @@ def test_issue_runner_state_view_reads_scheduler_and_audit_files(tmp_path: Path)
     assert view["running"][0]["issue_identifier"] == "#123"
     assert view["retrying"][0]["issue_identifier"] == "#124"
     assert view["latest_runs"][0]["mode"] == "tick"
-    assert view["codex_totals"]["total_tokens"] == 18
+    assert view["runtime_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
     assert view["recent_events"][0]["event"] == "issue_runner.tick.completed"
 
 
-def test_change_delivery_state_view_reads_codex_scheduler_totals(tmp_path: Path) -> None:
+def test_change_delivery_state_view_reads_runtime_scheduler_totals(tmp_path: Path) -> None:
     from workflows.change_delivery.server.views import state_view
 
     root = tmp_path / "change_delivery_root"
@@ -389,14 +389,14 @@ def test_change_delivery_state_view_reads_codex_scheduler_totals(tmp_path: Path)
     view = state_view(db, events, workflow_root=root)
 
     assert view["counts"] == {"running": 1, "retrying": 0}
-    assert view["codex_turn_counts"] == {"running": 0, "canceling": 1}
-    assert view["codex_totals"]["total_tokens"] == 18
+    assert view["runtime_session_counts"] == {"running": 0, "canceling": 1}
+    assert view["runtime_totals"]["total_tokens"] == 18
     assert view["rate_limits"] == {"requests_remaining": 88}
     assert view["latest_runs"][0]["mode"] == "active-iteration"
-    assert view["codex_turns"][0]["issue_id"] == "lane:42"
-    assert view["codex_turns"][0]["thread_id"] == "thread-42"
-    assert view["codex_turns"][0]["turn_id"] == "turn-42"
-    assert view["codex_turns"][0]["cancel_reason"] == "operator-interrupt"
+    assert view["runtime_sessions"][0]["issue_id"] == "lane:42"
+    assert view["runtime_sessions"][0]["thread_id"] == "thread-42"
+    assert view["runtime_sessions"][0]["turn_id"] == "turn-42"
+    assert view["runtime_sessions"][0]["cancel_reason"] == "operator-interrupt"
 
 
 def test_issue_runner_issue_view_resolves_running_and_retry_entries(tmp_path: Path) -> None:
@@ -488,7 +488,7 @@ def test_render_dashboard_escapes_html(tmp_path: Path) -> None:
             }
         ],
         "retrying": [],
-        "codex_totals": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "seconds_running": 0},
+        "runtime_totals": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "seconds_running": 0},
         "rate_limits": None,
         "recent_events": [],
     }

--- a/tests/test_systemd_template_units.py
+++ b/tests/test_systemd_template_units.py
@@ -194,7 +194,7 @@ def test_codex_app_server_doctor_reports_managed_health_and_threads(tmp_path, mo
         workflow="issue-runner",
         running_entries={},
         retry_entries={},
-        codex_threads={
+        runtime_sessions={
             "ISSUE-1": {
                 "issue_id": "ISSUE-1",
                 "identifier": "DAE-1",
@@ -205,7 +205,7 @@ def test_codex_app_server_doctor_reports_managed_health_and_threads(tmp_path, mo
                 "updated_at": "2026-04-30T00:00:00Z",
             }
         },
-        codex_totals={"total_tokens": 42, "turn_count": 1},
+        runtime_totals={"total_tokens": 42, "turn_count": 1},
         now_iso="2026-04-30T00:00:00Z",
         now_epoch=1777507200.0,
     )

--- a/tests/test_tools_bootstrap_workflow.py
+++ b/tests/test_tools_bootstrap_workflow.py
@@ -2,7 +2,6 @@ import importlib.util
 import json
 import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -293,13 +292,16 @@ def test_change_delivery_service_up_promotes_eligible_lane_before_start(tmp_path
     workflow_root.mkdir()
     calls: list[tuple] = []
 
-    fake_daedalus = SimpleNamespace(
-        init_daedalus_db=lambda **kwargs: calls.append(("init", kwargs)) or {"ok": True},
-    )
+    class FakeWorkflowModule:
+        @staticmethod
+        def service_prepare(*, workflow_root, project_key, service_mode):
+            return {
+                "init": calls.append(("init", {"workflow_root": workflow_root, "project_key": project_key, "service_mode": service_mode})) or {"ok": True},
+                "lane_selection": calls.append(("lane", str(workflow_root))) or {"ok": True, "promoted": True, "issueNumber": 7},
+            }
 
     monkeypatch.setattr(tools, "_validate_workflow_contract_preflight_for_service", lambda **_kwargs: {"ok": True, "workflow": "change-delivery"})
-    monkeypatch.setattr(tools, "_load_daedalus_module", lambda _workflow_root: fake_daedalus)
-    monkeypatch.setattr(tools, "_ensure_change_delivery_active_lane_for_start", lambda _workflow_root: calls.append(("lane", str(_workflow_root))) or {"ok": True, "promoted": True, "issueNumber": 7})
+    monkeypatch.setattr(tools, "_load_workflow_module_for_root", lambda _workflow_root: FakeWorkflowModule)
     monkeypatch.setattr(tools, "install_supervised_service", lambda **kwargs: calls.append(("install", kwargs)) or {"installed": True, "unit_path": str(tmp_path / "unit.service")})
     monkeypatch.setattr(tools, "service_control", lambda action, **kwargs: calls.append((action, kwargs)) or {"ok": True})
     monkeypatch.setattr(tools, "service_status", lambda **kwargs: calls.append(("status", kwargs)) or {"service_name": "daedalus-active@test.service"})
@@ -324,15 +326,27 @@ def test_change_delivery_active_service_loop_promotes_lane_before_running(tmp_pa
     workflow_root.mkdir()
     calls: list[str] = []
 
-    fake_daedalus = SimpleNamespace(
-        _project_key_for=lambda _workflow_root: "project",
-        run_active_loop=lambda **kwargs: calls.append("run-active") or {"loop_status": "completed", "kwargs": kwargs},
-        run_shadow_loop=lambda **kwargs: calls.append("run-shadow") or {"loop_status": "completed", "kwargs": kwargs},
-    )
+    class FakeWorkflowModule:
+        @staticmethod
+        def service_loop(*, workflow_root, project_key, instance_id, interval_seconds, max_iterations, service_mode):
+            calls.append("lane")
+            calls.append("run-active")
+            return {
+                "workflow": "change-delivery",
+                "service_mode": service_mode,
+                "loop_status": "completed",
+                "lane_selection": {"ok": True, "promoted": True, "issueNumber": 8},
+                "kwargs": {
+                    "workflow_root": workflow_root,
+                    "project_key": project_key,
+                    "instance_id": instance_id,
+                    "interval_seconds": interval_seconds,
+                    "max_iterations": max_iterations,
+                },
+            }
 
     monkeypatch.setattr(tools, "_assert_service_mode_supported", lambda **_kwargs: "change-delivery")
-    monkeypatch.setattr(tools, "_load_daedalus_module", lambda _workflow_root: fake_daedalus)
-    monkeypatch.setattr(tools, "_ensure_change_delivery_active_lane_for_start", lambda _workflow_root: calls.append("lane") or {"ok": True, "promoted": True, "issueNumber": 8})
+    monkeypatch.setattr(tools, "_load_workflow_module_for_root", lambda _workflow_root: FakeWorkflowModule)
 
     result = tools.service_loop(
         workflow_root=workflow_root,

--- a/tests/test_tools_run_cli_command_dispatch.py
+++ b/tests/test_tools_run_cli_command_dispatch.py
@@ -214,16 +214,19 @@ def test_run_cli_command_dispatches_bootstrap(tmp_path, capsys, monkeypatch):
 def test_run_cli_command_dispatches_service_loop_for_issue_runner(tmp_path, capsys, monkeypatch):
     tools = _tools()
 
-    class FakeWorkspace:
-        def run_loop(self, *, interval_seconds, max_iterations):
+    class FakeWorkflowModule:
+        @staticmethod
+        def service_loop(*, workflow_root, project_key, instance_id, interval_seconds, max_iterations, service_mode):
             return {
+                "workflow": "issue-runner",
+                "service_mode": service_mode,
                 "loop_status": "completed",
                 "iterations": max_iterations,
                 "last_result": {"ok": True},
             }
 
     monkeypatch.setattr(tools, "_assert_service_mode_supported", lambda **kwargs: "issue-runner")
-    monkeypatch.setattr(tools, "_load_issue_runner_workspace", lambda workflow_root: FakeWorkspace())
+    monkeypatch.setattr(tools, "_load_workflow_module_for_root", lambda workflow_root: FakeWorkflowModule)
     monkeypatch.setattr(tools, "_record_operator_command_event", lambda **kwargs: None)
 
     args = _parse(

--- a/tests/test_workflows_code_review_reviews.py
+++ b/tests/test_workflows_code_review_reviews.py
@@ -85,7 +85,7 @@ def test_run_inter_review_agent_review_via_runtime_uses_prompt_runtime(tmp_path)
         lane_state_path=None,
         head_sha="def456",
         runtime=FakeRuntime(),
-        runtime_cfg={"kind": "codex-app-server", "command": "codex app-server"},
+        runtime_cfg={"kind": "codex-app-server", "stage-command": False, "command": "codex app-server"},
         agent_cfg={"name": "Reviewer", "model": "gpt-review", "runtime": "codex-runtime"},
         session_name="internal-review-225",
         render_prompt_fn=lambda **kwargs: f"review {kwargs['issue']['number']}",
@@ -714,7 +714,7 @@ def test_external_review_review_shaping_helpers_cover_thread_mapping_findings_pe
     assert "lingering open thread(s) were superseded" in clean["summary"]
 
 
-def test_synthesize_repair_brief_collects_required_codex_threads_and_local_findings():
+def test_synthesize_repair_brief_collects_required_runtime_sessions_and_local_findings():
     reviews_module = load_module("daedalus_workflows_change_delivery_reviews_test", "workflows/change_delivery/reviews.py")
 
     result = reviews_module.synthesize_repair_brief(

--- a/tests/test_workflows_code_review_workspace.py
+++ b/tests/test_workflows_code_review_workspace.py
@@ -682,7 +682,7 @@ def test_workspace_internal_review_uses_configured_runtime(tmp_path):
     assert "Target local head SHA: abc123" in prompt_text
 
 
-def test_workspace_records_change_delivery_codex_threads_and_totals(tmp_path):
+def test_workspace_records_change_delivery_runtime_sessions_and_totals(tmp_path):
     from workflows.change_delivery.workspace import make_workspace
 
     cfg = _workflow_contract_config(tmp_path)
@@ -709,9 +709,9 @@ def test_workspace_records_change_delivery_codex_threads_and_totals(tmp_path):
     scheduler = json.loads((tmp_path / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
     assert metrics["thread_id"] == "thread-224"
     assert scheduler["workflow"] == "change-delivery"
-    assert scheduler["codex_threads"]["lane:224"]["thread_id"] == "thread-224"
-    assert scheduler["codex_totals"]["total_tokens"] == 18
-    assert scheduler["codex_totals"]["rate_limits"] == {"requests_remaining": 99}
+    assert scheduler["runtime_sessions"]["lane:224"]["thread_id"] == "thread-224"
+    assert scheduler["runtime_totals"]["total_tokens"] == 18
+    assert scheduler["runtime_totals"]["rate_limits"] == {"requests_remaining": 99}
     assert ws._codex_thread_for_issue_number(224) == "thread-224"
 
 
@@ -750,7 +750,7 @@ def test_workspace_records_progress_and_interrupts_active_codex_turn(tmp_path):
     result = ws._interrupt_active_implementation_turn(issue_number=224, reason="operator-interrupt")
 
     scheduler = json.loads((tmp_path / "memory" / "workflow-scheduler.json").read_text(encoding="utf-8"))
-    entry = scheduler["codex_threads"]["lane:224"]
+    entry = scheduler["runtime_sessions"]["lane:224"]
     assert result["interrupted"] is True
     assert calls == {"thread_id": "thread-224", "turn_id": "turn-active", "worktree": Path("/tmp/issue-224")}
     assert entry["status"] == "canceling"

--- a/tests/test_workflows_issue_runner_workspace.py
+++ b/tests/test_workflows_issue_runner_workspace.py
@@ -128,10 +128,11 @@ def _write_fake_codex_app_server(path: Path, *, requests_path: Path, fail: bool 
 def _use_codex_runtime_profile(cfg: dict, command: str) -> None:
     cfg["agent"]["runtime"] = "codex"
     cfg.pop("daedalus", None)
-    cfg["codex"]["command"] = command
+    cfg.pop("codex", None)
     cfg["runtimes"] = {
         "codex": {
             "kind": "codex-app-server",
+            "stage-command": False,
             "command": command,
             "ephemeral": False,
             "approval_policy": "never",
@@ -169,6 +170,34 @@ def _wait_for_supervised_futures(workspace, *, timeout: float = 2.0) -> None:
             return
         time.sleep(0.01)
     raise AssertionError("supervised futures did not finish")
+
+
+def test_issue_runner_workspace_exposes_orchestrator_boundary(tmp_path):
+    from workflows.issue_runner.orchestrator import IssueRunnerOrchestrator
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    cfg = _config(tmp_path)
+    workflow_root = tmp_path / "attmous-daedalus-issue-runner"
+    workflow_root.mkdir()
+    (tmp_path / "repo").mkdir()
+    _write_issue_runner_contract(workflow_root=workflow_root, cfg=cfg, issues=[])
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=lambda *args, **kwargs: None,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    orchestrator = workspace.orchestrator()
+    assert isinstance(orchestrator, IssueRunnerOrchestrator)
+    assert orchestrator.workspace is workspace
+
+    class FakeOrchestrator:
+        def tick(self):
+            return {"ok": True, "source": "fake-orchestrator"}
+
+    workspace.orchestrator = lambda: FakeOrchestrator()
+    assert workspace.tick() == {"ok": True, "source": "fake-orchestrator"}
 
 
 def test_issue_runner_tick_runs_selected_issue_and_writes_artifacts(tmp_path):
@@ -606,14 +635,14 @@ def test_issue_runner_tick_uses_codex_app_server_and_persists_metrics(tmp_path):
     status = workspace.build_status()
     assert status["metrics"]["tokens"]["total_tokens"] == 18
     assert status["metrics"]["rate_limits"]["requests_remaining"] == 99
-    assert status["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert status["scheduler"]["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
     assert status["runtimeDiagnostics"]["codex"]["kind"] == "codex-app-server"
     assert status["runtimeDiagnostics"]["codex"]["mode"] == "managed"
     assert status["runtimeDiagnostics"]["codex"]["transport"] == "stdio"
     assert status["runtimeDiagnostics"]["codex"]["keep_alive"] is False
 
 
-def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
+def test_issue_runner_runtime_session_mapping_persists_and_resumes(tmp_path):
     from workflows.issue_runner.workspace import load_workspace_from_config
 
     cfg = _config(tmp_path)
@@ -661,18 +690,18 @@ def test_issue_runner_codex_thread_mapping_persists_and_resumes(tmp_path):
     first_workspace = load_workspace_from_config(workspace_root=workflow_root)
     first = first_workspace.tick()
     assert first["ok"] is True
-    assert first_workspace.build_status()["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert first_workspace.build_status()["scheduler"]["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
 
     reloaded = load_workspace_from_config(workspace_root=workflow_root)
-    assert reloaded.build_status()["scheduler"]["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert reloaded.build_status()["scheduler"]["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
     reloaded.retry_entries["ISSUE-1"]["due_at_epoch"] = 0.0
 
     second = reloaded.tick()
     assert second["ok"] is True
     scheduler = reloaded.build_status()["scheduler"]
-    assert scheduler["codex_threads"]["ISSUE-1"]["thread_id"] == "thread-1"
-    assert scheduler["codex_totals"]["total_tokens"] == 36
-    assert scheduler["codex_totals"]["turn_count"] == 2
+    assert scheduler["runtime_sessions"]["ISSUE-1"]["thread_id"] == "thread-1"
+    assert scheduler["runtime_totals"]["total_tokens"] == 36
+    assert scheduler["runtime_totals"]["turn_count"] == 2
 
     requests = [json.loads(line) for line in requests_path.read_text(encoding="utf-8").splitlines()]
     methods = [item.get("method") for item in requests]
@@ -759,7 +788,7 @@ def test_issue_runner_retry_queue_retries_failed_issue_on_next_due_tick(tmp_path
     retry_queue = workspace.build_status()["scheduler"]["retry_queue"]
     assert retry_queue[0]["attempt"] == 1
     assert retry_queue[0]["error"] == "continuation"
-    assert workspace.build_status()["scheduler"]["codex_totals"]["total_tokens"] == 0
+    assert workspace.build_status()["scheduler"]["runtime_totals"]["total_tokens"] == 0
 
 
 def test_issue_runner_retry_queue_persists_across_workspace_reload(tmp_path):
@@ -1300,7 +1329,7 @@ def test_issue_runner_codex_failure_preserves_partial_metrics(tmp_path):
     assert result["ok"] is False
     assert result["metrics"]["tokens"]["total_tokens"] == 7
     assert result["metrics"]["rate_limits"]["requests_remaining"] == 88
-    assert workspace.build_status()["scheduler"]["codex_totals"]["total_tokens"] == 7
+    assert workspace.build_status()["scheduler"]["runtime_totals"]["total_tokens"] == 7
 
 
 def test_issue_runner_run_loop_keeps_last_known_good_on_invalid_reload(tmp_path):


### PR DESCRIPTION
## Summary

This PR tightens Daedalus engine neutrality across workflows, runtimes, trackers, and operator surfaces.

- Makes shared scheduler/state snapshots use runtime-neutral fields such as `runtime_sessions` and `runtime_totals`.
- Moves workflow-specific service preparation and loop behavior behind workflow-owned hooks.
- Removes change-delivery lane conversion from shared engine primitives.
- Treats Codex app-server commands as transport setup with `stage-command: false` instead of special-casing the runtime kind.
- Makes issue-runner persist and resume generic runtime sessions rather than Codex-only thread mappings.
- Updates watch/status/docs/tests to use tracker-neutral and runtime-neutral names.
- Adds a Symphony/Daedalus component audit document.

## Why

The engine was still carrying workflow- and Codex-specific names in shared contracts. That made the implementation less neutral than the intended design: workflows should own workflow policy, runtimes should own execution, and the engine should oversee state, scheduling, reconciliation, and telemetry without hardwiring a specific workflow or runtime.

## Validation

- `pytest -q` -> `899 passed, 7 skipped`
- `git diff --check` -> clean