### PR TITLE
[codex] Restructure Daedalus workflow system

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,16 @@ This wrapper keeps the repo installable via ``hermes plugins install`` without
 moving the engine package again.
 """
 
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent
+_INNER_DAEDALUS_DIR = _PLUGIN_ROOT / "daedalus"
+if "__path__" in globals() and _INNER_DAEDALUS_DIR.exists():
+    _inner_dir_str = str(_INNER_DAEDALUS_DIR)
+    if _inner_dir_str in __path__:
+        __path__.remove(_inner_dir_str)
+    __path__.insert(0, _inner_dir_str)
+
 try:
     from .daedalus import register as _register
 except ImportError:

--- a/daedalus/code_hosts/github.py
+++ b/daedalus/code_hosts/github.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from trackers.github import github_auth_host_from_slug, github_name_with_owner_from_slug
+from integrations.trackers.github import github_auth_host_from_slug, github_name_with_owner_from_slug
 
 from . import CodeHostConfigError, register
 

--- a/daedalus/engine/driver.py
+++ b/daedalus/engine/driver.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
+@runtime_checkable
 class WorkflowDriver(Protocol):
     """Minimal contract a workflow exposes to the Daedalus engine surface."""
 

--- a/daedalus/engine/events.py
+++ b/daedalus/engine/events.py
@@ -1,0 +1,35 @@
+"""Engine event compatibility exports."""
+
+try:
+    from daedalus.engine.state import (
+        append_engine_event_to_connection,
+        engine_event_stats_from_connection,
+        engine_events_for_run_from_connection,
+        engine_events_from_connection,
+        prune_engine_events_to_connection,
+        read_engine_event_stats,
+        read_engine_events,
+        read_engine_events_for_run,
+    )
+except ModuleNotFoundError:
+    from .state import (
+        append_engine_event_to_connection,
+        engine_event_stats_from_connection,
+        engine_events_for_run_from_connection,
+        engine_events_from_connection,
+        prune_engine_events_to_connection,
+        read_engine_event_stats,
+        read_engine_events,
+        read_engine_events_for_run,
+    )
+
+__all__ = [
+    "append_engine_event_to_connection",
+    "engine_event_stats_from_connection",
+    "engine_events_for_run_from_connection",
+    "engine_events_from_connection",
+    "prune_engine_events_to_connection",
+    "read_engine_event_stats",
+    "read_engine_events",
+    "read_engine_events_for_run",
+]

--- a/daedalus/engine/retries.py
+++ b/daedalus/engine/retries.py
@@ -1,0 +1,19 @@
+"""Engine retry/scheduler compatibility exports."""
+
+try:
+    from daedalus.engine.lifecycle import recover_running_as_retry, retry_delay, schedule_retry_entry
+    from daedalus.engine.scheduler import retry_due_at, retry_queue_snapshot
+    from daedalus.engine.work_items import RetryEntry
+except ModuleNotFoundError:
+    from .lifecycle import recover_running_as_retry, retry_delay, schedule_retry_entry
+    from .scheduler import retry_due_at, retry_queue_snapshot
+    from .work_items import RetryEntry
+
+__all__ = [
+    "RetryEntry",
+    "recover_running_as_retry",
+    "retry_delay",
+    "retry_due_at",
+    "retry_queue_snapshot",
+    "schedule_retry_entry",
+]

--- a/daedalus/engine/runs.py
+++ b/daedalus/engine/runs.py
@@ -1,0 +1,29 @@
+"""Engine run-state compatibility exports."""
+
+try:
+    from daedalus.engine.state import (
+        engine_run_from_connection,
+        finish_engine_run_to_connection,
+        latest_engine_runs_from_connection,
+        read_engine_run,
+        read_engine_runs,
+        start_engine_run_to_connection,
+    )
+except ModuleNotFoundError:
+    from .state import (
+        engine_run_from_connection,
+        finish_engine_run_to_connection,
+        latest_engine_runs_from_connection,
+        read_engine_run,
+        read_engine_runs,
+        start_engine_run_to_connection,
+    )
+
+__all__ = [
+    "engine_run_from_connection",
+    "finish_engine_run_to_connection",
+    "latest_engine_runs_from_connection",
+    "read_engine_run",
+    "read_engine_runs",
+    "start_engine_run_to_connection",
+]

--- a/daedalus/engine/schema.py
+++ b/daedalus/engine/schema.py
@@ -1,0 +1,14 @@
+"""Engine schema initialization compatibility exports."""
+
+try:
+    from daedalus.engine.sqlite import connect_daedalus_db
+    from daedalus.engine.state import engine_state_tables_exist, init_engine_state
+except ModuleNotFoundError:
+    from .sqlite import connect_daedalus_db
+    from .state import engine_state_tables_exist, init_engine_state
+
+__all__ = [
+    "connect_daedalus_db",
+    "engine_state_tables_exist",
+    "init_engine_state",
+]

--- a/daedalus/integrations/__init__.py
+++ b/daedalus/integrations/__init__.py
@@ -1,0 +1,2 @@
+"""External integration namespaces for Daedalus."""
+

--- a/daedalus/integrations/code_hosts/__init__.py
+++ b/daedalus/integrations/code_hosts/__init__.py
@@ -1,0 +1,7 @@
+"""Code-host integration compatibility namespace."""
+
+try:
+    from code_hosts import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.code_hosts import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/code_hosts/github.py
+++ b/daedalus/integrations/code_hosts/github.py
@@ -1,0 +1,7 @@
+"""GitHub code-host adapter compatibility exports."""
+
+try:
+    from code_hosts.github import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.code_hosts.github import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/code_hosts/registry.py
+++ b/daedalus/integrations/code_hosts/registry.py
@@ -1,0 +1,8 @@
+"""Code-host registry exports for the integrations namespace."""
+
+try:
+    from code_hosts import build_code_host_client, code_host_kind, register
+except ModuleNotFoundError:
+    from daedalus.code_hosts import build_code_host_client, code_host_kind, register
+
+__all__ = ["build_code_host_client", "code_host_kind", "register"]

--- a/daedalus/integrations/code_hosts/types.py
+++ b/daedalus/integrations/code_hosts/types.py
@@ -1,0 +1,8 @@
+"""Code-host type exports for the integrations namespace."""
+
+try:
+    from code_hosts import CodeHostClient, CodeHostConfigError
+except ModuleNotFoundError:
+    from daedalus.code_hosts import CodeHostClient, CodeHostConfigError
+
+__all__ = ["CodeHostClient", "CodeHostConfigError"]

--- a/daedalus/integrations/notifications/__init__.py
+++ b/daedalus/integrations/notifications/__init__.py
@@ -1,0 +1,4 @@
+"""Notification integration compatibility namespace."""
+
+from .webhooks import *  # noqa: F401,F403
+

--- a/daedalus/integrations/notifications/disabled.py
+++ b/daedalus/integrations/notifications/disabled.py
@@ -1,0 +1,7 @@
+"""Disabled webhook notification compatibility exports."""
+
+try:
+    from workflows.change_delivery.webhooks.disabled import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.webhooks.disabled import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/notifications/http_json.py
+++ b/daedalus/integrations/notifications/http_json.py
@@ -1,0 +1,7 @@
+"""HTTP JSON webhook notification compatibility exports."""
+
+try:
+    from workflows.change_delivery.webhooks.http_json import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.webhooks.http_json import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/notifications/slack.py
+++ b/daedalus/integrations/notifications/slack.py
@@ -1,0 +1,7 @@
+"""Slack notification compatibility exports."""
+
+try:
+    from workflows.change_delivery.webhooks.slack_incoming import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.webhooks.slack_incoming import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/notifications/types.py
+++ b/daedalus/integrations/notifications/types.py
@@ -1,0 +1,8 @@
+"""Notification type exports for the integrations namespace."""
+
+try:
+    from workflows.change_delivery.webhooks import Webhook, WebhookContext
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.webhooks import Webhook, WebhookContext
+
+__all__ = ["Webhook", "WebhookContext"]

--- a/daedalus/integrations/notifications/webhooks.py
+++ b/daedalus/integrations/notifications/webhooks.py
@@ -1,0 +1,7 @@
+"""Webhook notification compatibility exports."""
+
+try:
+    from workflows.change_delivery.webhooks import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.webhooks import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/integrations/trackers/__init__.py
+++ b/daedalus/integrations/trackers/__init__.py
@@ -1,0 +1,6 @@
+"""Tracker integration compatibility namespace."""
+
+try:
+    from trackers import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.trackers import *  # type: ignore # noqa: F401,F403

--- a/daedalus/integrations/trackers/feedback.py
+++ b/daedalus/integrations/trackers/feedback.py
@@ -1,0 +1,6 @@
+"""Tracker feedback helper compatibility exports."""
+
+try:
+    from trackers.feedback import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.trackers.feedback import *  # type: ignore # noqa: F401,F403

--- a/daedalus/integrations/trackers/github.py
+++ b/daedalus/integrations/trackers/github.py
@@ -1,0 +1,21 @@
+"""GitHub tracker adapter compatibility exports."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+try:
+    _MODULE = importlib.import_module("trackers.github")
+except ModuleNotFoundError:
+    _MODULE = importlib.import_module("daedalus.trackers.github")
+    sys.modules["trackers.github"] = _MODULE
+
+sys.modules["daedalus.trackers.github"] = _MODULE
+globals().update(
+    {
+        name: value
+        for name, value in _MODULE.__dict__.items()
+        if not (name.startswith("__") and name.endswith("__"))
+    }
+)

--- a/daedalus/integrations/trackers/linear.py
+++ b/daedalus/integrations/trackers/linear.py
@@ -1,0 +1,6 @@
+"""Linear tracker adapter compatibility exports."""
+
+try:
+    from trackers.linear import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.trackers.linear import *  # type: ignore # noqa: F401,F403

--- a/daedalus/integrations/trackers/local_json.py
+++ b/daedalus/integrations/trackers/local_json.py
@@ -1,0 +1,6 @@
+"""Local JSON tracker adapter compatibility exports."""
+
+try:
+    from trackers.local_json import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.trackers.local_json import *  # type: ignore # noqa: F401,F403

--- a/daedalus/integrations/trackers/registry.py
+++ b/daedalus/integrations/trackers/registry.py
@@ -1,0 +1,29 @@
+"""Tracker registry exports for the integrations namespace."""
+
+try:
+    from trackers import (
+        build_tracker_client,
+        describe_tracker_source,
+        load_issues,
+        register,
+        resolve_tracker_path,
+        tracker_kind,
+    )
+except ModuleNotFoundError:
+    from daedalus.trackers import (
+        build_tracker_client,
+        describe_tracker_source,
+        load_issues,
+        register,
+        resolve_tracker_path,
+        tracker_kind,
+    )
+
+__all__ = [
+    "build_tracker_client",
+    "describe_tracker_source",
+    "load_issues",
+    "register",
+    "resolve_tracker_path",
+    "tracker_kind",
+]

--- a/daedalus/integrations/trackers/types.py
+++ b/daedalus/integrations/trackers/types.py
@@ -1,0 +1,23 @@
+"""Tracker type exports for the integrations namespace."""
+
+try:
+    from trackers import (
+        DEFAULT_ACTIVE_STATES,
+        DEFAULT_TERMINAL_STATES,
+        TrackerClient,
+        TrackerConfigError,
+    )
+except ModuleNotFoundError:
+    from daedalus.trackers import (
+        DEFAULT_ACTIVE_STATES,
+        DEFAULT_TERMINAL_STATES,
+        TrackerClient,
+        TrackerConfigError,
+    )
+
+__all__ = [
+    "DEFAULT_ACTIVE_STATES",
+    "DEFAULT_TERMINAL_STATES",
+    "TrackerClient",
+    "TrackerConfigError",
+]

--- a/daedalus/operator/__init__.py
+++ b/daedalus/operator/__init__.py
@@ -1,0 +1,2 @@
+"""Operator-facing CLI, status, and service compatibility namespace."""
+

--- a/daedalus/operator/cli.py
+++ b/daedalus/operator/cli.py
@@ -1,0 +1,7 @@
+"""Operator CLI compatibility exports."""
+
+try:
+    from daedalus.daedalus_cli import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus_cli import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/operator/doctor.py
+++ b/daedalus/operator/doctor.py
@@ -1,0 +1,4 @@
+"""Operator doctor compatibility exports."""
+
+from .cli import *  # noqa: F401,F403
+

--- a/daedalus/operator/formatters.py
+++ b/daedalus/operator/formatters.py
@@ -1,0 +1,7 @@
+"""Operator formatter compatibility exports."""
+
+try:
+    from daedalus.formatters import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from formatters import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/operator/http_server.py
+++ b/daedalus/operator/http_server.py
@@ -1,0 +1,7 @@
+"""Operator HTTP status server compatibility exports."""
+
+try:
+    from workflows.change_delivery.server import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from daedalus.workflows.change_delivery.server import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/operator/service.py
+++ b/daedalus/operator/service.py
@@ -1,0 +1,4 @@
+"""Operator service-control compatibility exports."""
+
+from .cli import *  # noqa: F401,F403
+

--- a/daedalus/operator/systemd.py
+++ b/daedalus/operator/systemd.py
@@ -1,0 +1,4 @@
+"""Operator systemd compatibility exports."""
+
+from .cli import *  # noqa: F401,F403
+

--- a/daedalus/operator/watch.py
+++ b/daedalus/operator/watch.py
@@ -1,0 +1,7 @@
+"""Operator watch renderer compatibility exports."""
+
+try:
+    from daedalus.watch import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from watch import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/operator/watch_sources.py
+++ b/daedalus/operator/watch_sources.py
@@ -1,0 +1,7 @@
+"""Operator watch-source compatibility exports."""
+
+try:
+    from daedalus.watch_sources import *  # type: ignore # noqa: F401,F403
+except ModuleNotFoundError:
+    from watch_sources import *  # type: ignore # noqa: F401,F403
+

--- a/daedalus/runtimes/command.py
+++ b/daedalus/runtimes/command.py
@@ -1,0 +1,15 @@
+"""Runtime command-stage helper exports."""
+
+from .stages import (
+    materialize_prompt,
+    resolve_stage_command,
+    runtime_result_path,
+    substitute_command_placeholders,
+)
+
+__all__ = [
+    "materialize_prompt",
+    "resolve_stage_command",
+    "runtime_result_path",
+    "substitute_command_placeholders",
+]

--- a/daedalus/runtimes/registry.py
+++ b/daedalus/runtimes/registry.py
@@ -1,0 +1,8 @@
+"""Runtime registry compatibility exports."""
+
+try:
+    from runtimes import build_runtimes, register
+except ModuleNotFoundError:
+    from daedalus.runtimes import build_runtimes, register
+
+__all__ = ["build_runtimes", "register"]

--- a/daedalus/runtimes/types.py
+++ b/daedalus/runtimes/types.py
@@ -1,0 +1,13 @@
+"""Runtime protocol and result type exports."""
+
+try:
+    from runtimes import PromptRunResult, Runtime, SessionHandle, SessionHealth
+except ModuleNotFoundError:
+    from daedalus.runtimes import PromptRunResult, Runtime, SessionHandle, SessionHealth
+
+__all__ = [
+    "PromptRunResult",
+    "Runtime",
+    "SessionHandle",
+    "SessionHealth",
+]

--- a/daedalus/workflows/change_delivery/config.py
+++ b/daedalus/workflows/change_delivery/config.py
@@ -1,0 +1,214 @@
+"""Typed config view for the change-delivery workflow."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from workflows.core.config import ConfigView, resolve_path
+
+
+@dataclass(frozen=True)
+class RepositoryConfig:
+    local_path: Path | None
+    slug: str | None
+    active_lane_label: str
+
+
+@dataclass(frozen=True)
+class TrackerConfig:
+    kind: str | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CodeHostConfig:
+    kind: str | None
+    github_slug: str | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RuntimeProfilesConfig:
+    profiles: dict[str, dict[str, Any]]
+
+    def kind(self, runtime_name: str) -> str | None:
+        profile = self.profiles.get(runtime_name) or {}
+        value = profile.get("kind")
+        return str(value).strip() if value else None
+
+
+@dataclass(frozen=True)
+class ActorConfig:
+    name: str
+    model: str | None
+    runtime: str | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StageConfig:
+    name: str
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GateConfig:
+    name: str
+    type: str | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    ledger: Path
+    health: Path
+    audit_log: Path
+    scheduler: Path
+
+    def as_dict(self) -> dict[str, Path]:
+        return {
+            "ledger": self.ledger,
+            "health": self.health,
+            "audit_log": self.audit_log,
+            "scheduler": self.scheduler,
+        }
+
+
+@dataclass(frozen=True)
+class WebhookConfig:
+    subscriptions: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    port: int
+    bind: str
+
+
+@dataclass(frozen=True)
+class ChangeDeliveryConfig:
+    raw: dict[str, Any]
+    workflow_root: Path
+    repository: RepositoryConfig
+    tracker: TrackerConfig
+    code_host: CodeHostConfig
+    runtimes: RuntimeProfilesConfig
+    actors: dict[str, ActorConfig]
+    stages: dict[str, StageConfig]
+    gates: dict[str, GateConfig]
+    storage: StorageConfig
+    webhooks: WebhookConfig
+    server: ServerConfig
+
+    @classmethod
+    def from_raw(
+        cls,
+        config: dict[str, Any],
+        *,
+        workflow_root: Path | None = None,
+    ) -> "ChangeDeliveryConfig":
+        root = (workflow_root or Path(".")).expanduser().resolve()
+        view = ConfigView(config, workflow_root=root)
+        repository_raw = view.mapping("repository", default={}) or {}
+        repository = ConfigView(repository_raw, workflow_root=root)
+        tracker_raw = view.mapping("tracker", default={}) or {}
+        code_host_raw = view.mapping("code-host", "code_host", default={}) or {}
+        runtimes_raw = _mapping_of_mappings(view.mapping("runtimes", default={}) or {})
+        actors_raw = _mapping_of_mappings(view.mapping("actors", default={}) or {})
+        stages_raw = _mapping_of_mappings(view.mapping("stages", default={}) or {})
+        gates_raw = _mapping_of_mappings(view.mapping("gates", default={}) or {})
+        storage_raw = view.mapping("storage", default={}) or {}
+        storage = ConfigView(storage_raw, workflow_root=root)
+        server = ConfigView(view.mapping("server", default={}) or {})
+        local_path_value = repository.value("local-path", "local_path")
+        return cls(
+            raw=deepcopy(config),
+            workflow_root=root,
+            repository=RepositoryConfig(
+                local_path=(
+                    resolve_path(local_path_value, workflow_root=root)
+                    if local_path_value not in (None, "")
+                    else None
+                ),
+                slug=repository.str("slug"),
+                active_lane_label=repository.str("active-lane-label", "active_lane_label", default="active-lane") or "active-lane",
+            ),
+            tracker=TrackerConfig(
+                kind=ConfigView(tracker_raw).str("kind"),
+                raw=deepcopy(tracker_raw),
+            ),
+            code_host=CodeHostConfig(
+                kind=ConfigView(code_host_raw).str("kind"),
+                github_slug=ConfigView(code_host_raw).str("github_slug", "github-slug"),
+                raw=deepcopy(code_host_raw),
+            ),
+            runtimes=RuntimeProfilesConfig(profiles=deepcopy(runtimes_raw)),
+            actors={
+                name: ActorConfig(
+                    name=name,
+                    model=ConfigView(actor).str("model"),
+                    runtime=ConfigView(actor).str("runtime"),
+                    raw=deepcopy(actor),
+                )
+                for name, actor in actors_raw.items()
+            },
+            stages={
+                name: StageConfig(name=name, raw=deepcopy(stage))
+                for name, stage in stages_raw.items()
+            },
+            gates={
+                name: GateConfig(
+                    name=name,
+                    type=ConfigView(gate).str("type"),
+                    raw=deepcopy(gate),
+                )
+                for name, gate in gates_raw.items()
+            },
+            storage=StorageConfig(
+                ledger=resolve_path(storage.value("ledger"), workflow_root=root, default="memory/workflow-status.json"),
+                health=resolve_path(storage.value("health"), workflow_root=root, default="memory/workflow-health.json"),
+                audit_log=resolve_path(
+                    storage.value("audit-log", "audit_log"),
+                    workflow_root=root,
+                    default="memory/workflow-audit.jsonl",
+                ),
+                scheduler=resolve_path(
+                    storage.value("scheduler"),
+                    workflow_root=root,
+                    default="memory/workflow-scheduler.json",
+                ),
+            ),
+            webhooks=WebhookConfig(
+                subscriptions=list(view.list("webhooks", default=[]) or [])
+            ),
+            server=ServerConfig(
+                port=server.int("port", default=8080) or 8080,
+                bind=server.str("bind", default="127.0.0.1") or "127.0.0.1",
+            ),
+        )
+
+    def actor(self, name: str) -> ActorConfig | None:
+        return self.actors.get(name)
+
+    def runtime_for_actor(self, name: str) -> dict[str, Any] | None:
+        actor = self.actor(name)
+        if actor is None or not actor.runtime:
+            return None
+        return self.runtimes.profiles.get(actor.runtime)
+
+
+def _mapping_of_mappings(value: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(key): dict(item)
+        for key, item in value.items()
+        if isinstance(item, dict)
+    }
+
+
+def change_delivery_storage_paths_from_config(
+    workflow_root: Path,
+    config: dict[str, Any] | None,
+) -> dict[str, Path]:
+    return ChangeDeliveryConfig.from_raw(config or {}, workflow_root=workflow_root).storage.as_dict()

--- a/daedalus/workflows/change_delivery/github.py
+++ b/daedalus/workflows/change_delivery/github.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Any, Callable
 
-from trackers.github import GithubTrackerClient, issue_label_names as _shared_issue_label_names
+from integrations.trackers.github import GithubTrackerClient, issue_label_names as _shared_issue_label_names
 
 
 """Change-delivery workflow GitHub integration helpers.

--- a/daedalus/workflows/change_delivery/reviewers/github_comments.py
+++ b/daedalus/workflows/change_delivery/reviewers/github_comments.py
@@ -47,7 +47,7 @@ class GithubCommentsReviewer:
         self._repo_slug = cfg.get("repo-slug") or ws_context.repo_slug
         self._code_host_client = ws_context.code_host_client
         if self._repo_slug != ws_context.repo_slug:
-            from code_hosts import build_code_host_client
+            from integrations.code_hosts import build_code_host_client
 
             self._code_host_client = build_code_host_client(
                 workflow_root=ws_context.repo_path,

--- a/daedalus/workflows/change_delivery/storage.py
+++ b/daedalus/workflows/change_delivery/storage.py
@@ -5,30 +5,18 @@ import time
 from pathlib import Path
 from typing import Any
 
+from workflows.change_delivery.config import change_delivery_storage_paths_from_config
+
 
 def _now_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-
-
-def _resolve_storage_path(workflow_root: Path, value: Any, default: str) -> Path:
-    raw = str(value or default).strip() or default
-    path = Path(raw).expanduser()
-    if path.is_absolute():
-        return path
-    return (Path(workflow_root).resolve() / path).resolve()
 
 
 def change_delivery_storage_paths(
     workflow_root: Path,
     config: dict[str, Any] | None = None,
 ) -> dict[str, Path]:
-    storage = (config or {}).get("storage") or {}
-    return {
-        "ledger": _resolve_storage_path(workflow_root, storage.get("ledger"), "memory/workflow-status.json"),
-        "health": _resolve_storage_path(workflow_root, storage.get("health"), "memory/workflow-health.json"),
-        "audit_log": _resolve_storage_path(workflow_root, storage.get("audit-log"), "memory/workflow-audit.jsonl"),
-        "scheduler": _resolve_storage_path(workflow_root, storage.get("scheduler"), "memory/workflow-scheduler.json"),
-    }
+    return change_delivery_storage_paths_from_config(workflow_root, config)
 
 
 def default_idle_ledger(*, now_iso: str | None = None) -> dict[str, Any]:

--- a/daedalus/workflows/change_delivery/workspace.py
+++ b/daedalus/workflows/change_delivery/workspace.py
@@ -21,9 +21,9 @@ from workflows.change_delivery.migrations import get_ledger_field
 from workflows.change_delivery.storage import ensure_change_delivery_state_files
 from workflows.change_delivery.runtimes import build_runtimes
 from workflows.shared.paths import runtime_paths
-from code_hosts import build_code_host_client
-from trackers import build_tracker_client
-from trackers.feedback import feedback_enabled, publish_tracker_feedback
+from integrations.code_hosts import build_code_host_client
+from integrations.trackers import build_tracker_client
+from integrations.trackers.feedback import feedback_enabled, publish_tracker_feedback
 
 
 def _derive_lane_selection_cfg(yaml_cfg, *, active_lane_label):

--- a/daedalus/workflows/core/__init__.py
+++ b/daedalus/workflows/core/__init__.py
@@ -1,0 +1,38 @@
+"""Shared support utilities for Daedalus workflows."""
+
+from .config import (
+    ConfigError,
+    ConfigView,
+    first_present,
+    get_bool,
+    get_int,
+    get_list,
+    get_mapping,
+    get_str,
+    get_value,
+    require,
+    resolve_env_indirection,
+    resolve_path,
+)
+from .hooks import build_hook_env, run_shell_hook
+from .prompts import render_prompt_template
+from .types import WorkflowDriver
+
+__all__ = [
+    "ConfigError",
+    "ConfigView",
+    "first_present",
+    "get_bool",
+    "get_int",
+    "get_list",
+    "get_mapping",
+    "get_str",
+    "get_value",
+    "require",
+    "resolve_env_indirection",
+    "resolve_path",
+    "build_hook_env",
+    "run_shell_hook",
+    "render_prompt_template",
+    "WorkflowDriver",
+]

--- a/daedalus/workflows/core/config.py
+++ b/daedalus/workflows/core/config.py
@@ -1,0 +1,265 @@
+"""Typed access helpers for workflow configuration dictionaries."""
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_MISSING = object()
+
+
+class ConfigError(ValueError):
+    """Raised when workflow config is missing or has an unexpected type."""
+
+
+def _key_aliases(key: str) -> tuple[str, ...]:
+    aliases = [key]
+    dashed = key.replace("_", "-")
+    underscored = key.replace("-", "_")
+    for alias in (dashed, underscored):
+        if alias not in aliases:
+            aliases.append(alias)
+    return tuple(aliases)
+
+
+def _find_key(mapping: Mapping[str, Any], key: str) -> tuple[bool, Any]:
+    for alias in _key_aliases(key):
+        if alias in mapping:
+            return True, mapping[alias]
+    return False, None
+
+
+def _lookup_path(config: Mapping[str, Any], key: str) -> tuple[bool, Any]:
+    current: Any = config
+    for part in key.split("."):
+        if not isinstance(current, Mapping):
+            return False, None
+        found, current = _find_key(current, part)
+        if not found:
+            return False, None
+    return True, current
+
+
+def _path_label(keys: Sequence[str]) -> str:
+    return " / ".join(keys)
+
+
+def get_value(config: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    """Return the first configured value for ``keys`` with dash/underscore aliases."""
+
+    for key in keys:
+        found, value = _lookup_path(config, key)
+        if found:
+            return value
+    return default
+
+
+def first_present(config: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    """Alias for ``get_value`` that reads naturally at call sites with fallbacks."""
+
+    return get_value(config, *keys, default=default)
+
+
+def require(config: Mapping[str, Any], *keys: str) -> Any:
+    value = get_value(config, *keys, default=_MISSING)
+    if value is _MISSING or value in (None, ""):
+        raise ConfigError(f"missing required config value: {_path_label(keys)}")
+    return value
+
+
+def _typed_value(
+    config: Mapping[str, Any],
+    *keys: str,
+    expected: type | tuple[type, ...],
+    default: Any = None,
+    required: bool = False,
+) -> Any:
+    value = require(config, *keys) if required else get_value(config, *keys, default=_MISSING)
+    if value is _MISSING:
+        return default
+    if value is None:
+        if required:
+            raise ConfigError(f"missing required config value: {_path_label(keys)}")
+        return default
+    if not isinstance(value, expected):
+        expected_name = (
+            " or ".join(t.__name__ for t in expected)
+            if isinstance(expected, tuple)
+            else expected.__name__
+        )
+        raise ConfigError(
+            f"config value {_path_label(keys)} must be {expected_name}; "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def get_str(
+    config: Mapping[str, Any],
+    *keys: str,
+    default: str | None = None,
+    required: bool = False,
+) -> str | None:
+    return _typed_value(config, *keys, expected=str, default=default, required=required)
+
+
+def get_int(
+    config: Mapping[str, Any],
+    *keys: str,
+    default: int | None = None,
+    required: bool = False,
+) -> int | None:
+    value = require(config, *keys) if required else get_value(config, *keys, default=_MISSING)
+    if value is _MISSING or value is None:
+        return default
+    if isinstance(value, bool):
+        raise ConfigError(f"config value {_path_label(keys)} must be int; got bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        try:
+            return int(stripped)
+        except ValueError as exc:
+            raise ConfigError(f"config value {_path_label(keys)} must be int; got str") from exc
+    raise ConfigError(f"config value {_path_label(keys)} must be int; got {type(value).__name__}")
+
+
+def get_bool(
+    config: Mapping[str, Any],
+    *keys: str,
+    default: bool | None = None,
+    required: bool = False,
+) -> bool | None:
+    value = require(config, *keys) if required else get_value(config, *keys, default=_MISSING)
+    if value is _MISSING or value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ConfigError(f"config value {_path_label(keys)} must be bool; got {type(value).__name__}")
+
+
+def get_list(
+    config: Mapping[str, Any],
+    *keys: str,
+    default: list[Any] | None = None,
+    required: bool = False,
+) -> list[Any] | None:
+    value = _typed_value(config, *keys, expected=list, default=_MISSING, required=required)
+    if value is _MISSING:
+        return list(default) if default is not None else None
+    return list(value)
+
+
+def get_mapping(
+    config: Mapping[str, Any],
+    *keys: str,
+    default: Mapping[str, Any] | None = None,
+    required: bool = False,
+) -> dict[str, Any] | None:
+    value = _typed_value(config, *keys, expected=Mapping, default=_MISSING, required=required)
+    if value is _MISSING:
+        return dict(default) if default is not None else None
+    return dict(value)
+
+
+def resolve_env_indirection(
+    value: Any,
+    *,
+    env: Mapping[str, str] | None = None,
+    required: bool = False,
+) -> Any:
+    """Resolve ``$NAME`` values against the environment; literals pass through."""
+
+    if not isinstance(value, str) or not value.startswith("$") or len(value) == 1:
+        return value
+    env_name = value[1:]
+    source = os.environ if env is None else env
+    resolved = source.get(env_name)
+    if resolved in (None, "") and required:
+        raise ConfigError(f"environment variable {env_name} is required")
+    return resolved
+
+
+def resolve_path(
+    value: str | Path | None,
+    *,
+    workflow_root: Path,
+    default: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    raw: Any = value if value not in (None, "") else default
+    if raw in (None, ""):
+        raise ConfigError("path value is required")
+    raw = resolve_env_indirection(raw, env=env)
+    if raw in (None, ""):
+        raise ConfigError("path value is required")
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = workflow_root / path
+    return path.resolve()
+
+
+@dataclass(frozen=True)
+class ConfigView:
+    """Small typed facade around a raw workflow config mapping."""
+
+    raw: Mapping[str, Any]
+    workflow_root: Path | None = None
+
+    def value(self, *keys: str, default: Any = None) -> Any:
+        return get_value(self.raw, *keys, default=default)
+
+    def first_present(self, *keys: str, default: Any = None) -> Any:
+        return first_present(self.raw, *keys, default=default)
+
+    def require(self, *keys: str) -> Any:
+        return require(self.raw, *keys)
+
+    def str(self, *keys: str, default: str | None = None, required: bool = False) -> str | None:
+        return get_str(self.raw, *keys, default=default, required=required)
+
+    def int(self, *keys: str, default: int | None = None, required: bool = False) -> int | None:
+        return get_int(self.raw, *keys, default=default, required=required)
+
+    def bool(self, *keys: str, default: bool | None = None, required: bool = False) -> bool | None:
+        return get_bool(self.raw, *keys, default=default, required=required)
+
+    def list(self, *keys: str, default: list[Any] | None = None, required: bool = False) -> list[Any] | None:
+        return get_list(self.raw, *keys, default=default, required=required)
+
+    def mapping(
+        self,
+        *keys: str,
+        default: Mapping[str, Any] | None = None,
+        required: bool = False,
+    ) -> dict[str, Any] | None:
+        return get_mapping(self.raw, *keys, default=default, required=required)
+
+    def path(
+        self,
+        *keys: str,
+        default: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> Path:
+        if self.workflow_root is None:
+            raise ConfigError("ConfigView.path requires workflow_root")
+        return resolve_path(
+            get_value(self.raw, *keys, default=None),
+            workflow_root=self.workflow_root,
+            default=default,
+            env=env,
+        )
+
+    def section(self, *keys: str) -> "ConfigView":
+        value = get_mapping(self.raw, *keys, default={})
+        return ConfigView(value or {}, workflow_root=self.workflow_root)

--- a/daedalus/workflows/core/hooks.py
+++ b/daedalus/workflows/core/hooks.py
@@ -1,0 +1,46 @@
+"""Hook execution helpers shared by workflows."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import get_value
+
+
+def build_hook_env(values: dict[str, Any]) -> dict[str, str]:
+    """Return a subprocess environment overlay with stringified values."""
+
+    return {str(key): str(value) for key, value in values.items()}
+
+
+def run_shell_hook(
+    *,
+    hooks_config: dict[str, Any],
+    hook_name: str,
+    worktree: Path,
+    env: dict[str, str],
+    run: Callable[..., Any],
+    ignore_failure: bool = False,
+) -> dict[str, Any]:
+    script = str(get_value(hooks_config, hook_name, hook_name.replace("_", "-")) or "").strip()
+    if not script:
+        return {"hook": hook_name, "ran": False}
+    timeout_ms = int(get_value(hooks_config, "timeout_ms", "timeout-seconds", default=60000) or 60000)
+    timeout = max(timeout_ms // 1000, 1)
+    try:
+        completed = run(["bash", "-lc", script], cwd=worktree, timeout=timeout, env=env)
+    except Exception as exc:
+        if not ignore_failure:
+            raise
+        return {
+            "hook": hook_name,
+            "ran": True,
+            "returncode": None,
+            "ignored_failure": True,
+            "error": str(exc),
+        }
+    return {
+        "hook": hook_name,
+        "ran": True,
+        "returncode": getattr(completed, "returncode", 0),
+    }

--- a/daedalus/workflows/core/prompts.py
+++ b/daedalus/workflows/core/prompts.py
@@ -1,0 +1,51 @@
+"""Small prompt-template helpers shared by workflows."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+def render_prompt_template(
+    *,
+    prompt_template: str,
+    variables: dict[str, Any],
+    default_template: str = "",
+) -> str:
+    """Render simple ``{{ dotted.variable }}`` placeholders.
+
+    This is intentionally not a full template engine. Control blocks and
+    filters are rejected so workflow policy stays predictable.
+    """
+
+    template = str(prompt_template or "").strip()
+    if not template:
+        template = default_template
+    if "{%" in template or "%}" in template:
+        raise RuntimeError("template_parse_error: control blocks are not supported")
+
+    def replace(match: re.Match[str]) -> str:
+        expr = match.group(1).strip()
+        if "|" in expr:
+            raise RuntimeError(f"template_render_error: unsupported filter in {expr!r}")
+        value = _resolve_variable(expr, variables)
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, sort_keys=True)
+        return str(value)
+
+    rendered = re.sub(r"{{\s*([^{}]+?)\s*}}", replace, template)
+    if "{{" in rendered or "}}" in rendered:
+        raise RuntimeError("template_parse_error: unbalanced template delimiters")
+    return rendered.strip() + "\n"
+
+
+def _resolve_variable(expr: str, variables: dict[str, Any]) -> Any:
+    parts = expr.split(".")
+    value: Any = variables
+    for part in parts:
+        if not isinstance(value, dict) or part not in value:
+            raise RuntimeError(f"template_render_error: unknown variable {expr!r}")
+        value = value[part]
+    return value

--- a/daedalus/workflows/core/types.py
+++ b/daedalus/workflows/core/types.py
@@ -1,0 +1,8 @@
+"""Workflow-facing protocol types."""
+
+try:
+    from engine.driver import WorkflowDriver
+except ModuleNotFoundError:
+    from daedalus.engine.driver import WorkflowDriver
+
+__all__ = ["WorkflowDriver"]

--- a/daedalus/workflows/issue_runner/config.py
+++ b/daedalus/workflows/issue_runner/config.py
@@ -1,0 +1,194 @@
+"""Typed config normalization for the issue-runner workflow."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from workflows.core.config import ConfigView, get_int, get_mapping, get_value, resolve_path
+
+
+DEFAULT_ACTIVE_STATES = ("todo", "open", "ready")
+DEFAULT_TERMINAL_STATES = ("done", "closed", "canceled", "cancelled", "resolved")
+DEFAULT_MAX_RETRY_BACKOFF_MS = 300000
+
+
+def _clean_str_list(values: list[Any] | None, *, default: tuple[str, ...] = ()) -> tuple[str, ...]:
+    raw_values = values if values is not None else list(default)
+    return tuple(str(value).strip() for value in raw_values if str(value).strip())
+
+
+def _normalized_state_limit_map(raw: dict[str, Any] | None) -> dict[str, int]:
+    limits: dict[str, int] = {}
+    for state, limit in (raw or {}).items():
+        state_name = str(state).strip().lower()
+        if not state_name:
+            continue
+        numeric_limit = int(limit)
+        if numeric_limit > 0:
+            limits[state_name] = numeric_limit
+    return limits
+
+
+@dataclass(frozen=True)
+class PollingConfig:
+    interval_ms: int
+    interval_seconds: int
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "PollingConfig":
+        polling = ConfigView(get_mapping(config, "polling", default={}) or {})
+        interval_ms = polling.int("interval_ms")
+        if interval_ms in (None, ""):
+            interval_seconds = polling.int("interval_seconds", "interval-seconds", default=30) or 30
+            interval_ms = int(interval_seconds) * 1000
+        interval_ms = max(int(interval_ms or 30000), 1)
+        return cls(
+            interval_ms=interval_ms,
+            interval_seconds=max(interval_ms // 1000, 1),
+        )
+
+
+@dataclass(frozen=True)
+class WorkspaceConfig:
+    root: Path
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    status: Path
+    health: Path
+    audit_log: Path
+    scheduler: Path
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    max_concurrent_agents: int
+    max_concurrent_agents_by_state: dict[str, int]
+    max_retry_backoff_ms: int
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "AgentConfig":
+        agent = ConfigView(get_mapping(config, "agent", default={}) or {})
+        max_retry_backoff_ms = agent.int("max_retry_backoff_ms", default=DEFAULT_MAX_RETRY_BACKOFF_MS)
+        if max_retry_backoff_ms in (None, 0):
+            max_retry_backoff_ms = DEFAULT_MAX_RETRY_BACKOFF_MS
+        return cls(
+            max_concurrent_agents=max(agent.int("max_concurrent_agents", default=10) or 10, 1),
+            max_concurrent_agents_by_state=_normalized_state_limit_map(
+                agent.mapping("max_concurrent_agents_by_state", default={}) or {}
+            ),
+            max_retry_backoff_ms=int(max_retry_backoff_ms),
+        )
+
+
+@dataclass(frozen=True)
+class TrackerRuntimeConfig:
+    kind: str | None
+    active_states: tuple[str, ...]
+    terminal_states: tuple[str, ...]
+    required_labels: tuple[str, ...]
+    exclude_labels: tuple[str, ...]
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "TrackerRuntimeConfig":
+        tracker = ConfigView(get_mapping(config, "tracker", default={}) or {})
+        return cls(
+            kind=tracker.str("kind"),
+            active_states=tuple(value.lower() for value in _clean_str_list(
+                tracker.list("active_states", "active-states"),
+                default=DEFAULT_ACTIVE_STATES,
+            )),
+            terminal_states=tuple(value.lower() for value in _clean_str_list(
+                tracker.list("terminal_states", "terminal-states"),
+                default=DEFAULT_TERMINAL_STATES,
+            )),
+            required_labels=tuple(value.lower() for value in _clean_str_list(
+                tracker.list("required_labels", "required-labels"),
+            )),
+            exclude_labels=tuple(value.lower() for value in _clean_str_list(
+                tracker.list("exclude_labels", "exclude-labels"),
+            )),
+        )
+
+
+@dataclass(frozen=True)
+class IssueRunnerConfig:
+    raw: dict[str, Any]
+    workflow_root: Path
+    polling: PollingConfig
+    workspace: WorkspaceConfig
+    storage: StorageConfig
+    agent: AgentConfig
+    tracker: TrackerRuntimeConfig
+
+    @classmethod
+    def from_raw(
+        cls,
+        config: dict[str, Any],
+        *,
+        workflow_root: Path | None = None,
+    ) -> "IssueRunnerConfig":
+        root = (workflow_root or Path(".")).expanduser().resolve()
+        workspace_cfg = ConfigView(get_mapping(config, "workspace", default={}) or {}, workflow_root=root)
+        storage_cfg = ConfigView(get_mapping(config, "storage", default={}) or {}, workflow_root=root)
+        return cls(
+            raw=deepcopy(config),
+            workflow_root=root,
+            polling=PollingConfig.from_config(config),
+            workspace=WorkspaceConfig(
+                root=resolve_path(
+                    workspace_cfg.value("root"),
+                    workflow_root=root,
+                    default="workspace/issues",
+                )
+            ),
+            storage=StorageConfig(
+                status=resolve_path(
+                    storage_cfg.value("status"),
+                    workflow_root=root,
+                    default="memory/workflow-status.json",
+                ),
+                health=resolve_path(
+                    storage_cfg.value("health"),
+                    workflow_root=root,
+                    default="memory/workflow-health.json",
+                ),
+                audit_log=resolve_path(
+                    get_value(storage_cfg.raw, "audit-log", "audit_log"),
+                    workflow_root=root,
+                    default="memory/workflow-audit.jsonl",
+                ),
+                scheduler=resolve_path(
+                    storage_cfg.value("scheduler"),
+                    workflow_root=root,
+                    default="memory/workflow-scheduler.json",
+                ),
+            ),
+            agent=AgentConfig.from_config(config),
+            tracker=TrackerRuntimeConfig.from_config(config),
+        )
+
+
+def scheduler_state_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    polling = PollingConfig.from_config(config)
+    agent = AgentConfig.from_config(config)
+    return {
+        "poll_interval_ms": polling.interval_ms,
+        "max_concurrent_agents": agent.max_concurrent_agents,
+        "max_concurrent_agents_by_state": dict(agent.max_concurrent_agents_by_state),
+    }
+
+
+def poll_interval_seconds_from_config(config: dict[str, Any]) -> int:
+    return PollingConfig.from_config(config).interval_seconds
+
+
+def max_retry_backoff_ms_from_config(config: dict[str, Any]) -> int:
+    return AgentConfig.from_config(config).max_retry_backoff_ms
+
+
+def terminal_states_from_config(config: dict[str, Any]) -> set[str]:
+    return set(TrackerRuntimeConfig.from_config(config).terminal_states)

--- a/daedalus/workflows/issue_runner/orchestrator.py
+++ b/daedalus/workflows/issue_runner/orchestrator.py
@@ -10,7 +10,12 @@ from engine.lifecycle import clear_work_entries, mark_running_work, schedule_ret
 from engine.scheduler import retry_due_at
 from engine.storage import load_optional_json as _load_optional_json
 from engine.work_items import work_item_from_issue
-from runtimes import PromptRunResult
+from runtimes.types import PromptRunResult
+from workflows.issue_runner.config import (
+    max_retry_backoff_ms_from_config,
+    poll_interval_seconds_from_config,
+    scheduler_state_from_config as _typed_scheduler_state_from_config,
+)
 from workflows.issue_runner.tracker import eligible_issues, issue_session_name
 
 
@@ -22,28 +27,8 @@ def _now_epoch() -> float:
     return time.time()
 
 
-def _cfg_value(config: dict[str, Any], *keys: str, default: Any = None) -> Any:
-    for key in keys:
-        if key in config:
-            return config[key]
-    return default
-
-
 def scheduler_state_from_config(config: dict[str, Any]) -> dict[str, Any]:
-    polling_cfg = config.get("polling") or {}
-    agent_cfg = config.get("agent") or {}
-    interval_ms = _cfg_value(polling_cfg, "interval_ms")
-    if interval_ms in (None, ""):
-        interval_ms = int(_cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30) or 30) * 1000
-    return {
-        "poll_interval_ms": max(int(interval_ms or 30000), 1),
-        "max_concurrent_agents": max(int(agent_cfg.get("max_concurrent_agents") or 10), 1),
-        "max_concurrent_agents_by_state": {
-            str(state).strip().lower(): int(limit)
-            for state, limit in ((agent_cfg.get("max_concurrent_agents_by_state") or {}).items())
-            if str(state).strip() and int(limit) > 0
-        },
-    }
+    return _typed_scheduler_state_from_config(config)
 
 
 @dataclass
@@ -61,12 +46,7 @@ class IssueRunnerOrchestrator:
     def _poll_interval_seconds(self, override: int | None) -> int:
         if override is not None:
             return max(int(override), 1)
-        polling_cfg = self.workspace.config.get("polling") or {}
-        interval_ms = _cfg_value(polling_cfg, "interval_ms")
-        if interval_ms not in (None, ""):
-            return max(int(interval_ms) // 1000, 1)
-        interval_seconds = _cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30)
-        return max(int(interval_seconds or 30), 1)
+        return poll_interval_seconds_from_config(self.workspace.config)
 
     def _dispatch_slots(self) -> int:
         w = self.workspace
@@ -203,7 +183,7 @@ class IssueRunnerOrchestrator:
         run_id: str | None = None,
     ) -> dict[str, Any]:
         w = self.workspace
-        max_backoff_ms = int((w.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
+        max_backoff_ms = max_retry_backoff_ms_from_config(w.config)
         work_item = work_item_from_issue(issue, source=str((w.config.get("tracker") or {}).get("kind") or "tracker"))
         entry, retry = schedule_retry_entry(
             work_item=work_item,

--- a/daedalus/workflows/issue_runner/preflight.py
+++ b/daedalus/workflows/issue_runner/preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -7,13 +8,6 @@ from typing import Any
 from runtimes.capabilities import recognized_runtime_kinds
 from workflows.issue_runner.tracker import TrackerConfigError, build_tracker_client, resolve_tracker_path
 from workflows.runtime_presets import runtime_capability_checks, runtime_stage_checks
-from trackers.github import (
-    github_auth_host_from_slug,
-    github_auth_success_accounts,
-    github_name_with_owner_from_slug,
-    github_slug_from_config,
-    validate_github_tracker_config,
-)
 
 
 @dataclass(frozen=True)
@@ -82,6 +76,7 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
         tracker_kind = str(tracker_cfg.get("kind") or "").strip()
         tracker_client_cfg = dict(tracker_cfg)
         if tracker_kind == "github":
+            github_tracker = importlib.import_module("trackers.github")
             if tracker_client_cfg.get("github-slug"):
                 raise TrackerConfigError(
                     "issue-runner GitHub config uses tracker.github_slug; remove tracker.github-slug"
@@ -90,8 +85,8 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
                 raise TrackerConfigError(
                     "issue-runner GitHub config uses tracker.github_slug; remove repository.github-slug"
                 )
-            github_slug_from_config(tracker_client_cfg)
-            validate_github_tracker_config(
+            github_tracker.github_slug_from_config(tracker_client_cfg)
+            github_tracker.validate_github_tracker_config(
                 workflow_root=workflow_root,
                 tracker_cfg=tracker_client_cfg,
                 repository_cfg=repository_cfg,
@@ -101,18 +96,23 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
             path = resolve_tracker_path(workflow_root=workflow_root, tracker_cfg=tracker_cfg)
             if not path.exists():
                 raise TrackerConfigError(f"tracker.path does not exist: {path}")
+        github_run_json = None
+        if tracker_kind == "github":
+            github_run_json = importlib.import_module("trackers.github")._subprocess_run_json
         client = build_tracker_client(
             workflow_root=workflow_root,
             tracker_cfg=tracker_client_cfg,
             repo_path=repo_path,
+            run_json=github_run_json,
         )
         if tracker_kind == "github":
-            expected_slug = github_slug_from_config(tracker_client_cfg)
-            auth_host = github_auth_host_from_slug(expected_slug)
+            github_tracker = importlib.import_module("trackers.github")
+            expected_slug = github_tracker.github_slug_from_config(tracker_client_cfg)
+            auth_host = github_tracker.github_auth_host_from_slug(expected_slug)
             auth_status = getattr(client, "auth_status_payload")(hostname=auth_host)
             _assert_github_auth_ok(auth_status, hostname=auth_host)
             repo_view = getattr(client, "repo_view_payload")()
-            expected_name_with_owner = github_name_with_owner_from_slug(expected_slug)
+            expected_name_with_owner = github_tracker.github_name_with_owner_from_slug(expected_slug)
             actual_slug = str(repo_view.get("nameWithOwner") or "").strip()
             if (
                 expected_name_with_owner
@@ -127,4 +127,5 @@ def _validate_config(config: dict[str, Any], *, workflow_root: Path) -> None:
 
 
 def _assert_github_auth_ok(payload: dict[str, Any], *, hostname: str | None) -> None:
-    github_auth_success_accounts(payload, hostname=hostname)
+    github_tracker = importlib.import_module("trackers.github")
+    github_tracker.github_auth_success_accounts(payload, hostname=hostname)

--- a/daedalus/workflows/issue_runner/tracker.py
+++ b/daedalus/workflows/issue_runner/tracker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from trackers import (
+from integrations.trackers import (
     DEFAULT_ACTIVE_STATES,
     DEFAULT_TERMINAL_STATES,
     TrackerClient,

--- a/daedalus/workflows/issue_runner/workspace.py
+++ b/daedalus/workflows/issue_runner/workspace.py
@@ -23,7 +23,7 @@ from engine.scheduler import (
     retry_queue_snapshot,
     running_snapshot,
 )
-from engine.driver import WorkflowDriver
+from workflows.core.types import WorkflowDriver
 from engine.lifecycle import (
     clear_work_entries,
     mark_running_work,
@@ -35,11 +35,22 @@ from engine.storage import append_jsonl as _append_jsonl
 from engine.storage import load_optional_json as _load_optional_json
 from engine.storage import write_json_atomic as _write_json
 from engine.work_items import work_item_from_issue
-from runtimes import PromptRunResult, Runtime, build_runtimes
+from runtimes.registry import build_runtimes
+from runtimes.types import PromptRunResult, Runtime
 from runtimes.stages import prompt_result_from_stage, run_runtime_stage
 from workflows.contract import WORKFLOW_POLICY_KEY, WorkflowContractError, load_workflow_contract
+from workflows.core.config import ConfigError
+from workflows.core.hooks import build_hook_env, run_shell_hook
+from workflows.core.prompts import render_prompt_template
 from workflows.shared.config_snapshot import AtomicRef, ConfigSnapshot
 from workflows.shared.paths import runtime_paths
+from workflows.issue_runner.config import (
+    IssueRunnerConfig,
+    max_retry_backoff_ms_from_config,
+    poll_interval_seconds_from_config,
+    scheduler_state_from_config as _typed_scheduler_state_from_config,
+    terminal_states_from_config,
+)
 from workflows.issue_runner.orchestrator import IssueRunnerOrchestrator
 from workflows.issue_runner.tracker import (
     TrackerClient,
@@ -58,8 +69,8 @@ from workflows.runtime_presets import (
     runtime_capability_checks,
     runtime_stage_checks,
 )
-from trackers.feedback import publish_tracker_feedback
-from trackers.github import (
+from integrations.trackers.feedback import publish_tracker_feedback
+from integrations.trackers.github import (
     github_auth_host_from_slug,
     github_auth_success_accounts,
     github_name_with_owner_from_slug,
@@ -73,13 +84,6 @@ def _now_iso() -> str:
 
 def _now_epoch() -> float:
     return time.time()
-
-
-def _cfg_value(config: dict[str, Any], *keys: str, default: Any = None) -> Any:
-    for key in keys:
-        if key in config:
-            return config[key]
-    return default
 
 
 def _repository_path_from_config(workflow_root: Path, config: dict[str, Any]) -> Path | None:
@@ -153,37 +157,11 @@ def _assert_workspace_inside_root(workspace_root: Path, issue_workspace: Path) -
 
 
 def _render_prompt(*, prompt_template: str, issue: dict[str, Any], attempt: int | None) -> str:
-    template = str(prompt_template or "").strip()
-    if not template:
-        template = "You are working on an issue.\n\nIssue: {{ issue.identifier }} - {{ issue.title }}"
-    if "{%" in template or "%}" in template:
-        raise RuntimeError("template_parse_error: control blocks are not supported")
-
-    import re
-
-    def replace(match: re.Match[str]) -> str:
-        expr = match.group(1).strip()
-        if "|" in expr:
-            raise RuntimeError(f"template_render_error: unsupported filter in {expr!r}")
-        if expr == "attempt":
-            return "" if attempt is None else str(attempt)
-        if not expr.startswith("issue."):
-            raise RuntimeError(f"template_render_error: unknown variable {expr!r}")
-        value: Any = issue
-        for part in expr.split(".")[1:]:
-            if not isinstance(value, dict) or part not in value:
-                raise RuntimeError(f"template_render_error: unknown variable {expr!r}")
-            value = value[part]
-        if value is None:
-            return ""
-        if isinstance(value, (dict, list)):
-            return json.dumps(value, sort_keys=True)
-        return str(value)
-
-    rendered = re.sub(r"{{\s*([^{}]+?)\s*}}", replace, template)
-    if "{{" in rendered or "}}" in rendered:
-        raise RuntimeError("template_parse_error: unbalanced template delimiters")
-    return rendered.strip() + "\n"
+    return render_prompt_template(
+        prompt_template=prompt_template,
+        default_template="You are working on an issue.\n\nIssue: {{ issue.identifier }} - {{ issue.title }}",
+        variables={"issue": issue, "attempt": attempt},
+    )
 
 
 def _subprocess_run(command: list[str], *, cwd: Path | None = None, timeout: int | None = None, env: dict[str, str] | None = None):
@@ -230,20 +208,7 @@ def _build_runtimes_from_config(
 
 
 def _scheduler_state_from_config(config: dict[str, Any]) -> dict[str, Any]:
-    polling_cfg = config.get("polling") or {}
-    agent_cfg = config.get("agent") or {}
-    interval_ms = _cfg_value(polling_cfg, "interval_ms")
-    if interval_ms in (None, ""):
-        interval_ms = int(_cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30) or 30) * 1000
-    return {
-        "poll_interval_ms": max(int(interval_ms or 30000), 1),
-        "max_concurrent_agents": max(int(agent_cfg.get("max_concurrent_agents") or 10), 1),
-        "max_concurrent_agents_by_state": {
-            str(state).strip().lower(): int(limit)
-            for state, limit in ((agent_cfg.get("max_concurrent_agents_by_state") or {}).items())
-            if str(state).strip() and int(limit) > 0
-        },
-    }
+    return _typed_scheduler_state_from_config(config)
 
 
 @dataclass
@@ -312,12 +277,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
     def _poll_interval_seconds(self, override: int | None) -> int:
         if override is not None:
             return max(int(override), 1)
-        polling_cfg = self.config.get("polling") or {}
-        interval_ms = _cfg_value(polling_cfg, "interval_ms")
-        if interval_ms not in (None, ""):
-            return max(int(interval_ms) // 1000, 1)
-        interval_seconds = _cfg_value(polling_cfg, "interval_seconds", "interval-seconds", default=30)
-        return max(int(interval_seconds or 30), 1)
+        return poll_interval_seconds_from_config(self.config)
 
     def build_status(self) -> dict[str, Any]:
         snapshot = self.snapshot_ref.get()
@@ -649,7 +609,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         delay_type: str = "failure",
         run_id: str | None = None,
     ) -> dict[str, Any]:
-        max_backoff_ms = int((self.config.get("agent") or {}).get("max_retry_backoff_ms") or 300000)
+        max_backoff_ms = max_retry_backoff_ms_from_config(self.config)
         work_item = work_item_from_issue(issue, source=str((self.config.get("tracker") or {}).get("kind") or "tracker"))
         entry, retry = schedule_retry_entry(
             work_item=work_item,
@@ -678,15 +638,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         self.retry_entries = clear_work_entries(self.retry_entries, [issue_id])
 
     def _terminal_states(self) -> set[str]:
-        tracker_cfg = self.config.get("tracker") or {}
-        return {
-            str(value).strip().lower()
-            for value in (
-                _cfg_value(tracker_cfg, "terminal_states", "terminal-states")
-                or ["done", "closed", "canceled", "cancelled", "resolved"]
-            )
-            if str(value).strip()
-        }
+        return terminal_states_from_config(self.config)
 
     def _feedback_reached_terminal_state(self, feedback_result: dict[str, Any]) -> bool:
         state = str(feedback_result.get("state") or "").strip().lower()
@@ -1558,18 +1510,20 @@ class IssueRunnerWorkspace(WorkflowDriver):
         output_path: Path,
     ) -> dict[str, str]:
         repository_cfg = self.config.get("repository") or {}
-        return {
-            "WORKFLOW_ROOT": str(self.path),
-            "ISSUE_ID": str(issue.get("id") or ""),
-            "ISSUE_IDENTIFIER": str(issue.get("identifier") or ""),
-            "ISSUE_TITLE": str(issue.get("title") or ""),
-            "ISSUE_STATE": str(issue.get("state") or ""),
-            "ISSUE_LABELS": ",".join(issue.get("labels") or []),
-            "ISSUE_WORKSPACE": str(issue_workspace),
-            "PROMPT_PATH": str(prompt_path),
-            "OUTPUT_PATH": str(output_path),
-            "REPOSITORY_PATH": str(repository_cfg.get("local-path") or ""),
-        }
+        return build_hook_env(
+            {
+                "WORKFLOW_ROOT": self.path,
+                "ISSUE_ID": issue.get("id") or "",
+                "ISSUE_IDENTIFIER": issue.get("identifier") or "",
+                "ISSUE_TITLE": issue.get("title") or "",
+                "ISSUE_STATE": issue.get("state") or "",
+                "ISSUE_LABELS": ",".join(issue.get("labels") or []),
+                "ISSUE_WORKSPACE": issue_workspace,
+                "PROMPT_PATH": prompt_path,
+                "OUTPUT_PATH": output_path,
+                "REPOSITORY_PATH": repository_cfg.get("local-path") or "",
+            }
+        )
 
     def _run_hook(
         self,
@@ -1579,29 +1533,14 @@ class IssueRunnerWorkspace(WorkflowDriver):
         *,
         ignore_failure: bool = False,
     ) -> dict[str, Any]:
-        hooks_cfg = self.config.get("hooks") or {}
-        script = str(_cfg_value(hooks_cfg, hook_name, hook_name.replace("_", "-")) or "").strip()
-        if not script:
-            return {"hook": hook_name, "ran": False}
-        timeout_ms = int(_cfg_value(hooks_cfg, "timeout_ms", "timeout-seconds", default=60000) or 60000)
-        timeout = max(timeout_ms // 1000, 1)
-        try:
-            completed = self._run(["bash", "-lc", script], cwd=worktree, timeout=timeout, env=env)
-        except Exception as exc:
-            if not ignore_failure:
-                raise
-            return {
-                "hook": hook_name,
-                "ran": True,
-                "returncode": None,
-                "ignored_failure": True,
-                "error": str(exc),
-            }
-        return {
-            "hook": hook_name,
-            "ran": True,
-            "returncode": getattr(completed, "returncode", 0),
-        }
+        return run_shell_hook(
+            hooks_config=self.config.get("hooks") or {},
+            hook_name=hook_name,
+            worktree=worktree,
+            env=env,
+            run=self._run,
+            ignore_failure=ignore_failure,
+        )
 
     def _metrics_payload(self, result: PromptRunResult) -> dict[str, Any]:
         return {
@@ -1654,10 +1593,13 @@ class IssueRunnerWorkspace(WorkflowDriver):
     def reload_contract(self) -> None:
         try:
             contract = load_workflow_contract(self.path)
-            _validate_issue_runner_config(dict(contract.config))
+            next_config = dict(contract.config)
+            _validate_issue_runner_config(next_config)
+            typed_cfg = IssueRunnerConfig.from_raw(next_config, workflow_root=self.path)
         except (
             FileNotFoundError,
             WorkflowContractError,
+            ConfigError,
             JsonSchemaValidationError,
             OSError,
             UnicodeDecodeError,
@@ -1677,7 +1619,7 @@ class IssueRunnerWorkspace(WorkflowDriver):
         current_key = (current.source_mtime, current.source_size, str(self.contract_path))
         if key == current_key:
             return
-        cfg = dict(contract.config)
+        cfg = next_config
         prompts = cfg.get("prompts") or {}
         snapshot = ConfigSnapshot(
             config=cfg,
@@ -1692,8 +1634,6 @@ class IssueRunnerWorkspace(WorkflowDriver):
         self.snapshot_ref.set(snapshot)
         tracker_cfg = cfg.get("tracker") or {}
         tracker_client_cfg = _tracker_config_for_client(cfg)
-        workspace_cfg = cfg.get("workspace") or {}
-        storage_cfg = cfg.get("storage") or {}
         repo_path = _repository_path_from_config(self.path, cfg)
         tracker_source_cfg = dict(tracker_client_cfg)
         if repo_path is not None and str(tracker_cfg.get("kind") or "").strip() == "github":
@@ -1708,18 +1648,11 @@ class IssueRunnerWorkspace(WorkflowDriver):
         )
         previous_scheduler_path = self.scheduler_path
 
-        def _resolve_path(value: str, default: str) -> Path:
-            raw = str(value or default).strip()
-            path = Path(raw).expanduser()
-            if not path.is_absolute():
-                path = (self.path / path).resolve()
-            return path
-
-        self.issue_workspace_root = _resolve_path(_cfg_value(workspace_cfg, "root", default="workspace/issues"), "workspace/issues")
-        self.status_path = _resolve_path(storage_cfg.get("status") or "memory/workflow-status.json", "memory/workflow-status.json")
-        self.health_path = _resolve_path(storage_cfg.get("health") or "memory/workflow-health.json", "memory/workflow-health.json")
-        self.audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
-        self.scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
+        self.issue_workspace_root = typed_cfg.workspace.root
+        self.status_path = typed_cfg.storage.status
+        self.health_path = typed_cfg.storage.health
+        self.audit_log_path = typed_cfg.storage.audit_log
+        self.scheduler_path = typed_cfg.storage.scheduler
         self.db_path = runtime_paths(self.path)["db_path"]
         self.engine_store = EngineStore(
             db_path=self.db_path,
@@ -1744,6 +1677,7 @@ def load_workspace_from_config(
     root = workspace_root.expanduser().resolve()
     contract = load_workflow_contract(root)
     cfg = dict(config or contract.config)
+    typed_cfg = IssueRunnerConfig.from_raw(cfg, workflow_root=root)
     prompts = cfg.get("prompts") or {}
     st = contract.source_path.stat()
     snapshot = ConfigSnapshot(
@@ -1755,19 +1689,10 @@ def load_workspace_from_config(
     )
     tracker_cfg = cfg.get("tracker") or {}
     tracker_client_cfg = _tracker_config_for_client(cfg)
-    workspace_cfg = cfg.get("workspace") or {}
-    storage_cfg = cfg.get("storage") or {}
     repo_path = _repository_path_from_config(root, cfg)
     tracker_source_cfg = dict(tracker_client_cfg)
     if repo_path is not None and str(tracker_cfg.get("kind") or "").strip() == "github":
         tracker_source_cfg.setdefault("repo_path", str(repo_path))
-
-    def _resolve_path(value: str, default: str) -> Path:
-        raw = str(value or default).strip()
-        path = Path(raw).expanduser()
-        if not path.is_absolute():
-            path = (root / path).resolve()
-        return path
 
     runner = run or _subprocess_run
     runner_json = run_json or _subprocess_run_json
@@ -1779,11 +1704,11 @@ def load_workspace_from_config(
         run=runner,
         run_json=runner_json,
     )
-    issue_workspace_root = _resolve_path(_cfg_value(workspace_cfg, "root", default="workspace/issues"), "workspace/issues")
-    status_path = _resolve_path(storage_cfg.get("status") or "memory/workflow-status.json", "memory/workflow-status.json")
-    health_path = _resolve_path(storage_cfg.get("health") or "memory/workflow-health.json", "memory/workflow-health.json")
-    audit_log_path = _resolve_path(storage_cfg.get("audit-log") or "memory/workflow-audit.jsonl", "memory/workflow-audit.jsonl")
-    scheduler_path = _resolve_path(storage_cfg.get("scheduler") or "memory/workflow-scheduler.json", "memory/workflow-scheduler.json")
+    issue_workspace_root = typed_cfg.workspace.root
+    status_path = typed_cfg.storage.status
+    health_path = typed_cfg.storage.health
+    audit_log_path = typed_cfg.storage.audit_log
+    scheduler_path = typed_cfg.storage.scheduler
     db_path = runtime_paths(root)["db_path"]
     engine_store = EngineStore(
         db_path=db_path,

--- a/daedalus/workflows/runtime_matrix.py
+++ b/daedalus/workflows/runtime_matrix.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from runtimes import build_runtimes
+from runtimes.registry import build_runtimes
 from runtimes.stages import prompt_result_from_stage, run_runtime_stage
 from workflows.contract import load_workflow_contract
 from workflows.change_delivery.contract_model import actor_config as change_delivery_actor_config

--- a/docs/daedalus-restructure-implementation-plan.md
+++ b/docs/daedalus-restructure-implementation-plan.md
@@ -1,0 +1,662 @@
+# Daedalus Restructure Implementation Plan
+
+Status: implementation turns complete  
+Branch: `codex/daedalus-restructure-implementation-plan`  
+Worktree: `/tmp/daedalus-restructure-implementation-plan`  
+Current turn: Turn 12 complete
+
+This plan breaks the Daedalus restructure into small turns. Each turn should be
+reviewable on its own, preserve public behavior, and leave the repository in a
+passing state.
+
+The target architecture is a durable workflow engine plus workflow SDK plus
+bundled workflows:
+
+- `engine/` owns durable orchestration primitives.
+- `workflows/core/` owns shared workflow contract/config/hook/prompt/status
+  helpers.
+- `workflows/` owns workflow-specific policy.
+- `runtimes/` owns agent/runtime protocols and adapters.
+- `integrations/` owns trackers, code hosts, and notifications.
+- `operator/` owns CLI, doctor, status, watch, HTTP, and service control.
+- `platform/` owns host utilities such as paths, env, process, files, and time.
+
+## Ground Rules
+
+### Preserve Public Behavior
+
+Do not break these surfaces unless there is a separate breaking-change plan:
+
+- `WORKFLOW.md`
+- `WORKFLOW-<workflow>.md`
+- workflow root layout
+- `/daedalus ...`
+- `/workflow <name> ...`
+- `hermes daedalus bootstrap`
+- `hermes daedalus scaffold-workflow`
+- `hermes daedalus validate`
+- workflow names:
+  - `issue-runner`
+  - `change-delivery`
+- documented status/doctor JSON fields
+- root-level compatibility imports until packaging tests prove removal is safe
+
+### Keep Moves Separate From Behavior
+
+For each turn, choose one primary kind of change:
+
+- add tests and guardrails;
+- add a new shared module;
+- migrate one narrow caller group;
+- add compatibility shims;
+- remove dead compatibility only after all callers are moved.
+
+Avoid combining broad file moves with policy changes.
+
+### Dependency Direction
+
+Allowed direction:
+
+```text
+operator -> workflows -> workflows.core -> engine
+workflows -> runtimes
+workflows -> integrations
+engine -> platform
+runtimes -> platform
+integrations -> platform
+```
+
+Forbidden direction:
+
+```text
+engine -> workflows
+engine -> runtimes
+engine -> integrations
+runtimes -> workflows
+integrations -> workflows
+operator -> workflow internals when stable status/driver APIs exist
+```
+
+## Turn 0: Baseline Guardrails
+
+Status: complete on 2026-05-02.
+
+Objective: add tests and docs that protect the current public contract before
+moving code.
+
+Scope:
+
+- no behavior changes;
+- no file moves;
+- no import rewrites beyond test-only imports.
+
+Tasks:
+
+1. Add public import smoke tests for:
+   - `engine`
+   - `workflows`
+   - `runtimes`
+   - `trackers`
+   - `daedalus.engine`
+   - `daedalus.workflows`
+   - `daedalus.runtimes`
+   - `daedalus.trackers`
+2. Add workflow discovery tests:
+   - bundled workflows list includes `issue-runner`;
+   - bundled workflows list includes `change-delivery`;
+   - workflow CLI dispatch still resolves both names.
+3. Add contract loader tests:
+   - `WORKFLOW.md`;
+   - `WORKFLOW-issue-runner.md`;
+   - workflow-root pointer;
+   - Markdown body preserved as `prompt_template`;
+   - body projected as `workflow-policy`.
+4. Add a short architecture note to `docs/public-contract.md` or a new
+   `docs/restructure-notes.md` saying source of truth remains under
+   `daedalus/`, while root-level packages are compatibility shims.
+
+Suggested tests:
+
+```bash
+pytest tests/test_workflow_contract_loader.py \
+  tests/test_workflows_dispatcher.py \
+  tests/test_public_cli_docs_drift.py
+```
+
+Acceptance criteria:
+
+- new guardrail tests pass;
+- existing relevant tests pass;
+- no runtime behavior changes;
+- no production imports are moved yet.
+
+## Turn 1: Introduce `workflows/core/config.py`
+
+Status: complete on 2026-05-02.
+
+Objective: create shared config primitives without migrating workflow behavior
+broadly.
+
+New files:
+
+```text
+daedalus/workflows/core/__init__.py
+daedalus/workflows/core/config.py
+tests/test_workflows_core_config.py
+```
+
+Initial API:
+
+- `ConfigError`
+- `ConfigView`
+- `get_value`
+- `get_str`
+- `get_int`
+- `get_bool`
+- `get_list`
+- `get_mapping`
+- `resolve_env_indirection`
+- `resolve_path`
+- `first_present`
+- `require`
+
+Rules:
+
+- support dash/underscore aliases;
+- never mutate the caller's raw config;
+- path helpers must support relative-to-workflow-root resolution;
+- env indirection should support `$NAME` and plain literal values;
+- helper behavior must be unit tested before workflow adoption.
+
+Acceptance criteria:
+
+- helper tests cover defaults, missing values, wrong types, aliases, env values,
+  and path normalization;
+- no workflow behavior changes;
+- no public config shape changes.
+
+## Turn 2: Add `issue_runner/config.py`
+
+Status: complete on 2026-05-02.
+
+Objective: normalize `issue-runner` config in one place while keeping raw config
+available.
+
+New files:
+
+```text
+daedalus/workflows/issue_runner/config.py
+tests/test_issue_runner_config.py
+```
+
+Typed config objects:
+
+- `IssueRunnerConfig`
+- `PollingConfig`
+- `WorkspaceConfig`
+- `StorageConfig`
+- `AgentConfig`
+- `TrackerRuntimeConfig`
+
+Normalize:
+
+- `polling.interval_ms`;
+- `polling.interval_seconds` / `polling.interval-seconds`;
+- `agent.max_concurrent_agents`;
+- `agent.max_concurrent_agents_by_state`;
+- `agent.max_retry_backoff_ms`;
+- `workspace.root`;
+- `storage.status`;
+- `storage.health`;
+- `storage.audit-log`;
+- `storage.scheduler`;
+- tracker state aliases:
+  - `active_states` / `active-states`
+  - `terminal_states` / `terminal-states`
+  - `required_labels` / `required-labels`
+  - `exclude_labels` / `exclude-labels`
+
+First adoption points:
+
+- scheduler state derivation;
+- workspace/storage path resolution;
+- retry backoff config.
+
+Acceptance criteria:
+
+- `issue-runner` status output remains compatible;
+- hot reload still keeps last-known-good config on invalid reload;
+- existing `issue-runner` tests pass;
+- raw config remains available for schema validation and status/debug payloads.
+
+## Turn 3: Extract Shared Prompt and Hook Utilities
+
+Status: complete on 2026-05-02.
+
+Objective: move generic prompt rendering and hook execution out of
+`issue_runner/workspace.py`.
+
+New files:
+
+```text
+daedalus/workflows/core/prompts.py
+daedalus/workflows/core/hooks.py
+tests/test_workflows_core_prompts.py
+tests/test_workflows_core_hooks.py
+```
+
+Move or wrap:
+
+- simple `{{ issue.field }}` prompt rendering;
+- `attempt` substitution;
+- unsupported control-block detection;
+- hook timeout handling;
+- hook result shape;
+- common hook environment construction helpers where safe.
+
+Keep workflow-local:
+
+- issue-specific prompt variable policy;
+- change-delivery actor prompt composition;
+- lane memo/state prompt content.
+
+Acceptance criteria:
+
+- existing prompt rendering behavior is unchanged;
+- existing hook result payloads are unchanged;
+- `issue-runner` tests pass;
+- no `change-delivery` prompt behavior changes in this turn.
+
+## Turn 4: Create `integrations/trackers`
+
+Status: complete on 2026-05-02.
+
+Objective: introduce the target tracker namespace while preserving existing
+imports.
+
+New target layout:
+
+```text
+daedalus/integrations/__init__.py
+daedalus/integrations/trackers/__init__.py
+daedalus/integrations/trackers/types.py
+daedalus/integrations/trackers/registry.py
+daedalus/integrations/trackers/github.py
+daedalus/integrations/trackers/linear.py
+daedalus/integrations/trackers/local_json.py
+daedalus/integrations/trackers/feedback.py
+```
+
+Migration approach:
+
+1. Add new modules as wrappers/re-exports first.
+2. Move implementation only after import tests cover old and new paths.
+3. Keep `daedalus/trackers/*` as compatibility shims.
+4. Keep root-level `trackers` package working.
+
+Acceptance criteria:
+
+- old imports work;
+- new imports work;
+- GitHub tracker tests pass;
+- local-json tracker tests pass;
+- Linear tests pass or remain explicitly marked experimental;
+- no workflow config key changes.
+
+## Turn 5: Create `integrations/code_hosts` and `integrations/notifications`
+
+Status: complete on 2026-05-02.
+
+Objective: separate external system adapters from workflow packages.
+
+Target layout:
+
+```text
+daedalus/integrations/code_hosts/
+  __init__.py
+  types.py
+  registry.py
+  github.py
+
+daedalus/integrations/notifications/
+  __init__.py
+  types.py
+  webhooks.py
+  slack.py
+```
+
+Migration approach:
+
+- introduce wrappers first;
+- move GitHub code-host behavior behind compatibility imports;
+- move reusable webhook delivery logic out of `change_delivery/webhooks` only
+  when tests pin payloads and retry behavior;
+- keep change-delivery-specific subscriber policy workflow-local.
+
+Acceptance criteria:
+
+- `change-delivery` GitHub tests pass;
+- webhook tests pass;
+- old `daedalus/code_hosts` imports still work;
+- webhook payload shapes are unchanged.
+
+## Turn 6: Split Runtime Types and Registry
+
+Status: complete on 2026-05-02.
+
+Objective: make runtime API boundaries explicit without changing runtime
+behavior.
+
+Target files:
+
+```text
+daedalus/runtimes/types.py
+daedalus/runtimes/registry.py
+daedalus/runtimes/capabilities.py
+daedalus/runtimes/stages.py
+daedalus/runtimes/command.py
+```
+
+Migration approach:
+
+- move protocol dataclasses to `types.py`;
+- move register/build runtime logic to `registry.py`;
+- leave `runtimes/__init__.py` as a compatibility export;
+- keep concrete adapters in place;
+- only extract command runtime behavior if tests cover it.
+
+Acceptance criteria:
+
+- runtime matrix tests pass;
+- Codex app-server tests pass;
+- workflow runtime binding tests pass;
+- import compatibility tests pass.
+
+## Turn 7: Engine Cleanup Without Schema Changes
+
+Status: complete on 2026-05-02.
+
+Objective: clarify engine internals while keeping `EngineStore` stable.
+
+Possible target files:
+
+```text
+daedalus/engine/schema.py
+daedalus/engine/runs.py
+daedalus/engine/events.py
+daedalus/engine/retries.py
+```
+
+Migration approach:
+
+- keep `EngineStore` as the primary workflow-facing API;
+- move implementation details only when tests already cover them;
+- do not change database schema in this turn;
+- do not change event payloads in this turn;
+- keep `engine.state` compatibility imports until all callers move.
+
+Acceptance criteria:
+
+- engine primitive tests pass;
+- DB migration tests pass;
+- status server still reads runs/events/scheduler state;
+- no schema migration is needed.
+
+## Turn 8: Operator Namespace
+
+Status: complete on 2026-05-02.
+
+Objective: isolate human/operator surfaces from engine and workflow internals.
+
+Target layout:
+
+```text
+daedalus/operator/
+  __init__.py
+  cli.py
+  doctor.py
+  formatters.py
+  watch.py
+  watch_sources.py
+  http_server.py
+  service.py
+  systemd.py
+```
+
+Migration approach:
+
+- keep `daedalus/daedalus_cli.py` as the public entrypoint until packaging says
+  it can move;
+- move formatter/watch/service helpers behind compatibility imports;
+- prefer stable workflow driver/status APIs over direct workflow internals;
+- update docs only after commands are verified.
+
+Acceptance criteria:
+
+- slash command tests pass;
+- CLI dispatch tests pass;
+- formatter tests pass;
+- watch tests pass;
+- docs drift tests pass.
+
+## Turn 9: Add `change_delivery/config.py`
+
+Status: complete on 2026-05-02.
+
+Objective: normalize change-delivery config without flattening its rich policy
+into the generic workflow model.
+
+Typed config objects:
+
+- `ChangeDeliveryConfig`
+- `RepositoryConfig`
+- `TrackerConfig`
+- `CodeHostConfig`
+- `RuntimeProfilesConfig`
+- `ActorConfig`
+- `StageConfig`
+- `GateConfig`
+- `StorageConfig`
+- `WebhookConfig`
+
+Adopt first in low-risk places:
+
+- path resolution;
+- runtime binding checks;
+- actor lookup;
+- storage paths;
+- server config.
+
+Keep workflow-local:
+
+- lane state machine;
+- review policy;
+- gate policy;
+- PR publish/merge policy;
+- operator attention policy.
+
+Acceptance criteria:
+
+- change-delivery schema tests pass;
+- status tests pass;
+- action tests pass;
+- review and repair handoff tests pass;
+- no public workflow contract changes.
+
+## Turn 10: Tighten Workflow Driver APIs
+
+Status: complete on 2026-05-02.
+
+Objective: make operator surfaces depend on stable workflow APIs rather than
+workflow internals.
+
+Target API:
+
+```python
+class WorkflowDriver(Protocol):
+    def build_status(self) -> dict: ...
+    def doctor(self) -> dict: ...
+    def tick(self) -> dict: ...
+```
+
+Extend only when needed:
+
+- `run_loop`;
+- `serve`;
+- `preflight`;
+- `runtime_matrix`;
+- `workflow_cli_argv`.
+
+Tasks:
+
+- define or move protocol to `workflows/core/types.py`;
+- ensure both bundled workflows conform;
+- update operator code to use protocol boundaries;
+- add conformance tests for bundled workflows.
+
+Acceptance criteria:
+
+- operator commands work for both workflows;
+- workflow-specific commands still route correctly;
+- no operator code imports change-delivery internals for generic status paths.
+
+## Turn 11: Move Source Files Gradually
+
+Status: complete on 2026-05-02.
+
+Objective: perform physical moves only after wrappers and tests are in place.
+
+Rules:
+
+- one namespace per PR/turn;
+- move files with compatibility imports;
+- update direct imports in the moved namespace only;
+- run import smoke tests after each move;
+- defer deletion of old files.
+
+Recommended order:
+
+1. `workflows/core`
+2. `integrations/trackers`
+3. `integrations/code_hosts`
+4. `integrations/notifications`
+5. `runtimes/types.py` and `runtimes/registry.py`
+6. `operator`
+7. optional engine internals
+
+Acceptance criteria:
+
+- old imports still work;
+- new imports work;
+- packaging tests pass;
+- docs are updated only where public paths changed.
+
+## Turn 12: Remove Dead Shims
+
+Status: complete on 2026-05-02.
+
+Objective: remove compatibility layers only when they are proven unused and not
+part of the public contract.
+
+Tasks:
+
+- use `rg` to find old imports;
+- update internal imports to new paths;
+- keep public shims documented if external users may rely on them;
+- remove private-only shims;
+- update packaging manifests if needed.
+
+Acceptance criteria:
+
+- no internal imports use removed paths;
+- public import smoke tests match the intended public surface;
+- plugin packaging tests pass;
+- docs mention remaining compatibility paths.
+
+## Per-Turn Implementation Template
+
+Use this template for each turn:
+
+```markdown
+## Turn N: <title>
+
+Goal:
+- <one sentence>
+
+Files expected to change:
+- <paths>
+
+Behavior changes:
+- none
+- or explicitly list them
+
+Compatibility:
+- old import path:
+- new import path:
+- shim retained:
+
+Tests to run:
+- <pytest commands>
+
+Acceptance:
+- <checklist>
+
+Rollback:
+- <what to revert if this turn fails>
+```
+
+## Verification Matrix
+
+Run narrowly during each turn:
+
+```bash
+pytest tests/test_workflow_contract_loader.py
+pytest tests/test_workflows_dispatcher.py
+pytest tests/test_engine_primitives.py
+pytest tests/test_runtime_matrix.py
+pytest tests/test_workflows_issue_runner_workspace.py
+pytest tests/test_workflows_code_review_workflow.py
+```
+
+Run before merging a multi-turn branch:
+
+```bash
+pytest
+```
+
+For packaging-sensitive turns, also run:
+
+```bash
+pytest tests/test_pip_plugin_packaging.py \
+  tests/test_official_plugin_layout.py \
+  tests/test_public_cli_docs_drift.py
+```
+
+## First Branch Sequence
+
+Recommended first implementation branches:
+
+1. `codex/restructure-guardrails`
+2. `codex/workflow-core-config`
+3. `codex/issue-runner-typed-config`
+4. `codex/workflow-core-hooks-prompts`
+5. `codex/integrations-trackers-namespace`
+6. `codex/runtime-types-registry`
+
+Do not start with physical file moves. Start with guardrails and typed config.
+
+## Definition of Done
+
+The restructure is done when:
+
+- `issue-runner` can be understood as the reference generic workflow without
+  reading `change-delivery`;
+- `change-delivery` remains rich but workflow-local;
+- workflow config normalization lives in typed config modules;
+- engine imports no workflow, runtime, tracker, code-host, or operator modules;
+- runtime adapters import no workflow modules;
+- integrations import no workflow modules;
+- operator surfaces use stable workflow/engine APIs;
+- root-level compatibility packages are either removed safely or explicitly
+  documented as public shims;
+- public docs, examples, workflow templates, and CLI behavior agree.

--- a/docs/public-contract.md
+++ b/docs/public-contract.md
@@ -38,6 +38,15 @@ These are not public compatibility promises yet:
 
 We can refactor those freely as long as the stable surfaces above keep working.
 
+## Restructure guardrails
+
+The implementation source of truth remains under `daedalus/`. The repo-root
+packages `engine/`, `workflows/`, `runtimes/`, and `trackers/` are compatibility
+shims for existing imports, direct workflow CLI entrypoints, and plugin runtime
+paths. New implementation code should live under `daedalus/` while both
+`<package>` and `daedalus.<package>` imports remain available during the
+restructure.
+
 ## Bundled workflows
 
 - `workflow: change-delivery`

--- a/docs/restructure-shim-audit.md
+++ b/docs/restructure-shim-audit.md
@@ -1,0 +1,38 @@
+# Restructure Shim Audit
+
+Status: current as of Turn 12.
+
+The restructure keeps public compatibility shims while internal workflow code
+moves to the new namespaces.
+
+## Retained Public Shims
+
+- `engine/`
+- `workflows/`
+- `runtimes/`
+- `trackers/`
+
+These remain public compatibility paths for local plugin execution, direct
+workflow CLI entrypoints, and existing imports.
+
+## New Internal Namespaces
+
+- `workflows.core`
+- `integrations.trackers`
+- `integrations.code_hosts`
+- `integrations.notifications`
+- `runtimes.types`
+- `runtimes.registry`
+- `runtimes.command`
+- `daedalus.operator`
+
+Workflow code should prefer these namespaces for new imports. Compatibility
+wrappers may still import old paths internally because that is their purpose.
+
+## Removed In This Turn
+
+- Private duplicate change-delivery storage path resolver, replaced by
+  `workflows.change_delivery.config.ChangeDeliveryConfig`.
+
+No public shim was removed in this branch because root-level compatibility
+packages are still listed as stable public contract.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,16 +1,14 @@
 """Repo-root engine wrapper package for local development."""
 
-import sys
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
-_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
-if _PLUGIN_ROOT_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_ROOT_STR)
-
 _REAL_ENGINE_DIR = _PLUGIN_ROOT / "daedalus" / "engine"
 _real_dir_str = str(_REAL_ENGINE_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
-from daedalus.engine import *  # noqa: F401,F403
+_INIT = _REAL_ENGINE_DIR / "__init__.py"
+__file__ = str(_INIT)
+exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/runtimes/__init__.py
+++ b/runtimes/__init__.py
@@ -6,8 +6,10 @@ _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 _REAL_DIR = _PLUGIN_ROOT / "daedalus" / "runtimes"
 
 _real_dir_str = str(_REAL_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
 _INIT = _REAL_DIR / "__init__.py"
+__file__ = str(_INIT)
 exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/tests/test_change_delivery_config.py
+++ b/tests/test_change_delivery_config.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from workflows.change_delivery.config import ChangeDeliveryConfig, change_delivery_storage_paths_from_config
+
+
+def _config() -> dict:
+    return {
+        "workflow": "change-delivery",
+        "repository": {
+            "local-path": "repo",
+            "slug": "owner/repo",
+            "active-lane-label": "active-lane",
+        },
+        "tracker": {"kind": "github", "github_slug": "owner/repo"},
+        "code-host": {"kind": "github", "github_slug": "owner/repo"},
+        "runtimes": {
+            "coder-runtime": {"kind": "codex-app-server"},
+            "reviewer-runtime": {"kind": "claude-cli"},
+        },
+        "actors": {
+            "implementer": {"name": "impl", "model": "gpt-5", "runtime": "coder-runtime"},
+            "reviewer": {"name": "review", "model": "claude", "runtime": "reviewer-runtime"},
+        },
+        "stages": {
+            "implement": {"actor": "implementer"},
+        },
+        "gates": {
+            "pre-publish-review": {"type": "agent-review", "actor": "reviewer"},
+        },
+        "storage": {
+            "ledger": "state/ledger.json",
+            "health": "state/health.json",
+            "audit_log": "state/audit.jsonl",
+            "scheduler": "state/scheduler.json",
+        },
+        "server": {"port": "9090", "bind": "0.0.0.0"},
+        "webhooks": [{"name": "events", "kind": "http-json", "url": "https://example.test/hook"}],
+    }
+
+
+def test_change_delivery_config_normalizes_paths_and_sections(tmp_path):
+    cfg = _config()
+    typed = ChangeDeliveryConfig.from_raw(cfg, workflow_root=tmp_path)
+
+    assert typed.repository.local_path == (tmp_path / "repo").resolve()
+    assert typed.repository.slug == "owner/repo"
+    assert typed.repository.active_lane_label == "active-lane"
+    assert typed.tracker.kind == "github"
+    assert typed.code_host.kind == "github"
+    assert typed.code_host.github_slug == "owner/repo"
+    assert typed.storage.ledger == (tmp_path / "state/ledger.json").resolve()
+    assert typed.storage.health == (tmp_path / "state/health.json").resolve()
+    assert typed.storage.audit_log == (tmp_path / "state/audit.jsonl").resolve()
+    assert typed.storage.scheduler == (tmp_path / "state/scheduler.json").resolve()
+    assert typed.server.port == 9090
+    assert typed.server.bind == "0.0.0.0"
+    assert typed.webhooks.subscriptions == cfg["webhooks"]
+
+
+def test_change_delivery_config_exposes_actor_and_runtime_lookup_without_mutating_input(tmp_path):
+    cfg = _config()
+    typed = ChangeDeliveryConfig.from_raw(cfg, workflow_root=tmp_path)
+    typed.raw["actors"]["implementer"]["runtime"] = "changed"
+
+    assert typed.actor("implementer").runtime == "coder-runtime"
+    assert typed.runtime_for_actor("implementer") == {"kind": "codex-app-server"}
+    assert typed.runtimes.kind("reviewer-runtime") == "claude-cli"
+    assert cfg["actors"]["implementer"]["runtime"] == "coder-runtime"
+
+
+def test_change_delivery_storage_paths_helper_matches_typed_config(tmp_path):
+    cfg = _config()
+
+    paths = change_delivery_storage_paths_from_config(tmp_path, cfg)
+
+    assert paths == ChangeDeliveryConfig.from_raw(cfg, workflow_root=tmp_path).storage.as_dict()
+
+
+def test_change_delivery_config_applies_defaults(tmp_path):
+    typed = ChangeDeliveryConfig.from_raw({}, workflow_root=tmp_path)
+
+    assert typed.repository.local_path is None
+    assert typed.repository.active_lane_label == "active-lane"
+    assert typed.storage.ledger == (tmp_path / "memory/workflow-status.json").resolve()
+    assert typed.storage.health == (tmp_path / "memory/workflow-health.json").resolve()
+    assert typed.storage.audit_log == (tmp_path / "memory/workflow-audit.jsonl").resolve()
+    assert typed.storage.scheduler == (tmp_path / "memory/workflow-scheduler.json").resolve()
+    assert typed.server.port == 8080
+    assert typed.server.bind == "127.0.0.1"

--- a/tests/test_engine_namespace_cleanup.py
+++ b/tests/test_engine_namespace_cleanup.py
@@ -1,0 +1,20 @@
+import importlib
+
+
+def test_engine_cleanup_modules_reexport_existing_schema_run_event_and_retry_api():
+    engine = importlib.import_module("engine")
+    schema = importlib.import_module("engine.schema")
+    runs = importlib.import_module("engine.runs")
+    events = importlib.import_module("engine.events")
+    retries = importlib.import_module("engine.retries")
+
+    assert callable(schema.init_engine_state)
+    assert callable(schema.engine_state_tables_exist)
+    assert callable(runs.start_engine_run_to_connection)
+    assert callable(runs.read_engine_runs)
+    assert callable(events.append_engine_event_to_connection)
+    assert callable(events.read_engine_events)
+    assert callable(retries.schedule_retry_entry)
+    assert callable(retries.retry_due_at)
+    assert schema.init_engine_state.__name__ == engine.init_engine_state.__name__
+    assert retries.retry_due_at.__name__ == engine.retry_due_at.__name__

--- a/tests/test_integrations_code_hosts_notifications_namespace.py
+++ b/tests/test_integrations_code_hosts_notifications_namespace.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_code_host_old_and_new_namespace_imports_resolve_same_public_objects():
+    old = importlib.import_module("code_hosts")
+    new = importlib.import_module("integrations.code_hosts")
+    new_types = importlib.import_module("integrations.code_hosts.types")
+    new_registry = importlib.import_module("integrations.code_hosts.registry")
+    old_github = importlib.import_module("code_hosts.github")
+    new_github = importlib.import_module("integrations.code_hosts.github")
+
+    assert new.CodeHostConfigError is old.CodeHostConfigError
+    assert new_types.CodeHostClient is old.CodeHostClient
+    assert new_registry.build_code_host_client is old.build_code_host_client
+    assert new_registry.register is old.register
+    assert new_github.GithubCodeHostClient is old_github.GithubCodeHostClient
+
+
+def test_notification_namespace_wraps_change_delivery_webhooks():
+    old_webhooks = importlib.import_module("workflows.change_delivery.webhooks")
+    new_webhooks = importlib.import_module("integrations.notifications.webhooks")
+    new_types = importlib.import_module("integrations.notifications.types")
+    old_slack = importlib.import_module("workflows.change_delivery.webhooks.slack_incoming")
+    new_slack = importlib.import_module("integrations.notifications.slack")
+    old_http_json = importlib.import_module("workflows.change_delivery.webhooks.http_json")
+    new_http_json = importlib.import_module("integrations.notifications.http_json")
+
+    assert new_webhooks.build_webhooks is old_webhooks.build_webhooks
+    assert new_types.WebhookContext is old_webhooks.WebhookContext
+    assert new_slack.SlackIncomingWebhook is old_slack.SlackIncomingWebhook
+    assert new_http_json.HttpJsonWebhook is old_http_json.HttpJsonWebhook

--- a/tests/test_integrations_trackers_namespace.py
+++ b/tests/test_integrations_trackers_namespace.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_tracker_old_and_new_namespace_imports_resolve_same_public_objects():
+    old = importlib.import_module("trackers")
+    new = importlib.import_module("integrations.trackers")
+    old_types = importlib.import_module("trackers")
+    new_types = importlib.import_module("integrations.trackers.types")
+    old_registry = importlib.import_module("trackers")
+    new_registry = importlib.import_module("integrations.trackers.registry")
+
+    assert new.TrackerConfigError is old.TrackerConfigError
+    assert new_types.TrackerClient is old_types.TrackerClient
+    assert new_registry.build_tracker_client is old_registry.build_tracker_client
+    assert new_registry.register is old_registry.register
+
+
+def test_tracker_adapter_modules_are_available_from_new_namespace():
+    old_local_json = importlib.import_module("trackers.local_json")
+    new_local_json = importlib.import_module("integrations.trackers.local_json")
+    old_github = importlib.import_module("trackers.github")
+    new_github = importlib.import_module("integrations.trackers.github")
+    old_linear = importlib.import_module("trackers.linear")
+    new_linear = importlib.import_module("integrations.trackers.linear")
+    old_feedback = importlib.import_module("trackers.feedback")
+    new_feedback = importlib.import_module("integrations.trackers.feedback")
+
+    assert new_local_json.LocalJsonTrackerClient is old_local_json.LocalJsonTrackerClient
+    assert new_github.GithubTrackerClient is old_github.GithubTrackerClient
+    assert new_linear.LinearTrackerClient is old_linear.LinearTrackerClient
+    assert new_feedback.publish_tracker_feedback is old_feedback.publish_tracker_feedback

--- a/tests/test_issue_runner_config.py
+++ b/tests/test_issue_runner_config.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+from workflows.issue_runner.config import (
+    DEFAULT_MAX_RETRY_BACKOFF_MS,
+    IssueRunnerConfig,
+    max_retry_backoff_ms_from_config,
+    poll_interval_seconds_from_config,
+    scheduler_state_from_config,
+    terminal_states_from_config,
+)
+
+
+def test_issue_runner_config_normalizes_polling_aliases_and_scheduler_state(tmp_path):
+    cfg = {
+        "polling": {"interval-seconds": "7"},
+        "agent": {
+            "max_concurrent_agents": "3",
+            "max_concurrent_agents_by_state": {
+                "Todo": "2",
+                "": 5,
+                "Blocked": 0,
+            },
+        },
+    }
+
+    typed = IssueRunnerConfig.from_raw(cfg, workflow_root=tmp_path)
+
+    assert typed.polling.interval_ms == 7000
+    assert typed.polling.interval_seconds == 7
+    assert typed.agent.max_concurrent_agents == 3
+    assert typed.agent.max_concurrent_agents_by_state == {"todo": 2}
+    assert scheduler_state_from_config(cfg) == {
+        "poll_interval_ms": 7000,
+        "max_concurrent_agents": 3,
+        "max_concurrent_agents_by_state": {"todo": 2},
+    }
+
+
+def test_issue_runner_config_prefers_interval_ms_and_clamps_poll_seconds(tmp_path):
+    cfg = {
+        "polling": {"interval_ms": 500},
+        "agent": {},
+    }
+
+    typed = IssueRunnerConfig.from_raw(cfg, workflow_root=tmp_path)
+
+    assert typed.polling.interval_ms == 500
+    assert typed.polling.interval_seconds == 1
+    assert poll_interval_seconds_from_config(cfg) == 1
+
+
+def test_issue_runner_config_resolves_workspace_and_storage_paths(tmp_path):
+    cfg = {
+        "workspace": {"root": "workspace/custom"},
+        "storage": {
+            "status": "state/status.json",
+            "health": "state/health.json",
+            "audit_log": "state/audit.jsonl",
+            "scheduler": "state/scheduler.json",
+        },
+        "agent": {},
+    }
+
+    typed = IssueRunnerConfig.from_raw(cfg, workflow_root=tmp_path)
+
+    assert typed.workspace.root == (tmp_path / "workspace/custom").resolve()
+    assert typed.storage.status == (tmp_path / "state/status.json").resolve()
+    assert typed.storage.health == (tmp_path / "state/health.json").resolve()
+    assert typed.storage.audit_log == (tmp_path / "state/audit.jsonl").resolve()
+    assert typed.storage.scheduler == (tmp_path / "state/scheduler.json").resolve()
+
+
+def test_issue_runner_config_applies_path_and_retry_defaults(tmp_path):
+    typed = IssueRunnerConfig.from_raw({"agent": {}}, workflow_root=tmp_path)
+
+    assert typed.workspace.root == (tmp_path / "workspace/issues").resolve()
+    assert typed.storage.status == (tmp_path / "memory/workflow-status.json").resolve()
+    assert typed.storage.health == (tmp_path / "memory/workflow-health.json").resolve()
+    assert typed.storage.audit_log == (tmp_path / "memory/workflow-audit.jsonl").resolve()
+    assert typed.storage.scheduler == (tmp_path / "memory/workflow-scheduler.json").resolve()
+    assert typed.agent.max_retry_backoff_ms == DEFAULT_MAX_RETRY_BACKOFF_MS
+    assert max_retry_backoff_ms_from_config({"agent": {"max_retry_backoff_ms": 0}}) == DEFAULT_MAX_RETRY_BACKOFF_MS
+
+
+def test_issue_runner_config_normalizes_tracker_state_and_label_aliases(tmp_path):
+    cfg = {
+        "tracker": {
+            "kind": "local-json",
+            "active-states": ["Todo", "Ready"],
+            "terminal_states": ["Done", "Closed"],
+            "required-labels": ["Backend"],
+            "exclude_labels": ["Blocked"],
+        },
+        "agent": {},
+    }
+
+    typed = IssueRunnerConfig.from_raw(cfg, workflow_root=tmp_path)
+
+    assert typed.tracker.kind == "local-json"
+    assert typed.tracker.active_states == ("todo", "ready")
+    assert typed.tracker.terminal_states == ("done", "closed")
+    assert typed.tracker.required_labels == ("backend",)
+    assert typed.tracker.exclude_labels == ("blocked",)
+    assert terminal_states_from_config(cfg) == {"done", "closed"}
+
+
+def test_issue_runner_config_keeps_raw_config_available_without_mutating_input(tmp_path):
+    cfg = {
+        "workspace": {"root": "workspace/issues"},
+        "agent": {"max_concurrent_agents_by_state": {"Todo": 1}},
+    }
+
+    typed = IssueRunnerConfig.from_raw(cfg, workflow_root=tmp_path)
+    typed.raw["workspace"]["root"] = "changed"
+
+    assert cfg["workspace"]["root"] == "workspace/issues"
+    assert cfg["agent"]["max_concurrent_agents_by_state"] == {"Todo": 1}

--- a/tests/test_operator_namespace.py
+++ b/tests/test_operator_namespace.py
@@ -1,0 +1,28 @@
+import importlib
+
+
+def test_operator_namespace_wraps_existing_cli_and_formatters():
+    importlib.import_module("engine")
+    cli = importlib.import_module("daedalus.operator.cli")
+    service = importlib.import_module("daedalus.operator.service")
+    systemd = importlib.import_module("daedalus.operator.systemd")
+    formatters = importlib.import_module("daedalus.operator.formatters")
+    watch = importlib.import_module("daedalus.operator.watch")
+
+    daedalus_cli = importlib.import_module("daedalus.daedalus_cli")
+    old_formatters = importlib.import_module("daedalus.formatters")
+    old_watch = importlib.import_module("daedalus.watch")
+
+    assert cli.execute_raw_args is daedalus_cli.execute_raw_args
+    assert service.service_loop is daedalus_cli.service_loop
+    assert systemd.install_supervised_service is daedalus_cli.install_supervised_service
+    assert formatters.format_doctor is old_formatters.format_doctor
+    assert watch.render_frame_to_string is old_watch.render_frame_to_string
+
+
+def test_operator_http_server_wraps_status_server():
+    importlib.import_module("engine")
+    http_server = importlib.import_module("daedalus.operator.http_server")
+    old_server = importlib.import_module("workflows.change_delivery.server")
+
+    assert http_server.start_server is old_server.start_server

--- a/tests/test_restructure_guardrails.py
+++ b/tests/test_restructure_guardrails.py
@@ -71,6 +71,37 @@ assert "/daedalus/workflows/contract.py" in contract.__file__.replace("\\\\", "/
     assert completed.returncode == 0, completed.stderr + completed.stdout
 
 
+def test_repo_root_package_name_exposes_inner_daedalus_namespace():
+    script = """
+import importlib.util
+import sys
+from pathlib import Path
+
+root = Path.cwd()
+spec = importlib.util.spec_from_file_location(
+    "daedalus",
+    root / "__init__.py",
+    submodule_search_locations=[str(root)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["daedalus"] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+import daedalus.operator.cli as cli
+
+assert "/daedalus/operator/cli.py" in cli.__file__.replace("\\\\", "/")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr + completed.stdout
+
+
 @pytest.mark.parametrize("package_name", ("workflows", "daedalus.workflows"))
 def test_bundled_workflows_remain_discoverable(package_name):
     package = importlib.import_module(package_name)

--- a/tests/test_restructure_guardrails.py
+++ b/tests/test_restructure_guardrails.py
@@ -1,0 +1,144 @@
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from workflows.contract import (
+    WORKFLOW_POLICY_KEY,
+    load_workflow_contract,
+    load_workflow_contract_file,
+    write_workflow_contract_pointer,
+)
+
+
+PUBLIC_PACKAGE_IMPORTS = (
+    "engine",
+    "workflows",
+    "runtimes",
+    "trackers",
+    "daedalus.engine",
+    "daedalus.workflows",
+    "daedalus.runtimes",
+    "daedalus.trackers",
+)
+
+BUNDLED_WORKFLOWS = ("change-delivery", "issue-runner")
+
+
+def _write_contract(path: Path, *, workflow: str, body: str) -> None:
+    config = {
+        "workflow": workflow,
+        "schema-version": 1,
+    }
+    path.write_text(
+        "---\n" + yaml.safe_dump(config, sort_keys=False) + "---\n\n" + body + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("module_name", PUBLIC_PACKAGE_IMPORTS)
+def test_public_package_imports_remain_available(module_name):
+    module = importlib.import_module(module_name)
+
+    assert module.__name__ == module_name
+
+
+@pytest.mark.parametrize("package_name", ("workflows", "daedalus.workflows"))
+def test_bundled_workflows_remain_discoverable(package_name):
+    package = importlib.import_module(package_name)
+
+    assert set(BUNDLED_WORKFLOWS).issubset(package.list_workflows())
+
+
+@pytest.mark.parametrize("workflow_name", BUNDLED_WORKFLOWS)
+def test_workflow_cli_dispatch_resolves_bundled_workflow_names(tmp_path, monkeypatch, workflow_name):
+    workflows = importlib.import_module("workflows")
+    module = workflows.load_workflow(workflow_name)
+    schema_path = tmp_path / f"{workflow_name}.schema.yaml"
+    schema_path.write_text(
+        yaml.safe_dump(
+            {
+                "type": "object",
+                "required": ["workflow", "schema-version"],
+                "properties": {
+                    "workflow": {"type": "string"},
+                    "schema-version": {"type": "integer"},
+                    WORKFLOW_POLICY_KEY: {"type": "string"},
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+
+    def fake_make_workspace(*, workflow_root, config):
+        seen["workflow_root"] = workflow_root
+        seen["config"] = config
+        return {"workflow": config["workflow"]}
+
+    def fake_cli_main(workspace, argv):
+        seen["workspace"] = workspace
+        seen["argv"] = argv
+        return 17
+
+    monkeypatch.setattr(module, "CONFIG_SCHEMA_PATH", schema_path)
+    monkeypatch.setattr(module, "PREFLIGHT_GATED_COMMANDS", frozenset())
+    monkeypatch.setattr(module, "make_workspace", fake_make_workspace)
+    monkeypatch.setattr(module, "cli_main", fake_cli_main)
+
+    workflow_root = tmp_path / "workflow-root"
+    workflow_root.mkdir()
+    _write_contract(
+        workflow_root / "WORKFLOW.md",
+        workflow=workflow_name,
+        body=f"Prompt body for {workflow_name}.",
+    )
+
+    exit_code = workflows.run_cli(workflow_root, ["status", "--json"])
+
+    assert exit_code == 17
+    assert seen["workflow_root"] == workflow_root
+    assert seen["config"]["workflow"] == workflow_name
+    assert seen["config"][WORKFLOW_POLICY_KEY] == f"Prompt body for {workflow_name}."
+    assert seen["workspace"] == {"workflow": workflow_name}
+    assert seen["argv"] == ["status", "--json"]
+
+
+def test_contract_loader_supports_default_markdown_named_markdown_and_pointer(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    default_contract = repo_root / "WORKFLOW.md"
+    _write_contract(
+        default_contract,
+        workflow="change-delivery",
+        body="Change delivery prompt body.",
+    )
+
+    named_repo_root = tmp_path / "named-repo"
+    named_repo_root.mkdir()
+    named_contract = named_repo_root / "WORKFLOW-issue-runner.md"
+    _write_contract(
+        named_contract,
+        workflow="issue-runner",
+        body="Issue runner prompt body.\n\nKeep Markdown paragraphs intact.",
+    )
+
+    default_loaded = load_workflow_contract(default_contract.parent)
+    named_loaded = load_workflow_contract(named_repo_root)
+    named_file_loaded = load_workflow_contract_file(named_contract)
+    pointer_root = tmp_path / "workflow-root"
+    write_workflow_contract_pointer(pointer_root, named_contract)
+    pointer_loaded = load_workflow_contract(pointer_root)
+
+    assert default_loaded.source_path == default_contract.resolve()
+    assert default_loaded.prompt_template == "Change delivery prompt body."
+    assert default_loaded.config[WORKFLOW_POLICY_KEY] == "Change delivery prompt body."
+    assert named_loaded.source_path == named_contract.resolve()
+    assert named_loaded.prompt_template == "Issue runner prompt body.\n\nKeep Markdown paragraphs intact."
+    assert named_loaded.config[WORKFLOW_POLICY_KEY] == named_loaded.prompt_template
+    assert named_file_loaded.source_path == named_contract.resolve()
+    assert named_file_loaded.prompt_template == named_loaded.prompt_template
+    assert pointer_loaded.source_path == named_contract.resolve()
+    assert pointer_loaded.config["workflow"] == "issue-runner"

--- a/tests/test_restructure_guardrails.py
+++ b/tests/test_restructure_guardrails.py
@@ -1,4 +1,6 @@
 import importlib
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +26,7 @@ PUBLIC_PACKAGE_IMPORTS = (
 )
 
 BUNDLED_WORKFLOWS = ("change-delivery", "issue-runner")
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _write_contract(path: Path, *, workflow: str, body: str) -> None:
@@ -42,6 +45,30 @@ def test_public_package_imports_remain_available(module_name):
     module = importlib.import_module(module_name)
 
     assert module.__name__ == module_name
+
+
+def test_repo_root_workflow_wrapper_imports_in_clean_interpreter():
+    script = """
+import workflows
+import workflows.contract as contract
+import workflows.__main__ as workflow_main
+import workflows.issue_runner as issue_runner
+
+assert callable(workflows.run_cli)
+assert callable(workflow_main.main)
+assert contract.WORKFLOW_POLICY_KEY == "workflow-policy"
+assert issue_runner.NAME == "issue-runner"
+assert "/daedalus/workflows/__init__.py" in workflows.__file__.replace("\\\\", "/")
+assert "/daedalus/workflows/contract.py" in contract.__file__.replace("\\\\", "/")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr + completed.stdout
 
 
 @pytest.mark.parametrize("package_name", ("workflows", "daedalus.workflows"))

--- a/tests/test_restructure_import_direction.py
+++ b/tests/test_restructure_import_direction.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ALLOWED_COMPATIBILITY_FILES = {
+    "daedalus/integrations/trackers/__init__.py",
+    "daedalus/integrations/trackers/types.py",
+    "daedalus/integrations/trackers/registry.py",
+    "daedalus/integrations/trackers/github.py",
+    "daedalus/integrations/trackers/linear.py",
+    "daedalus/integrations/trackers/local_json.py",
+    "daedalus/integrations/trackers/feedback.py",
+    "daedalus/integrations/code_hosts/__init__.py",
+    "daedalus/integrations/code_hosts/types.py",
+    "daedalus/integrations/code_hosts/registry.py",
+    "daedalus/integrations/code_hosts/github.py",
+    "daedalus/runtimes/types.py",
+    "daedalus/runtimes/registry.py",
+    "daedalus/workflows/shared/runtimes/__init__.py",
+    "daedalus/workflows/core/types.py",
+}
+
+
+def test_internal_workflow_imports_use_new_restructure_namespaces():
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "daedalus").rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in ALLOWED_COMPATIBILITY_FILES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for old_import in (
+            "from trackers",
+            "from code_hosts",
+            "from engine.driver",
+            "from runtimes import",
+            "from workflow_core",
+        ):
+            if old_import in text:
+                offenders.append(f"{rel}: {old_import}")
+
+    assert offenders == []

--- a/tests/test_runtimes_split_namespace.py
+++ b/tests/test_runtimes_split_namespace.py
@@ -1,0 +1,24 @@
+import importlib
+
+
+def test_runtime_types_and_registry_modules_reexport_existing_runtime_api():
+    runtimes = importlib.import_module("runtimes")
+    types = importlib.import_module("runtimes.types")
+    registry = importlib.import_module("runtimes.registry")
+
+    assert types.PromptRunResult is runtimes.PromptRunResult
+    assert types.SessionHandle is runtimes.SessionHandle
+    assert types.SessionHealth is runtimes.SessionHealth
+    assert types.Runtime is runtimes.Runtime
+    assert registry.build_runtimes is runtimes.build_runtimes
+    assert registry.register is runtimes.register
+
+
+def test_runtime_command_module_reexports_stage_command_helpers():
+    stages = importlib.import_module("runtimes.stages")
+    command = importlib.import_module("runtimes.command")
+
+    assert command.resolve_stage_command is stages.resolve_stage_command
+    assert command.substitute_command_placeholders is stages.substitute_command_placeholders
+    assert command.materialize_prompt is stages.materialize_prompt
+    assert command.runtime_result_path is stages.runtime_result_path

--- a/tests/test_workflow_driver_api.py
+++ b/tests/test_workflow_driver_api.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from workflows.contract import render_workflow_markdown
+from workflows.core.types import WorkflowDriver
+
+
+def test_issue_runner_workspace_conforms_to_workflow_driver_protocol(tmp_path):
+    from workflows.issue_runner.workspace import load_workspace_from_config
+
+    workflow_root = tmp_path / "issue-runner"
+    workflow_root.mkdir()
+    (workflow_root / "config").mkdir()
+    (workflow_root / "config" / "issues.json").write_text(json.dumps({"issues": []}), encoding="utf-8")
+    cfg = {
+        "workflow": "issue-runner",
+        "schema-version": 1,
+        "repository": {"local-path": str(tmp_path / "repo")},
+        "tracker": {"kind": "local-json", "path": "config/issues.json"},
+        "agent": {"name": "runner", "model": "gpt-5", "runtime": "default"},
+        "runtimes": {"default": {"kind": "hermes-agent", "command": ["true"]}},
+        "storage": {},
+    }
+    (workflow_root / "WORKFLOW.md").write_text(
+        render_workflow_markdown(config=cfg, prompt_template="Issue: {{ issue.identifier }}"),
+        encoding="utf-8",
+    )
+
+    workspace = load_workspace_from_config(
+        workspace_root=workflow_root,
+        run=lambda *args, **kwargs: None,
+        run_json=lambda *args, **kwargs: {},
+    )
+
+    assert isinstance(workspace, WorkflowDriver)
+
+
+def test_change_delivery_workspace_conforms_to_workflow_driver_protocol(tmp_path):
+    from workflows.change_delivery.workspace import make_workspace
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    workspace = make_workspace(
+        workspace_root=tmp_path / "change-delivery",
+        config={
+            "repoPath": str(repo),
+            "cronJobsPath": str(tmp_path / "jobs.json"),
+            "ledgerPath": str(tmp_path / "memory" / "workflow-status.json"),
+            "healthPath": str(tmp_path / "memory" / "workflow-health.json"),
+            "auditLogPath": str(tmp_path / "memory" / "workflow-audit.jsonl"),
+            "schedulerPath": str(tmp_path / "memory" / "workflow-scheduler.json"),
+        },
+    )
+
+    assert isinstance(workspace, WorkflowDriver)

--- a/tests/test_workflows_core_config.py
+++ b/tests/test_workflows_core_config.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import pytest
+
+from workflows.core.config import (
+    ConfigError,
+    ConfigView,
+    first_present,
+    get_bool,
+    get_int,
+    get_list,
+    get_mapping,
+    get_str,
+    get_value,
+    require,
+    resolve_env_indirection,
+    resolve_path,
+)
+
+
+def test_get_value_supports_nested_paths_and_dash_underscore_aliases():
+    cfg = {
+        "agent": {
+            "max-concurrent-agents": 3,
+        },
+        "tracker": {
+            "active_states": ["todo"],
+        },
+    }
+
+    assert get_value(cfg, "agent.max_concurrent_agents") == 3
+    assert get_value(cfg, "tracker.active-states") == ["todo"]
+    assert first_present(cfg, "missing", "tracker.active-states") == ["todo"]
+    assert get_value(cfg, "missing", default="fallback") == "fallback"
+
+
+def test_require_rejects_missing_empty_and_none_values():
+    cfg = {"empty": "", "none": None}
+
+    with pytest.raises(ConfigError, match="missing required"):
+        require(cfg, "missing")
+    with pytest.raises(ConfigError, match="missing required"):
+        require(cfg, "empty")
+    with pytest.raises(ConfigError, match="missing required"):
+        require(cfg, "none")
+
+
+def test_typed_getters_apply_defaults_and_reject_wrong_types():
+    cfg = {
+        "name": "runner",
+        "limit": "7",
+        "enabled": "yes",
+        "labels": ["ready"],
+        "storage": {"status": "memory/status.json"},
+    }
+
+    assert get_str(cfg, "name") == "runner"
+    assert get_str(cfg, "missing", default="default") == "default"
+    assert get_int(cfg, "limit") == 7
+    assert get_bool(cfg, "enabled") is True
+    assert get_list(cfg, "labels") == ["ready"]
+    assert get_mapping(cfg, "storage") == {"status": "memory/status.json"}
+
+    with pytest.raises(ConfigError, match="must be int"):
+        get_int({"limit": True}, "limit")
+    with pytest.raises(ConfigError, match="must be bool"):
+        get_bool({"enabled": 1}, "enabled")
+    with pytest.raises(ConfigError, match="must be list"):
+        get_list({"labels": "ready"}, "labels")
+    with pytest.raises(ConfigError, match="must be Mapping"):
+        get_mapping({"storage": []}, "storage")
+
+
+def test_collection_getters_do_not_mutate_or_return_raw_collections():
+    cfg = {
+        "items": ["a"],
+        "mapping": {"a": 1},
+    }
+
+    items = get_list(cfg, "items")
+    mapping = get_mapping(cfg, "mapping")
+    items.append("b")
+    mapping["b"] = 2
+
+    assert cfg == {"items": ["a"], "mapping": {"a": 1}}
+
+
+def test_resolve_env_indirection_supports_env_tokens_and_literals():
+    env = {"TOKEN": "resolved"}
+
+    assert resolve_env_indirection("$TOKEN", env=env) == "resolved"
+    assert resolve_env_indirection("literal", env=env) == "literal"
+    assert resolve_env_indirection(7, env=env) == 7
+    assert resolve_env_indirection("$MISSING", env=env) is None
+    with pytest.raises(ConfigError, match="MISSING"):
+        resolve_env_indirection("$MISSING", env=env, required=True)
+
+
+def test_resolve_path_normalizes_relative_absolute_default_and_env_paths(tmp_path):
+    env_path = tmp_path / "from-env"
+    absolute = tmp_path / "absolute"
+
+    assert resolve_path("relative/file.json", workflow_root=tmp_path) == (tmp_path / "relative/file.json").resolve()
+    assert resolve_path(absolute, workflow_root=tmp_path) == absolute.resolve()
+    assert resolve_path("", workflow_root=tmp_path, default="default.json") == (tmp_path / "default.json").resolve()
+    assert resolve_path("$PATH_VALUE", workflow_root=tmp_path, env={"PATH_VALUE": str(env_path)}) == env_path.resolve()
+
+
+def test_config_view_wraps_typed_helpers(tmp_path):
+    cfg = {
+        "polling": {"interval-seconds": "5"},
+        "storage": {"status": "memory/status.json"},
+    }
+    view = ConfigView(cfg, workflow_root=tmp_path)
+
+    assert view.section("polling").int("interval_seconds") == 5
+    assert view.path("storage.status") == (tmp_path / "memory/status.json").resolve()
+    assert view.section("missing").raw == {}
+    with pytest.raises(ConfigError, match="workflow_root"):
+        ConfigView(cfg).path("storage.status")
+
+
+def test_resolve_path_requires_a_value(tmp_path):
+    with pytest.raises(ConfigError, match="path value is required"):
+        resolve_path(None, workflow_root=tmp_path)

--- a/tests/test_workflows_core_hooks.py
+++ b/tests/test_workflows_core_hooks.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from workflows.core.hooks import build_hook_env, run_shell_hook
+
+
+def test_build_hook_env_stringifies_values():
+    assert build_hook_env({"A": 1, "B": Path("/tmp/work")}) == {
+        "A": "1",
+        "B": "/tmp/work",
+    }
+
+
+def test_run_shell_hook_returns_not_ran_when_hook_is_missing(tmp_path):
+    result = run_shell_hook(
+        hooks_config={},
+        hook_name="before_run",
+        worktree=tmp_path,
+        env={},
+        run=lambda *args, **kwargs: None,
+    )
+
+    assert result == {"hook": "before_run", "ran": False}
+
+
+def test_run_shell_hook_executes_configured_script_with_timeout_alias(tmp_path):
+    calls = []
+
+    def fake_run(command, *, cwd, timeout, env):
+        calls.append({"command": command, "cwd": cwd, "timeout": timeout, "env": env})
+        return SimpleNamespace(returncode=4)
+
+    result = run_shell_hook(
+        hooks_config={"before-run": "echo before", "timeout_ms": 2500},
+        hook_name="before_run",
+        worktree=tmp_path,
+        env={"X": "1"},
+        run=fake_run,
+    )
+
+    assert result == {"hook": "before_run", "ran": True, "returncode": 4}
+    assert calls == [
+        {
+            "command": ["bash", "-lc", "echo before"],
+            "cwd": tmp_path,
+            "timeout": 2,
+            "env": {"X": "1"},
+        }
+    ]
+
+
+def test_run_shell_hook_raises_or_returns_ignored_failure(tmp_path):
+    def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_shell_hook(
+            hooks_config={"after_run": "false"},
+            hook_name="after_run",
+            worktree=tmp_path,
+            env={},
+            run=fail,
+        )
+
+    result = run_shell_hook(
+        hooks_config={"after_run": "false"},
+        hook_name="after_run",
+        worktree=tmp_path,
+        env={},
+        run=fail,
+        ignore_failure=True,
+    )
+
+    assert result == {
+        "hook": "after_run",
+        "ran": True,
+        "returncode": None,
+        "ignored_failure": True,
+        "error": "boom",
+    }

--- a/tests/test_workflows_core_prompts.py
+++ b/tests/test_workflows_core_prompts.py
@@ -1,0 +1,54 @@
+import pytest
+
+from workflows.core.prompts import render_prompt_template
+
+
+def test_render_prompt_template_renders_issue_fields_and_attempt():
+    prompt = render_prompt_template(
+        prompt_template="Issue: {{ issue.identifier }}\nAttempt: {{ attempt }}",
+        variables={"issue": {"identifier": "ISSUE-1"}, "attempt": 2},
+    )
+
+    assert prompt == "Issue: ISSUE-1\nAttempt: 2\n"
+
+
+def test_render_prompt_template_uses_default_and_empty_attempt():
+    prompt = render_prompt_template(
+        prompt_template="",
+        default_template="Issue: {{ issue.identifier }}\nAttempt: {{ attempt }}",
+        variables={"issue": {"identifier": "ISSUE-1"}, "attempt": None},
+    )
+
+    assert prompt == "Issue: ISSUE-1\nAttempt:\n"
+
+
+def test_render_prompt_template_json_encodes_nested_values():
+    prompt = render_prompt_template(
+        prompt_template="Labels: {{ issue.labels }}",
+        variables={"issue": {"labels": ["backend", "ready"]}},
+    )
+
+    assert prompt == 'Labels: ["backend", "ready"]\n'
+
+
+def test_render_prompt_template_rejects_unsupported_syntax():
+    with pytest.raises(RuntimeError, match="control blocks"):
+        render_prompt_template(
+            prompt_template="{% if issue %}Issue{% endif %}",
+            variables={"issue": {}},
+        )
+    with pytest.raises(RuntimeError, match="unsupported filter"):
+        render_prompt_template(
+            prompt_template="{{ issue.title | upper }}",
+            variables={"issue": {"title": "Title"}},
+        )
+    with pytest.raises(RuntimeError, match="unknown variable"):
+        render_prompt_template(
+            prompt_template="{{ ticket.title }}",
+            variables={"issue": {"title": "Title"}},
+        )
+    with pytest.raises(RuntimeError, match="unbalanced"):
+        render_prompt_template(
+            prompt_template="{{ issue.title",
+            variables={"issue": {"title": "Title"}},
+        )

--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -6,8 +6,10 @@ _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 _REAL_DIR = _PLUGIN_ROOT / "daedalus" / "trackers"
 
 _real_dir_str = str(_REAL_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
 _INIT = _REAL_DIR / "__init__.py"
+__file__ = str(_INIT)
 exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -1,16 +1,14 @@
 """Repo-root workflow wrapper package for official Hermes plugin installs."""
 
-import sys
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
-_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
-if _PLUGIN_ROOT_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_ROOT_STR)
-
 _REAL_WORKFLOWS_DIR = _PLUGIN_ROOT / "daedalus" / "workflows"
 _real_dir_str = str(_REAL_WORKFLOWS_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
-from daedalus.workflows import *  # noqa: F401,F403
+_INIT = _REAL_WORKFLOWS_DIR / "__init__.py"
+__file__ = str(_INIT)
+exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/workflows/__main__.py
+++ b/workflows/__main__.py
@@ -1,5 +1,7 @@
 """Repo-root workflow dispatcher wrapper for official Hermes plugin installs."""
+from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -8,10 +10,47 @@ _PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
 if _PLUGIN_ROOT_STR not in sys.path:
     sys.path.insert(0, _PLUGIN_ROOT_STR)
 
-from daedalus.workflows.__main__ import *  # noqa: F401,F403
-from daedalus.workflows.__main__ import main as _main
-from daedalus.workflows.__main__ import _resolve_workflow_root
+from workflows import run_cli
+
+
+def _resolve_workflow_root(argv: list[str]) -> tuple[Path, list[str]]:
+    out: list[str] = []
+    workflow_root: Path | None = None
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--workflow-root":
+            if index + 1 >= len(argv):
+                raise SystemExit("--workflow-root requires a path argument")
+            workflow_root = Path(argv[index + 1]).expanduser().resolve()
+            index += 2
+            continue
+        if arg.startswith("--workflow-root="):
+            workflow_root = Path(arg.split("=", 1)[1]).expanduser().resolve()
+            index += 1
+            continue
+        out.append(arg)
+        index += 1
+
+    if workflow_root is None:
+        from workflows.shared.paths import resolve_default_workflow_root
+
+        workflow_root = resolve_default_workflow_root(plugin_dir=_PLUGIN_ROOT)
+    return workflow_root, out
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = list(argv) if argv is not None else sys.argv[1:]
+    workflow_root, command_argv = _resolve_workflow_root(raw)
+    try:
+        return run_cli(workflow_root, command_argv)
+    except subprocess.CalledProcessError as exc:
+        msg = f"Command failed with exit status {exc.returncode}"
+        if exc.stderr:
+            msg += f"\n{exc.stderr.strip()}"
+        print(msg, file=sys.stderr)
+        return exc.returncode or 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(_main())
+    raise SystemExit(main())

--- a/workflows/change_delivery/__init__.py
+++ b/workflows/change_delivery/__init__.py
@@ -1,27 +1,14 @@
 """Repo-root change-delivery workflow wrapper for official Hermes plugin installs."""
 
-import importlib
-import sys
-import types
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[2]
-_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
-if _PLUGIN_ROOT_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_ROOT_STR)
-
 _REAL_WORKFLOW_DIR = _PLUGIN_ROOT / "daedalus" / "workflows" / "change_delivery"
 _real_dir_str = str(_REAL_WORKFLOW_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
-from daedalus.workflows.change_delivery import *  # noqa: F401,F403
-
-
-class _ServerProxy(types.ModuleType):
-    def __getattr__(self, name):
-        real_server = importlib.import_module("daedalus.workflows.change_delivery.server")
-        return getattr(real_server, name)
-
-
-server = sys.modules.setdefault(__name__ + ".server", _ServerProxy(__name__ + ".server"))
+_INIT = _REAL_WORKFLOW_DIR / "__init__.py"
+__file__ = str(_INIT)
+exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/workflows/change_delivery/__main__.py
+++ b/workflows/change_delivery/__main__.py
@@ -1,5 +1,7 @@
 """Repo-root change-delivery workflow entrypoint wrapper."""
+from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -8,9 +10,24 @@ _PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
 if _PLUGIN_ROOT_STR not in sys.path:
     sys.path.insert(0, _PLUGIN_ROOT_STR)
 
-from daedalus.workflows.change_delivery.__main__ import *  # noqa: F401,F403
-from daedalus.workflows.change_delivery.__main__ import main as _main
+from workflows import run_cli
+from workflows.__main__ import _resolve_workflow_root
+
+resolve_workflow_root = _resolve_workflow_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = list(argv) if argv is not None else sys.argv[1:]
+    workflow_root, command_argv = _resolve_workflow_root(raw)
+    try:
+        return run_cli(workflow_root, command_argv, require_workflow="change-delivery")
+    except subprocess.CalledProcessError as exc:
+        msg = f"Command failed with exit status {exc.returncode}"
+        if exc.stderr:
+            msg += f"\n{exc.stderr.strip()}"
+        print(msg, file=sys.stderr)
+        return exc.returncode or 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(_main())
+    raise SystemExit(main())

--- a/workflows/contract.py
+++ b/workflows/contract.py
@@ -1,11 +1,8 @@
 """Repo-root workflow-contract wrapper for official Hermes plugin installs."""
 
-import sys
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
-_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
-if _PLUGIN_ROOT_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_ROOT_STR)
-
-from daedalus.workflows.contract import *  # noqa: F401,F403
+_REAL_MODULE = _PLUGIN_ROOT / "daedalus" / "workflows" / "contract.py"
+__file__ = str(_REAL_MODULE)
+exec(compile(_REAL_MODULE.read_text(encoding="utf-8"), str(_REAL_MODULE), "exec"), globals())

--- a/workflows/issue_runner/__init__.py
+++ b/workflows/issue_runner/__init__.py
@@ -1,17 +1,14 @@
 """Repo-root issue-runner workflow wrapper for official Hermes plugin installs."""
 
-import sys
 from pathlib import Path
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[2]
-_PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
-if _PLUGIN_ROOT_STR not in sys.path:
-    sys.path.insert(0, _PLUGIN_ROOT_STR)
-
 _REAL_WORKFLOW_DIR = _PLUGIN_ROOT / "daedalus" / "workflows" / "issue_runner"
 _real_dir_str = str(_REAL_WORKFLOW_DIR)
-if _real_dir_str not in __path__:
-    __path__.append(_real_dir_str)
+if _real_dir_str in __path__:
+    __path__.remove(_real_dir_str)
+__path__.insert(0, _real_dir_str)
 
-from daedalus.workflows.issue_runner import *  # noqa: F401,F403
-
+_INIT = _REAL_WORKFLOW_DIR / "__init__.py"
+__file__ = str(_INIT)
+exec(compile(_INIT.read_text(encoding="utf-8"), str(_INIT), "exec"), globals())

--- a/workflows/issue_runner/__main__.py
+++ b/workflows/issue_runner/__main__.py
@@ -1,5 +1,7 @@
 """Repo-root issue-runner workflow entrypoint wrapper."""
+from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -8,9 +10,24 @@ _PLUGIN_ROOT_STR = str(_PLUGIN_ROOT)
 if _PLUGIN_ROOT_STR not in sys.path:
     sys.path.insert(0, _PLUGIN_ROOT_STR)
 
-from daedalus.workflows.issue_runner.__main__ import *  # noqa: F401,F403
-from daedalus.workflows.issue_runner.__main__ import main as _main
+from workflows import run_cli
+from workflows.__main__ import _resolve_workflow_root
+
+resolve_workflow_root = _resolve_workflow_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = list(argv) if argv is not None else sys.argv[1:]
+    workflow_root, command_argv = _resolve_workflow_root(raw)
+    try:
+        return run_cli(workflow_root, command_argv, require_workflow="issue-runner")
+    except subprocess.CalledProcessError as exc:
+        msg = f"Command failed with exit status {exc.returncode}"
+        if exc.stderr:
+            msg += f"\n{exc.stderr.strip()}"
+        print(msg, file=sys.stderr)
+        return exc.returncode or 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(_main())
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Restructures Daedalus toward the audited SDLC workflow architecture by introducing clearer internal namespaces and shared workflow support modules.

- Adds `workflows.core` for shared workflow config, hook, prompt, and driver helpers.
- Adds namespace wrappers/splits for engine primitives, integrations, runtimes, and operator surfaces.
- Moves issue-runner and change-delivery config normalization into workflow-specific config modules.
- Adds restructure guardrails and namespace/import direction tests.
- Documents the turn-by-turn implementation plan and retained compatibility shims.

## Impact

Public workflow behavior and CLI contract are preserved while new internal code can import from the target namespaces. The latest follow-up move places the shared workflow core under `daedalus/workflows/core/` and removes the old `daedalus/workflow_core/` package.

## Validation

- `pytest tests/test_workflows_core_config.py tests/test_workflows_core_hooks.py tests/test_workflows_core_prompts.py tests/test_workflow_driver_api.py tests/test_restructure_import_direction.py tests/test_issue_runner_config.py tests/test_change_delivery_config.py tests/test_workflows_issue_runner_workspace.py` -> 48 passed
- `pytest` -> 951 passed, 7 skipped
